### PR TITLE
Add some basic error handling capabilities

### DIFF
--- a/include/miscellaneous/error.h
+++ b/include/miscellaneous/error.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <sstream>
+#include <iostream>
+
+class NEMLException : public std::exception
+{
+
+public:
+  NEMLException(char * msg)
+    : _message(msg)
+  {
+  }
+
+  char * what() { return _message; }
+
+private:
+  char * _message;
+};
+
+/// Throws an exception with given message if the assertion fails. Variadic template is used here so
+/// that we can pass in any number of arguments of any type.
+template <typename... Args>
+void neml_assert(bool assertion, Args &&... args);
+
+/// Similar to assert, but is only effective in debug modes
+template <typename... Args>
+void neml_assert_dbg(bool assertion, Args &&... args);
+
+/// Internal methods not intended for the public
+namespace internal
+{
+template <typename T, typename... Args>
+void stream_all(std::ostringstream & ss, T && val, Args &&... args);
+
+void stream_all(std::ostringstream & ss);
+} // namespace internal
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Implementations for templated methods below
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+template <typename... Args>
+void
+neml_assert(bool assertion, Args &&... args)
+{
+  if (!assertion)
+  {
+    std::ostringstream oss;
+    internal::stream_all(oss, std::forward<Args>(args)...);
+    throw NEMLException(oss.str().data());
+  }
+}
+
+template <typename... Args>
+void
+neml_assert_dbg([[maybe_unused]] bool assertion, [[maybe_unused]] Args &&... args)
+{
+#ifndef NDEBUG
+  neml_assert(assertion, args...);
+#endif
+}
+
+namespace internal
+{
+template <typename T, typename... Args>
+void
+stream_all(std::ostringstream & ss, T && val, Args &&... args)
+{
+  ss << val;
+  stream_all(ss, std::forward<Args>(args)...);
+}
+} // namespace internal

--- a/src/miscellaneous/error.cxx
+++ b/src/miscellaneous/error.cxx
@@ -1,0 +1,9 @@
+#include "miscellaneous/error.h"
+
+namespace internal
+{
+void
+stream_all(std::ostringstream &)
+{
+}
+} // namespace internal

--- a/tests/unit/tensors/test_BatchTensor.cxx
+++ b/tests/unit/tensors/test_BatchTensor.cxx
@@ -25,6 +25,8 @@ TEST_CASE("BatchTensors have the correct shapes", "[BatchTensors]")
 TEST_CASE("BatchTensors can't be created with few than the number of "
           "batch dimensions")
 {
-  // Can't make this guy, as it won't have enough dimensions for the batch
+// Can't make this guy, as it won't have enough dimensions for the batch
+#ifndef NDEBUG
   REQUIRE_THROWS(BatchTensor<2>(torch::zeros({10}, TorchDefaults)));
+#endif
 }

--- a/tests/unit/tensors/test_FixedDimTensor.cxx
+++ b/tests/unit/tensors/test_FixedDimTensor.cxx
@@ -41,12 +41,16 @@ TEST_CASE("FixedDimTensors have the right shapes, construct with tensor", "[Fixe
 
 TEST_CASE("Not enough required dimensions", "[FixedDimTensor]")
 {
+#ifndef NDEBUG
   // Can't make this guy, as it won't have enough dimensions for the logical dimensions
   REQUIRE_THROWS(FixedDimTensor<2, 3, 4>(torch::zeros({10, 3, 4}, TorchDefaults)));
+#endif
 }
 
 TEST_CASE("FixedDimTensors can't be created with the wrong base dimensions", "[FixedDimTensor]")
 {
+#ifndef NDEBUG
   // Batch is okay, base dimension (5, 4) isn't what we expected (3, 4)
   REQUIRE_THROWS(FixedDimTensor<2, 3, 4>(torch::zeros({10, 2, 5, 4}, TorchDefaults)));
+#endif
 }

--- a/tests/unit/tensors/test_Scalar.cxx
+++ b/tests/unit/tensors/test_Scalar.cxx
@@ -174,6 +174,8 @@ TEST_CASE("Batched Scalar", "[Scalar]")
 
 TEST_CASE("Scalar can't be created with semantically non-scalar tensors", "[Scalar]")
 {
+#ifndef NDEBUG
   // This can't happen as the tensor dimension is not (1,)
   REQUIRE_THROWS(Scalar(torch::zeros({2, 2}, TorchDefaults)));
+#endif
 }


### PR DESCRIPTION
```
neml_assert(bool assertion, Args... args)
neml_assert_dbg(bool assertion, Args... args)
```

The `neml_assert` method is effective in all build types. We should use this to check errors during the model construction phase. The `neml_assert_dbg` method should be optimized out in all other builds. So we should add many of those as possible.