### PR TITLE
Make set_value protected

### DIFF
--- a/include/models/ADModel.h
+++ b/include/models/ADModel.h
@@ -8,5 +8,5 @@ class ADModel : public Model
 public:
   using Model::Model;
 
-  virtual LabeledMatrix dvalue(LabeledVector in) const;
+  virtual std::tuple<LabeledVector, LabeledMatrix> value_and_dvalue(LabeledVector in) const;
 };

--- a/include/models/ADSecDerivModel.h
+++ b/include/models/ADSecDerivModel.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "models/SecDerivModel.h"
+
+/// Similar to `SecDerivModel`, but uses automatic differention to get the model's second derivative.
+class ADSecDerivModel : public SecDerivModel
+{
+public:
+  using SecDerivModel::SecDerivModel;
+
+  virtual std::tuple<LabeledVector, LabeledMatrix> value_and_dvalue(LabeledVector in) const;
+
+  virtual std::tuple<LabeledMatrix, LabeledTensor<1, 3>> dvalue_and_d2value(LabeledVector in) const;
+};

--- a/include/models/ComposedModel.h
+++ b/include/models/ComposedModel.h
@@ -18,9 +18,6 @@ public:
   /// Return dependencies of a registered model
   const std::vector<Model *> & dependent_models(const std::string & name) const;
 
-  /// Evaluate the model graph all the way up from the leaf models
-  void set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
-
   /// Stringify the evaluation order
   std::string evaluation_order() const;
 
@@ -28,6 +25,10 @@ public:
   void to_dot(std::ostream & os) const;
 
 protected:
+  /// Evaluate the model graph all the way up from the leaf models
+  virtual void
+  set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
+
   virtual void setup();
 
   /// Resolve dependency using topological traversal of the dependent models

--- a/include/models/IdentityMap.h
+++ b/include/models/IdentityMap.h
@@ -21,6 +21,7 @@ public:
     setup();
   }
 
+protected:
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const
   {
@@ -32,7 +33,6 @@ public:
     }
   }
 
-protected:
   std::string _axis_name;
   std::string _var_name;
 };

--- a/include/models/ImplicitTimeIntegration.h
+++ b/include/models/ImplicitTimeIntegration.h
@@ -9,12 +9,12 @@ class ImplicitTimeIntegration : public ImplicitModel
 public:
   ImplicitTimeIntegration(const std::string & name, Model & rate);
 
-  virtual void
-  set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
-
   // Define the nonlinear system we are solving for
   virtual void set_residual(BatchTensor<1> x, BatchTensor<1> r, BatchTensor<1> * J = nullptr) const;
 
 protected:
+  virtual void
+  set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
+
   Model & _rate;
 };

--- a/include/models/ImplicitUpdate.h
+++ b/include/models/ImplicitUpdate.h
@@ -9,10 +9,10 @@ class ImplicitUpdate : public Model
 public:
   ImplicitUpdate(const std::string & name, ImplicitModel & model, NonlinearSolver & solver);
 
+protected:
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 
-protected:
   /// The implicit model to be updated
   ImplicitModel & _model;
 

--- a/include/models/Model.h
+++ b/include/models/Model.h
@@ -26,19 +26,24 @@ public:
   const LabeledAxis & output() const { return _output; }
   /// @}
 
-  /// The map between input -> output, and optionally its derivatives
-  virtual void
-  set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const = 0;
-
   /// Convenient shortcut to construct and return the model value
   virtual LabeledVector value(LabeledVector in) const;
 
   /// Convenient shortcut to construct and return the model derivative
+  /// NOTE: this method is inefficient and not recommended for use.
+  /// Consider using `value` or `value_and_dvalue` if possible.
   virtual LabeledMatrix dvalue(LabeledVector in) const;
+
+  /// Convenient shortcut to construct and return the model value and its derivative
+  virtual std::tuple<LabeledVector, LabeledMatrix> value_and_dvalue(LabeledVector in) const;
 
   const std::vector<Model *> & registered_models() const { return _registered_models; }
 
 protected:
+  /// The map between input -> output, and optionally its derivatives
+  virtual void
+  set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const = 0;
+
   virtual void setup() { setup_layout(); }
 
   /// Register a model that the current model may use during its evaluation

--- a/include/models/SecDerivModel.h
+++ b/include/models/SecDerivModel.h
@@ -8,6 +8,9 @@ class SecDerivModel : public Model
 public:
   using Model::Model;
 
+  /// Convenient shortcut to construct and return the model's first derivative
+  virtual LabeledMatrix dvalue(LabeledVector in) const;
+
   /// Convenient shortcut to construct and return the model's second derivative
   virtual LabeledTensor<1, 3> d2value(LabeledVector in) const;
 

--- a/include/models/SecDerivModel.h
+++ b/include/models/SecDerivModel.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "models/Model.h"
+
+/// Similar to `Model`, but provides an additional method `set_dvalue` that should be implemented.
+class SecDerivModel : public Model
+{
+public:
+  using Model::Model;
+
+  /// Convenient shortcut to construct and return the model's second derivative
+  virtual LabeledTensor<1, 3> d2value(LabeledVector in) const;
+
+  /// Convenient shortcut to construct and return the model's first and second derivative
+  virtual std::tuple<LabeledMatrix, LabeledTensor<1, 3>> dvalue_and_d2value(LabeledVector in) const;
+
+protected:
+  /// The derivative and optionally the second derivative of the yield function w.r.t. the inputs
+  virtual void set_dvalue(LabeledVector in,
+                          LabeledMatrix dout_din,
+                          LabeledTensor<1, 3> * d2out_din2 = nullptr) const = 0;
+};

--- a/include/models/forces/ForceRate.h
+++ b/include/models/forces/ForceRate.h
@@ -9,6 +9,7 @@ class ForceRate : public Force<T, false>
 public:
   ForceRate(const std::string & name);
 
+protected:
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 };

--- a/include/models/forces/QuasiStaticForce.h
+++ b/include/models/forces/QuasiStaticForce.h
@@ -9,6 +9,7 @@ class QuasiStaticForce : public Force<T, stateful>
 public:
   QuasiStaticForce(const std::string & name);
 
+protected:
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 };

--- a/include/models/solid_mechanics/AssociativePlasticFlowDirection.h
+++ b/include/models/solid_mechanics/AssociativePlasticFlowDirection.h
@@ -9,9 +9,10 @@ class AssociativePlasticFlowDirection : public PlasticFlowDirection
 public:
   AssociativePlasticFlowDirection(const std::string & name, YieldFunction & f);
 
+  YieldFunction & yield_function;
+
+protected:
   /// The flow direction
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
-
-  YieldFunction & yield_function;
 };

--- a/include/models/solid_mechanics/AssociativePlasticHardening.h
+++ b/include/models/solid_mechanics/AssociativePlasticHardening.h
@@ -9,9 +9,10 @@ class AssociativePlasticHardening : public PlasticHardening
 public:
   AssociativePlasticHardening(const std::string & name, YieldFunction & f);
 
+  YieldFunction & yield_function;
+
+protected:
   /// The flow direction
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
-
-  YieldFunction & yield_function;
 };

--- a/include/models/solid_mechanics/ElasticStrain.h
+++ b/include/models/solid_mechanics/ElasticStrain.h
@@ -8,6 +8,7 @@ class ElasticStrainTempl : public Model
 public:
   ElasticStrainTempl(const std::string & name);
 
+protected:
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 };

--- a/include/models/solid_mechanics/J2IsotropicYieldFunction.h
+++ b/include/models/solid_mechanics/J2IsotropicYieldFunction.h
@@ -7,6 +7,7 @@ class J2IsotropicYieldFunction : public YieldFunction
 public:
   J2IsotropicYieldFunction(const std::string & name);
 
+protected:
   /// The value of the yield function
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;

--- a/include/models/solid_mechanics/LinearIsotropicElasticity.h
+++ b/include/models/solid_mechanics/LinearIsotropicElasticity.h
@@ -8,10 +8,10 @@ class LinearIsotropicElasticity : public Model
 public:
   LinearIsotropicElasticity(const std::string & name, Scalar E, Scalar nu);
 
+protected:
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 
-protected:
   Scalar _E;
   Scalar _nu;
 };

--- a/include/models/solid_mechanics/LinearIsotropicHardening.h
+++ b/include/models/solid_mechanics/LinearIsotropicHardening.h
@@ -7,10 +7,10 @@ class LinearIsotropicHardening : public IsotropicHardening
 public:
   LinearIsotropicHardening(const std::string & name, Scalar s0, Scalar K);
 
+protected:
   /// Simple linear map between equivalent strain and hardening
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 
-protected:
   Scalar _s0, _K;
 };

--- a/include/models/solid_mechanics/NoKinematicHardening.h
+++ b/include/models/solid_mechanics/NoKinematicHardening.h
@@ -7,6 +7,7 @@ class NoKinematicHardening : public KinematicHardening
 public:
   using KinematicHardening::KinematicHardening;
 
+protected:
   /// No kinematic hardening
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;

--- a/include/models/solid_mechanics/PerzynaPlasticFlowRate.h
+++ b/include/models/solid_mechanics/PerzynaPlasticFlowRate.h
@@ -8,10 +8,10 @@ public:
   /// Construct given the value of eta and n
   PerzynaPlasticFlowRate(const std::string & name, Scalar eta, Scalar n);
 
+protected:
   /// The flow rate
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 
-protected:
   Scalar _eta, _n;
 };

--- a/include/models/solid_mechanics/PlasticStrainRate.h
+++ b/include/models/solid_mechanics/PlasticStrainRate.h
@@ -8,6 +8,7 @@ class PlasticStrainRate : public Model
 public:
   PlasticStrainRate(const std::string & name);
 
+protected:
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 };

--- a/include/models/solid_mechanics/YieldFunction.h
+++ b/include/models/solid_mechanics/YieldFunction.h
@@ -1,23 +1,13 @@
 #pragma once
 
-#include "models/Model.h"
+#include "models/SecDerivModel.h"
 
 /// Parent class for all yield functions
-class YieldFunction : public Model
+class YieldFunction : public SecDerivModel
 {
 public:
   /// Calculate yield function knowing the corresponding hardening model
   YieldFunction(const std::string & name);
 
-  /// Convenient shortcut to construct and return the model's second derivative
-  virtual LabeledTensor<1, 3> d2value(LabeledVector in) const;
-
-  /// Convenient shortcut to construct and return the model's second derivative
-  virtual std::tuple<LabeledMatrix, LabeledTensor<1, 3>> dvalue_and_d2value(LabeledVector in) const;
-
 protected:
-  /// The derivative and optionally the second derivative of the yield function w.r.t. the inputs
-  virtual void set_dvalue(LabeledVector in,
-                          LabeledMatrix dout_din,
-                          LabeledTensor<1, 3> * d2out_din2 = nullptr) const = 0;
 };

--- a/include/models/solid_mechanics/YieldFunction.h
+++ b/include/models/solid_mechanics/YieldFunction.h
@@ -9,11 +9,15 @@ public:
   /// Calculate yield function knowing the corresponding hardening model
   YieldFunction(const std::string & name);
 
+  /// Convenient shortcut to construct and return the model's second derivative
+  virtual LabeledTensor<1, 3> d2value(LabeledVector in) const;
+
+  /// Convenient shortcut to construct and return the model's second derivative
+  virtual std::tuple<LabeledMatrix, LabeledTensor<1, 3>> dvalue_and_d2value(LabeledVector in) const;
+
+protected:
   /// The derivative and optionally the second derivative of the yield function w.r.t. the inputs
   virtual void set_dvalue(LabeledVector in,
                           LabeledMatrix dout_din,
                           LabeledTensor<1, 3> * d2out_din2 = nullptr) const = 0;
-
-  /// Convenient shortcut to construct and return the model's second derivative
-  virtual LabeledTensor<1, 3> d2value(LabeledVector in) const final;
 };

--- a/src/models/ADModel.cxx
+++ b/src/models/ADModel.cxx
@@ -1,7 +1,7 @@
 #include "models/ADModel.h"
 
-LabeledMatrix
-ADModel::dvalue(LabeledVector in) const
+std::tuple<LabeledVector, LabeledMatrix>
+ADModel::value_and_dvalue(LabeledVector in) const
 {
   bool was_ad = true;
   if (!in.tensor().requires_grad())
@@ -14,7 +14,7 @@ ADModel::dvalue(LabeledVector in) const
   auto out = Model::value(in);
 
   // Allocate space for Jacobian
-  LabeledMatrix dout_din(in.batch_size(), output(), input());
+  LabeledMatrix dout_din(out, in);
 
   // Loop over rows of the state to retrieve the derivatives
   for (TorchSize i = 0; i < out.tensor().base_sizes()[0]; i++)
@@ -27,5 +27,5 @@ ADModel::dvalue(LabeledVector in) const
 
   in.tensor().requires_grad_(was_ad);
 
-  return dout_din;
+  return {out, dout_din};
 }

--- a/src/models/ADSecDerivModel.cxx
+++ b/src/models/ADSecDerivModel.cxx
@@ -1,0 +1,63 @@
+#include "models/ADSecDerivModel.h"
+
+std::tuple<LabeledVector, LabeledMatrix>
+ADSecDerivModel::value_and_dvalue(LabeledVector in) const
+{
+  bool was_ad = true;
+  if (!in.tensor().requires_grad())
+  {
+    was_ad = false;
+    in.tensor().requires_grad_();
+  }
+
+  // Evalute the model (not its derivatives)
+  auto out = SecDerivModel::value(in);
+
+  // Allocate space for Jacobian
+  LabeledMatrix dout_din(out, in);
+
+  // Loop over rows of the state to retrieve the derivatives
+  for (TorchSize i = 0; i < out.tensor().base_sizes()[0]; i++)
+  {
+    BatchTensor<1> grad_outputs = torch::zeros_like(out.tensor());
+    grad_outputs.index_put_({torch::indexing::Ellipsis, i}, 1);
+    auto jac_row = torch::autograd::grad({out.tensor()}, {in.tensor()}, {grad_outputs}, true)[0];
+    dout_din.tensor().base_index_put({i, torch::indexing::Slice()}, jac_row);
+  }
+
+  in.tensor().requires_grad_(was_ad);
+
+  return {out, dout_din};
+}
+
+std::tuple<LabeledMatrix, LabeledTensor<1, 3>>
+ADSecDerivModel::dvalue_and_d2value(LabeledVector in) const
+{
+  bool was_ad = true;
+  if (!in.tensor().requires_grad())
+  {
+    was_ad = false;
+    in.tensor().requires_grad_();
+  }
+
+  // Evalute the model's first derivative (not its second derivatives)
+  auto dout_din = SecDerivModel::dvalue(in);
+
+  // Allocate space for Jacobian
+  LabeledTensor<1, 3> d2out_din2(in.batch_size(), output(), in.axis(0), in.axis(0));
+
+  // Loop over rows of the state to retrieve the derivatives
+  for (TorchSize i = 0; i < dout_din.tensor().base_sizes()[0]; i++)
+    for (TorchSize j = 0; j < dout_din.tensor().base_sizes()[1]; j++)
+    {
+      BatchTensor<1> grad_outputs = torch::zeros_like(dout_din.tensor());
+      grad_outputs.index_put_({torch::indexing::Ellipsis, i, j}, 1);
+      auto jac_row =
+          torch::autograd::grad({dout_din.tensor()}, {in.tensor()}, {grad_outputs}, true)[0];
+      d2out_din2.tensor().base_index_put({i, j, torch::indexing::Slice()}, jac_row);
+    }
+
+  in.tensor().requires_grad_(was_ad);
+
+  return {dout_din, d2out_din2};
+}

--- a/src/models/ComposedModel.cxx
+++ b/src/models/ComposedModel.cxx
@@ -86,8 +86,6 @@ ComposedModel::set_value(LabeledVector in, LabeledVector out, LabeledMatrix * do
   for (auto i : _evaluation_order)
   {
     LabeledVector pin(nbatch, i->input());
-    LabeledVector pout(nbatch, i->output());
-    LabeledMatrix dpout_dpin(nbatch, i->output(), i->input());
     const auto & deps = dependent_models(i->name());
 
     // If this is a leaf model, the total input is its input
@@ -108,13 +106,13 @@ ComposedModel::set_value(LabeledVector in, LabeledVector out, LabeledMatrix * do
     }
     if (dout_din)
     {
-      i->set_value(pin, pout, &dpout_dpin);
+      auto [pout, dpout_dpin] = i->value_and_dvalue(pin);
       cached_pout.emplace(i->name(), pout);
       cached_dpout_dpin.emplace(i->name(), dpout_dpin);
     }
     else
     {
-      i->set_value(pin, pout);
+      auto pout = i->value(pin);
       cached_pout.emplace(i->name(), pout);
     }
   }

--- a/src/models/ImplicitTimeIntegration.cxx
+++ b/src/models/ImplicitTimeIntegration.cxx
@@ -39,9 +39,9 @@ ImplicitTimeIntegration::set_value(LabeledVector in,
   LabeledVector rate(nbatch, _rate.output());
   LabeledMatrix drate_din(nbatch, _rate.output(), input());
   if (dout_din)
-    _rate.set_value(in, rate, &drate_din);
+    std::tie(rate, drate_din) = _rate.value_and_dvalue(in);
   else
-    _rate.set_value(in, rate);
+    rate = _rate.value(in);
 
   // r = s_np1 - s_n - s_dot * (t_np1 - t_n)
   auto s_np1 = in("state");
@@ -98,7 +98,7 @@ ImplicitTimeIntegration::set_residual(BatchTensor<1> x, BatchTensor<1> r, BatchT
 
   if (J)
   {
-    LabeledMatrix dout_din(nbatch, output(), input());
+    LabeledMatrix dout_din(out, in);
     set_value(in, out, &dout_din);
     J->copy_(dout_din("residual", "state"));
   }

--- a/src/models/Model.cxx
+++ b/src/models/Model.cxx
@@ -19,8 +19,15 @@ Model::value(LabeledVector in) const
 LabeledMatrix
 Model::dvalue(LabeledVector in) const
 {
-  LabeledVector out(in.batch_size(), output());
-  LabeledMatrix dout_din(in.batch_size(), output(), input());
-  set_value(in, out, &dout_din);
+  auto [out, dout_din] = value_and_dvalue(in);
   return dout_din;
+}
+
+std::tuple<LabeledVector, LabeledMatrix>
+Model::value_and_dvalue(LabeledVector in) const
+{
+  LabeledVector out(in.batch_size(), output());
+  LabeledMatrix dout_din(out, in);
+  set_value(in, out, &dout_din);
+  return {out, dout_din};
 }

--- a/src/models/SecDerivModel.cxx
+++ b/src/models/SecDerivModel.cxx
@@ -1,0 +1,17 @@
+#include "models/SecDerivModel.h"
+
+LabeledTensor<1, 3>
+SecDerivModel::d2value(LabeledVector in) const
+{
+  auto [dout_din, d2out_din2] = dvalue_and_d2value(in);
+  return d2out_din2;
+}
+
+std::tuple<LabeledMatrix, LabeledTensor<1, 3>>
+SecDerivModel::dvalue_and_d2value(LabeledVector in) const
+{
+  LabeledMatrix dout_din(in.batch_size(), output(), in.axis(0));
+  LabeledTensor<1, 3> d2out_din2(in.batch_size(), output(), in.axis(0), in.axis(0));
+  set_dvalue(in, dout_din, &d2out_din2);
+  return {dout_din, d2out_din2};
+}

--- a/src/models/SecDerivModel.cxx
+++ b/src/models/SecDerivModel.cxx
@@ -1,5 +1,13 @@
 #include "models/SecDerivModel.h"
 
+LabeledMatrix
+SecDerivModel::dvalue(LabeledVector in) const
+{
+  LabeledMatrix dout_din(in.batch_size(), output(), in.axis(0));
+  set_dvalue(in, dout_din);
+  return dout_din;
+}
+
 LabeledTensor<1, 3>
 SecDerivModel::d2value(LabeledVector in) const
 {

--- a/src/models/solid_mechanics/AssociativePlasticFlowDirection.cxx
+++ b/src/models/solid_mechanics/AssociativePlasticFlowDirection.cxx
@@ -21,9 +21,9 @@ AssociativePlasticFlowDirection::set_value(LabeledVector in,
       nbatch, yield_function.output(), yield_function.input(), yield_function.input());
 
   if (dout_din)
-    yield_function.set_dvalue(in, df_din, &d2f_din2);
+    std::tie(df_din, d2f_din2) = yield_function.dvalue_and_d2value(in);
   else
-    yield_function.set_dvalue(in, df_din);
+    df_din = yield_function.dvalue(in);
 
   auto df_dmandel = df_din.block("state", "state").get<SymR2>("yield_function", "mandel_stress");
 

--- a/src/models/solid_mechanics/AssociativePlasticHardening.cxx
+++ b/src/models/solid_mechanics/AssociativePlasticHardening.cxx
@@ -22,9 +22,9 @@ AssociativePlasticHardening::set_value(LabeledVector in,
       nbatch, yield_function.output(), yield_function.input(), yield_function.input());
 
   if (dout_din)
-    yield_function.set_dvalue(in, df_din, &d2f_din2);
+    std::tie(df_din, d2f_din2) = yield_function.dvalue_and_d2value(in);
   else
-    yield_function.set_dvalue(in, df_din);
+    df_din = yield_function.dvalue(in);
 
   auto gamma_dot = in.slice(0, "state").get<Scalar>("hardening_rate");
   auto df_dh = df_din.block("state", "state").get<Scalar>("yield_function", "isotropic_hardening");

--- a/src/models/solid_mechanics/YieldFunction.cxx
+++ b/src/models/solid_mechanics/YieldFunction.cxx
@@ -14,8 +14,15 @@ YieldFunction::YieldFunction(const std::string & name)
 LabeledTensor<1, 3>
 YieldFunction::d2value(LabeledVector in) const
 {
-  LabeledMatrix dout_din(in.batch_size(), output(), input());
-  LabeledTensor<1, 3> d2out_din2(in.batch_size(), output(), input(), input());
-  set_dvalue(in, dout_din, &d2out_din2);
+  auto [dout_din, d2out_din2] = dvalue_and_d2value(in);
   return d2out_din2;
+}
+
+std::tuple<LabeledMatrix, LabeledTensor<1, 3>>
+YieldFunction::dvalue_and_d2value(LabeledVector in) const
+{
+  LabeledMatrix dout_din(in.batch_size(), output(), in.axis(0));
+  LabeledTensor<1, 3> d2out_din2(in.batch_size(), output(), in.axis(0), in.axis(0));
+  set_dvalue(in, dout_din, &d2out_din2);
+  return {dout_din, d2out_din2};
 }

--- a/src/models/solid_mechanics/YieldFunction.cxx
+++ b/src/models/solid_mechanics/YieldFunction.cxx
@@ -1,7 +1,7 @@
 #include "models/solid_mechanics/YieldFunction.h"
 
 YieldFunction::YieldFunction(const std::string & name)
-  : Model(name)
+  : SecDerivModel(name)
 {
   input().add<LabeledAxis>("state");
   input().subaxis("state").add<SymR2>("mandel_stress");
@@ -9,20 +9,4 @@ YieldFunction::YieldFunction(const std::string & name)
   output().add<LabeledAxis>("state");
   output().subaxis("state").add<Scalar>("yield_function");
   setup();
-}
-
-LabeledTensor<1, 3>
-YieldFunction::d2value(LabeledVector in) const
-{
-  auto [dout_din, d2out_din2] = dvalue_and_d2value(in);
-  return d2out_din2;
-}
-
-std::tuple<LabeledMatrix, LabeledTensor<1, 3>>
-YieldFunction::dvalue_and_d2value(LabeledVector in) const
-{
-  LabeledMatrix dout_din(in.batch_size(), output(), in.axis(0));
-  LabeledTensor<1, 3> d2out_din2(in.batch_size(), output(), in.axis(0), in.axis(0));
-  set_dvalue(in, dout_din, &d2out_din2);
-  return {dout_din, d2out_din2};
 }

--- a/src/solvers/NewtonNonlinearSolver.cxx
+++ b/src/solvers/NewtonNonlinearSolver.cxx
@@ -29,7 +29,7 @@ NewtonNonlinearSolver::solve(const NonlinearSystem & system, const BatchTensor<1
   for (size_t i = 1; i < params.miters; i++)
   {
     // Update R and the norm of R
-    system.set_residual(x, R, &J);
+    std::tie(R, J) = system.residual_and_Jacobian(x);
     BatchTensor<1> nR = torch::linalg::vector_norm(R, 2, -1, false, c10::nullopt);
 
     // Check for initial convergence

--- a/src/solvers/NonlinearSystem.cxx
+++ b/src/solvers/NonlinearSystem.cxx
@@ -11,10 +11,7 @@ NonlinearSystem::residual(BatchTensor<1> x) const
 BatchTensor<1>
 NonlinearSystem::Jacobian(BatchTensor<1> x) const
 {
-  TorchSize n = x.base_sizes()[0];
-  BatchTensor<1> r = x.clone();
-  BatchTensor<1> J(x.batch_sizes(), {n, n});
-  set_residual(x, r, &J);
+  auto [r, J] = residual_and_Jacobian(x);
   return J;
 }
 

--- a/tests/include/SampleRateModel.h
+++ b/tests/include/SampleRateModel.h
@@ -13,6 +13,7 @@ class SampleRateModelTempl : public SampleRateModelBase<is_ad>
 public:
   SampleRateModelTempl(const std::string & name);
 
+protected:
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 };

--- a/tests/include/SampleSecDerivModel.h
+++ b/tests/include/SampleSecDerivModel.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "models/SecDerivModel.h"
+#include "models/ADSecDerivModel.h"
+
+template <bool is_ad>
+using SampleSecDerivModelBase = std::conditional_t<is_ad, ADSecDerivModel, SecDerivModel>;
+
+// A dummy rate model for testing purposes
+template <bool is_ad>
+class SampleSecDerivModelTempl : public SampleSecDerivModelBase<is_ad>
+{
+public:
+  SampleSecDerivModelTempl(const std::string & name);
+
+protected:
+  virtual void
+  set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
+
+  virtual void set_dvalue(LabeledVector in,
+                          LabeledMatrix dout_din,
+                          LabeledTensor<1, 3> * d2out_din2 = nullptr) const;
+};
+
+typedef SampleSecDerivModelTempl<true> ADSampleSecDerivModel;
+typedef SampleSecDerivModelTempl<false> SampleSecDerivModel;

--- a/tests/src/SampleRateModel.cxx
+++ b/tests/src/SampleRateModel.cxx
@@ -45,37 +45,38 @@ SampleRateModelTempl<is_ad>::set_value(LabeledVector in,
   out.slice(0, "state").set(bar_dot, "bar_rate");
   out.slice(0, "state").set(baz_dot, "baz_rate");
 
-  if (dout_din)
-  {
-    TorchSize nbatch = in.batch_size();
-    auto dfoo_dot_dfoo = 2 * foo * T;
-    auto dfoo_dot_dbar = T;
-    auto dfoo_dot_dbaz = SymR2::identity().expand_batch(nbatch);
-    auto dbar_dot_dfoo = Scalar(-0.5, nbatch);
-    auto dbar_dot_dbar = Scalar(-0.01, nbatch);
-    auto dbar_dot_dbaz = SymR2::identity().expand_batch(nbatch);
-    auto dbaz_dot_dfoo = baz * (T - 3);
-    auto dbaz_dot_dbar = baz * (T - 3);
-    auto dbaz_dot_dbaz = (foo + bar) * (T - 3) * SymR2::identity_map().expand_batch(nbatch);
+  if constexpr (!is_ad)
+    if (dout_din)
+    {
+      TorchSize nbatch = in.batch_size();
+      auto dfoo_dot_dfoo = 2 * foo * T;
+      auto dfoo_dot_dbar = T;
+      auto dfoo_dot_dbaz = SymR2::identity().expand_batch(nbatch);
+      auto dbar_dot_dfoo = Scalar(-0.5, nbatch);
+      auto dbar_dot_dbar = Scalar(-0.01, nbatch);
+      auto dbar_dot_dbaz = SymR2::identity().expand_batch(nbatch);
+      auto dbaz_dot_dfoo = baz * (T - 3);
+      auto dbaz_dot_dbar = baz * (T - 3);
+      auto dbaz_dot_dbaz = (foo + bar) * (T - 3) * SymR2::identity_map().expand_batch(nbatch);
 
-    dout_din->block("state", "state").set(dfoo_dot_dfoo, "foo_rate", "foo");
-    dout_din->block("state", "state").set(dfoo_dot_dbar, "foo_rate", "bar");
-    dout_din->block("state", "state").set(dfoo_dot_dbaz, "foo_rate", "baz");
-    dout_din->block("state", "state").set(dbar_dot_dfoo, "bar_rate", "foo");
-    dout_din->block("state", "state").set(dbar_dot_dbar, "bar_rate", "bar");
-    dout_din->block("state", "state").set(dfoo_dot_dbaz, "bar_rate", "baz");
-    dout_din->block("state", "state").set(dbaz_dot_dfoo, "baz_rate", "foo");
-    dout_din->block("state", "state").set(dbaz_dot_dbar, "baz_rate", "bar");
-    dout_din->block("state", "state").set(dbaz_dot_dbaz, "baz_rate", "baz");
+      dout_din->block("state", "state").set(dfoo_dot_dfoo, "foo_rate", "foo");
+      dout_din->block("state", "state").set(dfoo_dot_dbar, "foo_rate", "bar");
+      dout_din->block("state", "state").set(dfoo_dot_dbaz, "foo_rate", "baz");
+      dout_din->block("state", "state").set(dbar_dot_dfoo, "bar_rate", "foo");
+      dout_din->block("state", "state").set(dbar_dot_dbar, "bar_rate", "bar");
+      dout_din->block("state", "state").set(dfoo_dot_dbaz, "bar_rate", "baz");
+      dout_din->block("state", "state").set(dbaz_dot_dfoo, "baz_rate", "foo");
+      dout_din->block("state", "state").set(dbaz_dot_dbar, "baz_rate", "bar");
+      dout_din->block("state", "state").set(dbaz_dot_dbaz, "baz_rate", "baz");
 
-    auto dfoo_dot_dT = foo * foo + bar;
-    auto dbar_dot_dT = Scalar(-0.9, nbatch);
-    auto dbaz_dot_dT = (foo + bar) * baz;
+      auto dfoo_dot_dT = foo * foo + bar;
+      auto dbar_dot_dT = Scalar(-0.9, nbatch);
+      auto dbaz_dot_dT = (foo + bar) * baz;
 
-    dout_din->block("state", "forces").set(dfoo_dot_dT, "foo_rate", "temperature");
-    dout_din->block("state", "forces").set(dbar_dot_dT, "bar_rate", "temperature");
-    dout_din->block("state", "forces").set(dbaz_dot_dT, "baz_rate", "temperature");
-  }
+      dout_din->block("state", "forces").set(dfoo_dot_dT, "foo_rate", "temperature");
+      dout_din->block("state", "forces").set(dbar_dot_dT, "bar_rate", "temperature");
+      dout_din->block("state", "forces").set(dbaz_dot_dT, "baz_rate", "temperature");
+    }
 }
 
 template class SampleRateModelTempl<true>;

--- a/tests/src/SampleSecDerivModel.cxx
+++ b/tests/src/SampleSecDerivModel.cxx
@@ -1,0 +1,74 @@
+#include "SampleSecDerivModel.h"
+
+template <bool is_ad>
+SampleSecDerivModelTempl<is_ad>::SampleSecDerivModelTempl(const std::string & name)
+  : SampleSecDerivModelBase<is_ad>(name)
+{
+  this->input().template add<LabeledAxis>("state");
+  this->input().subaxis("state").template add<Scalar>("x1");
+  this->input().subaxis("state").template add<Scalar>("x2");
+
+  this->output().template add<LabeledAxis>("state");
+  this->output().subaxis("state").template add<Scalar>("y");
+
+  this->setup();
+}
+
+template <bool is_ad>
+void
+SampleSecDerivModelTempl<is_ad>::set_value(LabeledVector in,
+                                           LabeledVector out,
+                                           LabeledMatrix * dout_din) const
+{
+  // Grab the inputs
+  auto x1 = in.slice(0, "state").get<Scalar>("x1");
+  auto x2 = in.slice(0, "state").get<Scalar>("x2");
+
+  // y = x1^3 + x2^4
+  auto y = x1 * x1 * x1 + x2 * x2 * x2 * x2;
+
+  // Set the output
+  out.slice(0, "state").set(y, "y");
+
+  if constexpr (!is_ad)
+    if (dout_din)
+    {
+      auto dy_dx1 = 3 * x1 * x1;
+      auto dy_dx2 = 4 * x2 * x2 * x2;
+
+      dout_din->block("state", "state").set(dy_dx1, "y", "x1");
+      dout_din->block("state", "state").set(dy_dx2, "y", "x2");
+    }
+}
+
+template <bool is_ad>
+void
+SampleSecDerivModelTempl<is_ad>::set_dvalue(LabeledVector in,
+                                            LabeledMatrix dout_din,
+                                            LabeledTensor<1, 3> * d2out_din2) const
+{
+  // Grab the inputs
+  auto x1 = in.slice(0, "state").get<Scalar>("x1");
+  auto x2 = in.slice(0, "state").get<Scalar>("x2");
+
+  // y = x1^3 + x2^4
+  auto dy_dx1 = 3 * x1 * x1;
+  auto dy_dx2 = 4 * x2 * x2 * x2;
+
+  // Set the output
+  dout_din.block("state", "state").set(dy_dx1, "y", "x1");
+  dout_din.block("state", "state").set(dy_dx2, "y", "x2");
+
+  if constexpr (!is_ad)
+    if (d2out_din2)
+    {
+      auto d2y_dx12 = 6 * x1;
+      auto d2y_dx22 = 12 * x2 * x2;
+
+      d2out_din2->block("state", "state", "state").set(d2y_dx12, "y", "x1", "x1");
+      d2out_din2->block("state", "state", "state").set(d2y_dx22, "y", "x2", "x2");
+    }
+}
+
+template class SampleSecDerivModelTempl<true>;
+template class SampleSecDerivModelTempl<false>;

--- a/tests/unit/models/test_ADSecDerivModel.cxx
+++ b/tests/unit/models/test_ADSecDerivModel.cxx
@@ -1,0 +1,39 @@
+#include <catch2/catch.hpp>
+
+#include "TestUtils.h"
+#include "SampleSecDerivModel.h"
+
+TEST_CASE("ADSecDerivModel", "[ADSecDerivModel]")
+{
+  TorchSize nbatch = 10;
+  auto model = SampleSecDerivModel("sample_model");
+  auto ad_model = ADSampleSecDerivModel("ad_sample_model");
+
+  LabeledVector in(nbatch, model.input());
+  in.slice(0, "state").set(Scalar(1.1, nbatch), "x1");
+  in.slice(0, "state").set(Scalar(0.01, nbatch), "x2");
+
+  SECTION("model derivatives")
+  {
+    auto exact = model.dvalue(in);
+    auto AD = ad_model.dvalue(in);
+    auto numerical = LabeledMatrix(nbatch, model.output(), model.input());
+    finite_differencing_derivative(
+        [model](const LabeledVector & x) { return model.value(x); }, in, numerical);
+
+    REQUIRE(torch::allclose(exact.tensor(), numerical.tensor(), /*rtol=*/0, /*atol=*/5e-4));
+    REQUIRE(torch::allclose(AD.tensor(), numerical.tensor(), /*rtol=*/0, /*atol=*/5e-4));
+  }
+
+  SECTION("model second derivatives")
+  {
+    auto exact = model.d2value(in);
+    auto AD = ad_model.d2value(in);
+    auto numerical = LabeledTensor<1, 3>(nbatch, model.output(), model.input(), model.input());
+    finite_differencing_derivative(
+        [model](const LabeledVector & x) { return model.dvalue(x); }, in, numerical);
+
+    REQUIRE(torch::allclose(exact.tensor(), numerical.tensor(), /*rtol=*/0, /*atol=*/5e-4));
+    REQUIRE(torch::allclose(AD.tensor(), numerical.tensor(), /*rtol=*/0, /*atol=*/5e-4));
+  }
+}


### PR DESCRIPTION
Provide three public interfaces:
- value
- dvalue
- value_and_dvalue

`value` and `value_and_dvalue` are both prefered as `Model`s always only override `set_value` which evaluate BOTH the forward operator and its derivative. Calling `dvalue` alone will waste the model output.

I was trying to think of a better as mentioned in #5, but I failed. The real issue is that I can't come up with a name set that is consistent for all these three public interfaces. For example
- forward
- D
- forward_and_D

looks weird. But I am fine with
- forward
- dforward
- forward_and_dforward

I am okay with this if you think it plays better with torch idioms.

Possibly close #5, we'll see.