### PR TITLE
Model can be .to(CUDA)

### DIFF
--- a/include/models/ComposedModel.h
+++ b/include/models/ComposedModel.h
@@ -26,10 +26,10 @@ protected:
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 
   /// Add a node in the DAG
-  void add_node(const std::shared_ptr<Model> & model);
+  void add_node(std::shared_ptr<Model> model);
 
   /// Register a dependency, e.g., adding a directed edge in the DAG
-  void register_dependency(const std::shared_ptr<Model> & from, const std::shared_ptr<Model> & to);
+  void register_dependency(std::shared_ptr<Model> from, std::shared_ptr<Model> to);
 
   /// Resolve dependency using topological traversal of the dependent models
   void resolve_dependency();
@@ -52,18 +52,18 @@ protected:
 
 private:
   /// Helper function to recurse the model graph to evaluate the total derivative
-  void chain_rule(const std::shared_ptr<Model> & i,
+  void chain_rule(const Model & i,
                   const std::unordered_map<std::string, LabeledMatrix> & cached_dpout_dpin,
                   LabeledMatrix dout_din) const;
 
   /// Dependency resolution helper
-  void resolve_dependency(const std::shared_ptr<Model> & i,
+  void resolve_dependency(std::shared_ptr<Model> i,
                           std::vector<std::shared_ptr<Model>> & dep,
                           std::unordered_map<std::string, bool> & visited);
 
   /// Helper function to write this model only
   void to_dot(std::ostream & os,
-              const std::shared_ptr<Model> & model,
+              const Model & model,
               int & id,
               std::unordered_map<std::string, int> & io_ids) const;
 };

--- a/include/models/ComposedModel.h
+++ b/include/models/ComposedModel.h
@@ -26,10 +26,10 @@ protected:
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 
   /// Add a node in the DAG
-  void add_node(std::shared_ptr<Model> model);
+  void add_node(const std::shared_ptr<Model> & model);
 
   /// Register a dependency, e.g., adding a directed edge in the DAG
-  void register_dependency(std::shared_ptr<Model> from, std::shared_ptr<Model> to);
+  void register_dependency(const std::shared_ptr<Model> & from, const std::shared_ptr<Model> & to);
 
   /// Resolve dependency using topological traversal of the dependent models
   void resolve_dependency();
@@ -57,7 +57,7 @@ private:
                   LabeledMatrix dout_din) const;
 
   /// Dependency resolution helper
-  void resolve_dependency(std::shared_ptr<Model> i,
+  void resolve_dependency(const std::shared_ptr<Model> & i,
                           std::vector<std::shared_ptr<Model>> & dep,
                           std::unordered_map<std::string, bool> & visited);
 

--- a/include/models/ComposedModel.h
+++ b/include/models/ComposedModel.h
@@ -7,16 +7,12 @@
 class ComposedModel : public Model
 {
 public:
-  ComposedModel(const std::string & name);
-
-  /// Register a model, e.g., adding a node in the DAG
-  void registerModel(Model & model);
-
-  /// Register a dependency, e.g., adding a directed edge in the DAG
-  void registerDependency(const std::string & from, const std::string & to);
+  ComposedModel(
+      const std::string & name,
+      const std::vector<std::pair<std::shared_ptr<Model>, std::shared_ptr<Model>>> & dependencies);
 
   /// Return dependencies of a registered model
-  const std::vector<Model *> & dependent_models(const std::string & name) const;
+  const std::vector<std::shared_ptr<Model>> & dependent_models(const std::string & name) const;
 
   /// Stringify the evaluation order
   std::string evaluation_order() const;
@@ -29,41 +25,45 @@ protected:
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 
-  virtual void setup();
+  /// Add a node in the DAG
+  void add_node(const std::shared_ptr<Model> & model);
+
+  /// Register a dependency, e.g., adding a directed edge in the DAG
+  void register_dependency(const std::shared_ptr<Model> & from, const std::shared_ptr<Model> & to);
 
   /// Resolve dependency using topological traversal of the dependent models
   void resolve_dependency();
 
   /// Nodes of this DAG
-  std::unordered_map<std::string, Model *> _models;
+  std::unordered_map<std::string, std::shared_ptr<Model>> _models;
 
   /// Dependencies among the nodes, e.g., the directed edges of the DAG
   /// This is also referred to as the adjacency matrix of a graph
-  std::unordered_map<std::string, std::vector<Model *>> _dependecies;
+  std::unordered_map<std::string, std::vector<std::shared_ptr<Model>>> _dependecies;
 
   /// Leaf nodes in the DAG -- they define the inputs of this composed model graph
-  std::vector<Model *> _input_models;
+  std::vector<std::shared_ptr<Model>> _input_models;
 
   /// Root node(s) in the DAG -- they define the outputs of this composed model graph
-  std::vector<Model *> _output_models;
+  std::vector<std::shared_ptr<Model>> _output_models;
 
   /// The order which we can follow to evaluate all the registered models
-  std::vector<Model *> _evaluation_order;
+  std::vector<std::shared_ptr<Model>> _evaluation_order;
 
 private:
   /// Helper function to recurse the model graph to evaluate the total derivative
-  void chain_rule(Model * i,
+  void chain_rule(const std::shared_ptr<Model> & i,
                   const std::unordered_map<std::string, LabeledMatrix> & cached_dpout_dpin,
                   LabeledMatrix dout_din) const;
 
   /// Dependency resolution helper
-  void resolve_dependency(Model * i,
-                          std::vector<Model *> & dep,
-                          std::unordered_map<Model *, bool> & visited);
+  void resolve_dependency(const std::shared_ptr<Model> & i,
+                          std::vector<std::shared_ptr<Model>> & dep,
+                          std::unordered_map<std::string, bool> & visited);
 
   /// Helper function to write this model only
   void to_dot(std::ostream & os,
-              Model * model,
+              const std::shared_ptr<Model> & model,
               int & id,
               std::unordered_map<std::string, int> & io_ids) const;
 };

--- a/include/models/ImplicitTimeIntegration.h
+++ b/include/models/ImplicitTimeIntegration.h
@@ -7,7 +7,7 @@
 class ImplicitTimeIntegration : public ImplicitModel
 {
 public:
-  ImplicitTimeIntegration(const std::string & name, Model & rate);
+  ImplicitTimeIntegration(const std::string & name, std::shared_ptr<Model> rate);
 
   // Define the nonlinear system we are solving for
   virtual void set_residual(BatchTensor<1> x, BatchTensor<1> r, BatchTensor<1> * J = nullptr) const;
@@ -16,5 +16,5 @@ protected:
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;
 
-  Model & _rate;
+  const Model & _rate;
 };

--- a/include/models/ImplicitUpdate.h
+++ b/include/models/ImplicitUpdate.h
@@ -7,7 +7,9 @@
 class ImplicitUpdate : public Model
 {
 public:
-  ImplicitUpdate(const std::string & name, ImplicitModel & model, NonlinearSolver & solver);
+  ImplicitUpdate(const std::string & name,
+                 std::shared_ptr<ImplicitModel> model,
+                 std::shared_ptr<NonlinearSolver> solver);
 
 protected:
   virtual void
@@ -17,5 +19,5 @@ protected:
   ImplicitModel & _model;
 
   /// The nonlinear solver used to solve the nonlinear system
-  NonlinearSolver & _solver;
+  const NonlinearSolver & _solver;
 };

--- a/include/models/Model.h
+++ b/include/models/Model.h
@@ -54,7 +54,7 @@ protected:
   NOTE: We also register this model as a submodule (in torch's language), so that when *this*
   `Model` is send to another device, the registered `Model` is also sent to that device.
   */
-  void registerModel(const std::shared_ptr<Model> & model);
+  void register_model(std::shared_ptr<Model> model);
 
   /// Models *this* model may use during its evaluation
   std::vector<std::shared_ptr<Model>> _registered_models;

--- a/include/models/Model.h
+++ b/include/models/Model.h
@@ -4,15 +4,13 @@
 #include "tensors/LabeledMatrix.h"
 #include "models/LabeledAxisInterface.h"
 
-/// Class that maps some input -> output,
-/// which is also the broader definition of a constitutive model :)
-class Model : public LabeledAxisInterface
+/**
+Class that maps some input -> output, which is also the broader definition of constitutive model.
+*/
+class Model : public torch::nn::Module, public LabeledAxisInterface
 {
 public:
   Model(const std::string & name);
-
-  /// Get the name of the model
-  std::string name() const { return _name; }
 
   /// Definition of the input variables
   /// @{
@@ -37,7 +35,10 @@ public:
   /// Convenient shortcut to construct and return the model value and its derivative
   virtual std::tuple<LabeledVector, LabeledMatrix> value_and_dvalue(LabeledVector in) const;
 
-  const std::vector<Model *> & registered_models() const { return _registered_models; }
+  const std::vector<std::shared_ptr<Model>> & registered_models() const
+  {
+    return _registered_models;
+  }
 
 protected:
   /// The map between input -> output, and optionally its derivatives
@@ -46,21 +47,19 @@ protected:
 
   virtual void setup() { setup_layout(); }
 
-  /// Register a model that the current model may use during its evaluation
-  /// No dependency information is added
-  template <class T>
-  T & registerModel(Model & model)
-  {
-    input().merge(model.input());
-    _registered_models.push_back(&model);
-    return dynamic_cast<T &>(model);
-  }
+  /**
+  Register a model that the current model may use during its evaluation. No dependency information
+  is added.
+
+  NOTE: We also register this model as a submodule (in torch's language), so that when *this*
+  `Model` is send to another device, the registered `Model` is also sent to that device.
+  */
+  void registerModel(const std::shared_ptr<Model> & model);
 
   /// Models *this* model may use during its evaluation
-  std::vector<Model *> _registered_models;
+  std::vector<std::shared_ptr<Model>> _registered_models;
 
 private:
-  std::string _name;
   LabeledAxis & _input;
   LabeledAxis & _output;
 };

--- a/include/models/solid_mechanics/AssociativePlasticFlowDirection.h
+++ b/include/models/solid_mechanics/AssociativePlasticFlowDirection.h
@@ -7,9 +7,9 @@
 class AssociativePlasticFlowDirection : public PlasticFlowDirection
 {
 public:
-  AssociativePlasticFlowDirection(const std::string & name, YieldFunction & f);
+  AssociativePlasticFlowDirection(const std::string & name, std::shared_ptr<YieldFunction> f);
 
-  YieldFunction & yield_function;
+  const YieldFunction & yield_function;
 
 protected:
   /// The flow direction

--- a/include/models/solid_mechanics/AssociativePlasticFlowDirection.h
+++ b/include/models/solid_mechanics/AssociativePlasticFlowDirection.h
@@ -7,7 +7,8 @@
 class AssociativePlasticFlowDirection : public PlasticFlowDirection
 {
 public:
-  AssociativePlasticFlowDirection(const std::string & name, std::shared_ptr<YieldFunction> f);
+  AssociativePlasticFlowDirection(const std::string & name,
+                                  const std::shared_ptr<YieldFunction> & f);
 
   const YieldFunction & yield_function;
 

--- a/include/models/solid_mechanics/AssociativePlasticHardening.h
+++ b/include/models/solid_mechanics/AssociativePlasticHardening.h
@@ -7,7 +7,7 @@
 class AssociativePlasticHardening : public PlasticHardening
 {
 public:
-  AssociativePlasticHardening(const std::string & name, std::shared_ptr<YieldFunction> f);
+  AssociativePlasticHardening(const std::string & name, const std::shared_ptr<YieldFunction> & f);
 
   const YieldFunction & yield_function;
 

--- a/include/models/solid_mechanics/AssociativePlasticHardening.h
+++ b/include/models/solid_mechanics/AssociativePlasticHardening.h
@@ -7,9 +7,9 @@
 class AssociativePlasticHardening : public PlasticHardening
 {
 public:
-  AssociativePlasticHardening(const std::string & name, YieldFunction & f);
+  AssociativePlasticHardening(const std::string & name, std::shared_ptr<YieldFunction> f);
 
-  YieldFunction & yield_function;
+  const YieldFunction & yield_function;
 
 protected:
   /// The flow direction

--- a/include/models/solid_mechanics/LinearIsotropicElasticity.h
+++ b/include/models/solid_mechanics/LinearIsotropicElasticity.h
@@ -3,10 +3,10 @@
 #include "models/Model.h"
 
 template <bool rate>
-class LinearIsotropicElasticity : public Model
+class LinearIsotropicElasticityTempl : public Model
 {
 public:
-  LinearIsotropicElasticity(const std::string & name, Scalar E, Scalar nu);
+  LinearIsotropicElasticityTempl(const std::string & name, Scalar E, Scalar nu);
 
 protected:
   virtual void
@@ -15,3 +15,6 @@ protected:
   Scalar _E;
   Scalar _nu;
 };
+
+typedef LinearIsotropicElasticityTempl<true> LinearIsotropicElasticityRate;
+typedef LinearIsotropicElasticityTempl<false> LinearIsotropicElasticity;

--- a/include/models/solid_mechanics/YieldFunction.h
+++ b/include/models/solid_mechanics/YieldFunction.h
@@ -8,6 +8,4 @@ class YieldFunction : public SecDerivModel
 public:
   /// Calculate yield function knowing the corresponding hardening model
   YieldFunction(const std::string & name);
-
-protected:
 };

--- a/src/models/ComposedModel.cxx
+++ b/src/models/ComposedModel.cxx
@@ -18,7 +18,7 @@ ComposedModel::ComposedModel(
 }
 
 void
-ComposedModel::add_node(std::shared_ptr<Model> model)
+ComposedModel::add_node(const std::shared_ptr<Model> & model)
 {
   _models[model->name()] = model;
   if (_dependecies.count(model->name()) == 0)
@@ -26,7 +26,8 @@ ComposedModel::add_node(std::shared_ptr<Model> model)
 }
 
 void
-ComposedModel::register_dependency(std::shared_ptr<Model> from, std::shared_ptr<Model> to)
+ComposedModel::register_dependency(const std::shared_ptr<Model> & from,
+                                   const std::shared_ptr<Model> & to)
 {
   add_node(from);
   add_node(to);
@@ -166,7 +167,7 @@ ComposedModel::resolve_dependency()
 }
 
 void
-ComposedModel::resolve_dependency(std::shared_ptr<Model> i,
+ComposedModel::resolve_dependency(const std::shared_ptr<Model> & i,
                                   std::vector<std::shared_ptr<Model>> & order,
                                   std::unordered_map<std::string, bool> & visited)
 {

--- a/src/models/ComposedModel.cxx
+++ b/src/models/ComposedModel.cxx
@@ -1,76 +1,46 @@
 #include "models/ComposedModel.h"
 
-ComposedModel::ComposedModel(const std::string & name)
+ComposedModel::ComposedModel(
+    const std::string & name,
+    const std::vector<std::pair<std::shared_ptr<Model>, std::shared_ptr<Model>>> & dependencies)
   : Model(name)
 {
-}
+  for (const auto & [from, to] : dependencies)
+    register_dependency(from, to);
 
-void
-ComposedModel::registerModel(Model & model)
-{
-  if (_models.count(model.name()))
-    throw std::runtime_error(name() + " already has a registered model named " + model.name());
+  resolve_dependency();
 
-  _models.emplace(model.name(), &model);
-  _dependecies[model.name()];
-}
+  // Registered the models that are needed for evaluation as submodules
+  for (auto i : _evaluation_order)
+    register_module(i->name(), i);
 
-void
-ComposedModel::registerDependency(const std::string & from, const std::string & to)
-{
-  if (_models.count(from) == 0)
-    throw std::runtime_error(from + " is not registered model in " + name());
-  if (_models.count(to) == 0)
-    throw std::runtime_error(to + " is not registered model in " + name());
-
-  _dependecies[to].push_back(_models[from]);
   setup();
 }
 
-const std::vector<Model *> &
+void
+ComposedModel::add_node(const std::shared_ptr<Model> & model)
+{
+  _models[model->name()] = model;
+  if (_dependecies.count(model->name()) == 0)
+    _dependecies[model->name()];
+}
+
+void
+ComposedModel::register_dependency(const std::shared_ptr<Model> & from,
+                                   const std::shared_ptr<Model> & to)
+{
+  add_node(from);
+  add_node(to);
+  _dependecies[to->name()].push_back(from);
+}
+
+const std::vector<std::shared_ptr<Model>> &
 ComposedModel::dependent_models(const std::string & n) const
 {
   if (_models.count(n) == 0)
     throw std::runtime_error(n + " is not registered model in " + name());
 
   return _dependecies.at(n);
-}
-
-void
-ComposedModel::setup()
-{
-  // First figure out the leaf models
-  _input_models.clear();
-  for (const auto & [name, deps] : _dependecies)
-    if (deps.empty())
-      _input_models.push_back(_models[name]);
-
-  // The leaf models define the inputs
-  input().clear();
-  for (auto i : _input_models)
-    input().merge(i->input());
-
-  // Find the root model(s)
-  // Basic idea: if a model is not needed by any other model, then it must be a root model
-  _output_models.clear();
-  std::unordered_map<std::string, bool> visited;
-  for (const auto & [name, deps] : _dependecies)
-    for (auto dep : deps)
-      visited[dep->name()] = true;
-  for (const auto & [name, i] : _models)
-    if (!visited[name])
-      _output_models.push_back(i);
-
-  // The root models define the outputs
-  output().clear();
-  for (auto i : _output_models)
-    output().merge(i->output());
-
-  // Now that we know the leaf models and root models, we can resolve the dependencies.
-  resolve_dependency();
-
-  // Actually setup this model
-  Model::setup();
 }
 
 void
@@ -132,7 +102,7 @@ ComposedModel::set_value(LabeledVector in, LabeledVector out, LabeledMatrix * do
 }
 
 void
-ComposedModel::chain_rule(Model * i,
+ComposedModel::chain_rule(const std::shared_ptr<Model> & i,
                           const std::unordered_map<std::string, LabeledMatrix> & cached_dpout_dpin,
                           LabeledMatrix dout_din) const
 {
@@ -162,23 +132,51 @@ ComposedModel::chain_rule(Model * i,
 void
 ComposedModel::resolve_dependency()
 {
+  // First figure out the leaf models
+  _input_models.clear();
+  for (const auto & [name, deps] : _dependecies)
+    if (deps.empty())
+      _input_models.push_back(_models[name]);
+
+  // The leaf models define the inputs
+  input().clear();
+  for (auto i : _input_models)
+    input().merge(i->input());
+
+  // Find the root model(s)
+  // Basic idea: if a model is not needed by any other model, then it must be a root model
+  _output_models.clear();
+  std::unordered_map<std::string, bool> visited;
+  for (const auto & [name, deps] : _dependecies)
+    for (auto dep : deps)
+      visited[dep->name()] = true;
+  for (const auto & [name, i] : _models)
+    if (!visited[name])
+      _output_models.push_back(i);
+
+  // The root models define the outputs
+  output().clear();
+  for (auto i : _output_models)
+    output().merge(i->output());
+
+  // Figure out the evaluation order
   _evaluation_order.clear();
-  std::unordered_map<Model *, bool> visited;
+  visited.clear();
   for (auto i : _output_models)
     resolve_dependency(i, _evaluation_order, visited);
 }
 
 void
-ComposedModel::resolve_dependency(Model * i,
-                                  std::vector<Model *> & order,
-                                  std::unordered_map<Model *, bool> & visited)
+ComposedModel::resolve_dependency(const std::shared_ptr<Model> & i,
+                                  std::vector<std::shared_ptr<Model>> & order,
+                                  std::unordered_map<std::string, bool> & visited)
 {
   // Mark the current node as visited
-  visited[i] = true;
+  visited[i->name()] = true;
 
   // Recurse for all the dependent models
   for (auto dep : dependent_models(i->name()))
-    if (!visited[dep])
+    if (!visited[dep->name()])
       resolve_dependency(dep, order, visited);
 
   order.push_back(i);
@@ -214,7 +212,7 @@ ComposedModel::to_dot(std::ostream & os) const
 
 void
 ComposedModel::to_dot(std::ostream & os,
-                      Model * model,
+                      const std::shared_ptr<Model> & model,
                       int & id,
                       std::unordered_map<std::string, int> & io_ids) const
 {

--- a/src/models/ImplicitTimeIntegration.cxx
+++ b/src/models/ImplicitTimeIntegration.cxx
@@ -1,9 +1,12 @@
 #include "models/ImplicitTimeIntegration.h"
 
-ImplicitTimeIntegration::ImplicitTimeIntegration(const std::string & name, Model & rate)
+ImplicitTimeIntegration::ImplicitTimeIntegration(const std::string & name,
+                                                 std::shared_ptr<Model> rate)
   : ImplicitModel(name),
-    _rate(registerModel<Model>(rate))
+    _rate(*rate)
 {
+  registerModel(rate);
+
   // Does the implicit constitutive model already requires time and old time?
   // Probably not, so we add time and old time here anyways, since we need them to perform time
   // integration.

--- a/src/models/ImplicitTimeIntegration.cxx
+++ b/src/models/ImplicitTimeIntegration.cxx
@@ -5,7 +5,7 @@ ImplicitTimeIntegration::ImplicitTimeIntegration(const std::string & name,
   : ImplicitModel(name),
     _rate(*rate)
 {
-  registerModel(rate);
+  register_model(rate);
 
   // Does the implicit constitutive model already requires time and old time?
   // Probably not, so we add time and old time here anyways, since we need them to perform time

--- a/src/models/ImplicitUpdate.cxx
+++ b/src/models/ImplicitUpdate.cxx
@@ -1,12 +1,13 @@
 #include "models/ImplicitUpdate.h"
 
 ImplicitUpdate::ImplicitUpdate(const std::string & name,
-                               ImplicitModel & model,
-                               NonlinearSolver & solver)
+                               std::shared_ptr<ImplicitModel> model,
+                               std::shared_ptr<NonlinearSolver> solver)
   : Model(name),
-    _model(registerModel<ImplicitModel>(model)),
-    _solver(solver)
+    _model(*model),
+    _solver(*solver)
 {
+  registerModel(model);
   // Now that the implicit model has been registered, the input of this ImplicitUpdate model should
   // be the same as the implicit model's input. The input subaxes of the implicit model looks
   // something like
@@ -26,7 +27,7 @@ ImplicitUpdate::ImplicitUpdate(const std::string & name,
   // as we have eliminated the trial state by solving the nonlinear system.
   // So, we need to remove the "state" subaxis from the input
   output().add<LabeledAxis>("state");
-  output().subaxis("state").merge(model.input().subaxis("state"));
+  output().subaxis("state").merge(model->input().subaxis("state"));
   input().remove("state");
   setup();
 }

--- a/src/models/ImplicitUpdate.cxx
+++ b/src/models/ImplicitUpdate.cxx
@@ -7,7 +7,7 @@ ImplicitUpdate::ImplicitUpdate(const std::string & name,
     _model(*model),
     _solver(*solver)
 {
-  registerModel(model);
+  register_model(model);
   // Now that the implicit model has been registered, the input of this ImplicitUpdate model should
   // be the same as the implicit model's input. The input subaxes of the implicit model looks
   // something like

--- a/src/models/Model.cxx
+++ b/src/models/Model.cxx
@@ -1,7 +1,7 @@
 #include "models/Model.h"
 
 Model::Model(const std::string & name)
-  : _name(name),
+  : torch::nn::Module(name),
     _input(declareAxis()),
     _output(declareAxis())
 {
@@ -30,4 +30,12 @@ Model::value_and_dvalue(LabeledVector in) const
   LabeledMatrix dout_din(out, in);
   set_value(in, out, &dout_din);
   return {out, dout_din};
+}
+
+void
+Model::registerModel(const std::shared_ptr<Model> & model)
+{
+  input().merge(model->input());
+  _registered_models.push_back(model);
+  register_module(model->name(), model);
 }

--- a/src/models/Model.cxx
+++ b/src/models/Model.cxx
@@ -33,7 +33,7 @@ Model::value_and_dvalue(LabeledVector in) const
 }
 
 void
-Model::registerModel(const std::shared_ptr<Model> & model)
+Model::register_model(std::shared_ptr<Model> model)
 {
   input().merge(model->input());
   _registered_models.push_back(model);

--- a/src/models/solid_mechanics/AssociativePlasticFlowDirection.cxx
+++ b/src/models/solid_mechanics/AssociativePlasticFlowDirection.cxx
@@ -1,8 +1,8 @@
 #include "models/solid_mechanics/AssociativePlasticFlowDirection.h"
 #include "tensors/SymSymR4.h"
 
-AssociativePlasticFlowDirection::AssociativePlasticFlowDirection(const std::string & name,
-                                                                 std::shared_ptr<YieldFunction> f)
+AssociativePlasticFlowDirection::AssociativePlasticFlowDirection(
+    const std::string & name, const std::shared_ptr<YieldFunction> & f)
   : PlasticFlowDirection(name),
     yield_function(*f)
 {

--- a/src/models/solid_mechanics/AssociativePlasticFlowDirection.cxx
+++ b/src/models/solid_mechanics/AssociativePlasticFlowDirection.cxx
@@ -6,7 +6,7 @@ AssociativePlasticFlowDirection::AssociativePlasticFlowDirection(const std::stri
   : PlasticFlowDirection(name),
     yield_function(*f)
 {
-  registerModel(f);
+  register_model(f);
   setup();
 }
 

--- a/src/models/solid_mechanics/AssociativePlasticFlowDirection.cxx
+++ b/src/models/solid_mechanics/AssociativePlasticFlowDirection.cxx
@@ -2,10 +2,11 @@
 #include "tensors/SymSymR4.h"
 
 AssociativePlasticFlowDirection::AssociativePlasticFlowDirection(const std::string & name,
-                                                                 YieldFunction & f)
+                                                                 std::shared_ptr<YieldFunction> f)
   : PlasticFlowDirection(name),
-    yield_function(registerModel<YieldFunction>(f))
+    yield_function(*f)
 {
+  registerModel(f);
   setup();
 }
 

--- a/src/models/solid_mechanics/AssociativePlasticHardening.cxx
+++ b/src/models/solid_mechanics/AssociativePlasticHardening.cxx
@@ -2,7 +2,7 @@
 #include "tensors/SymSymR4.h"
 
 AssociativePlasticHardening::AssociativePlasticHardening(const std::string & name,
-                                                         std::shared_ptr<YieldFunction> f)
+                                                         const std::shared_ptr<YieldFunction> & f)
   : PlasticHardening(name),
     yield_function(*f)
 {

--- a/src/models/solid_mechanics/AssociativePlasticHardening.cxx
+++ b/src/models/solid_mechanics/AssociativePlasticHardening.cxx
@@ -2,10 +2,11 @@
 #include "tensors/SymSymR4.h"
 
 AssociativePlasticHardening::AssociativePlasticHardening(const std::string & name,
-                                                         YieldFunction & f)
+                                                         std::shared_ptr<YieldFunction> f)
   : PlasticHardening(name),
-    yield_function(registerModel<YieldFunction>(f))
+    yield_function(*f)
 {
+  registerModel(f);
   setup();
 }
 

--- a/src/models/solid_mechanics/AssociativePlasticHardening.cxx
+++ b/src/models/solid_mechanics/AssociativePlasticHardening.cxx
@@ -6,7 +6,7 @@ AssociativePlasticHardening::AssociativePlasticHardening(const std::string & nam
   : PlasticHardening(name),
     yield_function(*f)
 {
-  registerModel(f);
+  register_model(f);
   setup();
 }
 

--- a/src/models/solid_mechanics/LinearIsotropicElasticity.cxx
+++ b/src/models/solid_mechanics/LinearIsotropicElasticity.cxx
@@ -2,12 +2,12 @@
 #include "tensors/SymSymR4.h"
 
 template <bool rate>
-LinearIsotropicElasticity<rate>::LinearIsotropicElasticity(const std::string & name,
-                                                           Scalar E,
-                                                           Scalar nu)
+LinearIsotropicElasticityTempl<rate>::LinearIsotropicElasticityTempl(const std::string & name,
+                                                                     Scalar E,
+                                                                     Scalar nu)
   : Model(name),
-    _E(E),
-    _nu(nu)
+    _E(register_parameter("youngs_modulus", E)),
+    _nu(register_parameter("poissons_ratio", nu))
 {
   input().add<LabeledAxis>("state");
   input().subaxis("state").add<SymR2>(rate ? "elastic_strain_rate" : "elastic_strain");
@@ -20,9 +20,9 @@ LinearIsotropicElasticity<rate>::LinearIsotropicElasticity(const std::string & n
 
 template <bool rate>
 void
-LinearIsotropicElasticity<rate>::set_value(LabeledVector in,
-                                           LabeledVector out,
-                                           LabeledMatrix * dout_din) const
+LinearIsotropicElasticityTempl<rate>::set_value(LabeledVector in,
+                                                LabeledVector out,
+                                                LabeledMatrix * dout_din) const
 {
   // Retrieve whatever we need from the input,
   // Here we need the elastic strain
@@ -45,5 +45,5 @@ LinearIsotropicElasticity<rate>::set_value(LabeledVector in,
   }
 }
 
-template class LinearIsotropicElasticity<true>;
-template class LinearIsotropicElasticity<false>;
+template class LinearIsotropicElasticityTempl<true>;
+template class LinearIsotropicElasticityTempl<false>;

--- a/src/models/solid_mechanics/LinearIsotropicHardening.cxx
+++ b/src/models/solid_mechanics/LinearIsotropicHardening.cxx
@@ -2,8 +2,8 @@
 
 LinearIsotropicHardening::LinearIsotropicHardening(const std::string & name, Scalar s0, Scalar K)
   : IsotropicHardening(name),
-    _s0(s0),
-    _K(K)
+    _s0(register_parameter("yield_stress", s0)),
+    _K(register_parameter("hardening_modulus", K))
 {
 }
 

--- a/src/models/solid_mechanics/PerzynaPlasticFlowRate.cxx
+++ b/src/models/solid_mechanics/PerzynaPlasticFlowRate.cxx
@@ -2,8 +2,8 @@
 
 PerzynaPlasticFlowRate::PerzynaPlasticFlowRate(const std::string & name, Scalar eta, Scalar n)
   : PlasticFlowRate(name),
-    _eta(eta),
-    _n(n)
+    _eta(register_parameter("reference_flow_stress", eta)),
+    _n(register_parameter("flow_rate_exponent", n))
 {
 }
 

--- a/tests/include/UniaxialStrainStructuralDriver.h
+++ b/tests/include/UniaxialStrainStructuralDriver.h
@@ -7,7 +7,7 @@ class UniaxialStrainStructuralDriver : public LabeledAxisInterface
 {
 public:
   // TODO: add temperature here and elsewhere
-  UniaxialStrainStructuralDriver(const std::shared_ptr<Model> & model,
+  UniaxialStrainStructuralDriver(std::shared_ptr<Model> model,
                                  Scalar max_strain,
                                  Scalar end_time,
                                  TorchSize nsteps);

--- a/tests/include/UniaxialStrainStructuralDriver.h
+++ b/tests/include/UniaxialStrainStructuralDriver.h
@@ -7,7 +7,7 @@ class UniaxialStrainStructuralDriver : public LabeledAxisInterface
 {
 public:
   // TODO: add temperature here and elsewhere
-  UniaxialStrainStructuralDriver(Model & model,
+  UniaxialStrainStructuralDriver(const std::shared_ptr<Model> & model,
                                  Scalar max_strain,
                                  Scalar end_time,
                                  TorchSize nsteps);
@@ -21,7 +21,7 @@ protected:
                            std::vector<LabeledVector> & all_inputs,
                            std::vector<LabeledVector> & all_outputs) const;
 
-  Model & _model;
+  const Model & _model;
   Scalar _max_strain;
   Scalar _end_time;
   TorchSize _nsteps;

--- a/tests/include/UniaxialStrainStructuralDriver.h
+++ b/tests/include/UniaxialStrainStructuralDriver.h
@@ -7,7 +7,7 @@ class UniaxialStrainStructuralDriver : public LabeledAxisInterface
 {
 public:
   // TODO: add temperature here and elsewhere
-  UniaxialStrainStructuralDriver(std::shared_ptr<Model> model,
+  UniaxialStrainStructuralDriver(const std::shared_ptr<Model> & model,
                                  Scalar max_strain,
                                  Scalar end_time,
                                  TorchSize nsteps);

--- a/tests/include/UniaxialStrainStructuralDriver.h
+++ b/tests/include/UniaxialStrainStructuralDriver.h
@@ -7,7 +7,7 @@ class UniaxialStrainStructuralDriver : public LabeledAxisInterface
 {
 public:
   // TODO: add temperature here and elsewhere
-  UniaxialStrainStructuralDriver(const std::shared_ptr<Model> & model,
+  UniaxialStrainStructuralDriver(const Model & model,
                                  Scalar max_strain,
                                  Scalar end_time,
                                  TorchSize nsteps);

--- a/tests/regression/models/regression_dot.txt
+++ b/tests/regression/models/regression_dot.txt
@@ -8,22 +8,22 @@ label = "kinematic_hardening input"
 bgcolor = lightgrey
 "kinematic_hardening input" [label = "", style = invis]
 subgraph cluster_2 {
-label = "kinematic_hardening input state"
-bgcolor = lightgrey
-"kinematic_hardening input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
-"kinematic_hardening input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
-}
-subgraph cluster_3 {
 label = "kinematic_hardening input forces"
 bgcolor = lightgrey
 "kinematic_hardening input forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "kinematic_hardening input forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
 }
-subgraph cluster_4 {
+subgraph cluster_3 {
 label = "kinematic_hardening input old_forces"
 bgcolor = lightgrey
 "kinematic_hardening input old_forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "kinematic_hardening input old_forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
+}
+subgraph cluster_4 {
+label = "kinematic_hardening input state"
+bgcolor = lightgrey
+"kinematic_hardening input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
+"kinematic_hardening input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
 }
 }
 subgraph cluster_5 {
@@ -33,8 +33,8 @@ bgcolor = lightgrey
 subgraph cluster_6 {
 label = "kinematic_hardening output state"
 bgcolor = lightgrey
-"kinematic_hardening output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 "kinematic_hardening output state cauchy_stress_rate" [style = filled, color = white, shape = Square, label = "cauchy_stress_rate [6]"]
+"kinematic_hardening output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 }
 }
 }
@@ -45,22 +45,22 @@ label = "isotropic_hardening input"
 bgcolor = lightgrey
 "isotropic_hardening input" [label = "", style = invis]
 subgraph cluster_9 {
-label = "isotropic_hardening input state"
-bgcolor = lightgrey
-"isotropic_hardening input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
-"isotropic_hardening input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
-}
-subgraph cluster_10 {
 label = "isotropic_hardening input forces"
 bgcolor = lightgrey
 "isotropic_hardening input forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "isotropic_hardening input forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
 }
-subgraph cluster_11 {
+subgraph cluster_10 {
 label = "isotropic_hardening input old_forces"
 bgcolor = lightgrey
 "isotropic_hardening input old_forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "isotropic_hardening input old_forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
+}
+subgraph cluster_11 {
+label = "isotropic_hardening input state"
+bgcolor = lightgrey
+"isotropic_hardening input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
+"isotropic_hardening input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
 }
 }
 subgraph cluster_12 {
@@ -70,8 +70,8 @@ bgcolor = lightgrey
 subgraph cluster_13 {
 label = "isotropic_hardening output state"
 bgcolor = lightgrey
-"isotropic_hardening output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 "isotropic_hardening output state cauchy_stress_rate" [style = filled, color = white, shape = Square, label = "cauchy_stress_rate [6]"]
+"isotropic_hardening output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 }
 }
 }
@@ -82,22 +82,22 @@ label = "yield_function input"
 bgcolor = lightgrey
 "yield_function input" [label = "", style = invis]
 subgraph cluster_16 {
-label = "yield_function input state"
-bgcolor = lightgrey
-"yield_function input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
-"yield_function input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
-}
-subgraph cluster_17 {
 label = "yield_function input forces"
 bgcolor = lightgrey
 "yield_function input forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "yield_function input forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
 }
-subgraph cluster_18 {
+subgraph cluster_17 {
 label = "yield_function input old_forces"
 bgcolor = lightgrey
 "yield_function input old_forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "yield_function input old_forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
+}
+subgraph cluster_18 {
+label = "yield_function input state"
+bgcolor = lightgrey
+"yield_function input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
+"yield_function input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
 }
 }
 subgraph cluster_19 {
@@ -107,8 +107,8 @@ bgcolor = lightgrey
 subgraph cluster_20 {
 label = "yield_function output state"
 bgcolor = lightgrey
-"yield_function output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 "yield_function output state cauchy_stress_rate" [style = filled, color = white, shape = Square, label = "cauchy_stress_rate [6]"]
+"yield_function output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 }
 }
 "kinematic_hardening output" -> "yield_function input"[ltail = cluster_5, lhead = cluster_15, penwidth = 2]
@@ -121,22 +121,22 @@ label = "hardening_rate input"
 bgcolor = lightgrey
 "hardening_rate input" [label = "", style = invis]
 subgraph cluster_23 {
-label = "hardening_rate input state"
-bgcolor = lightgrey
-"hardening_rate input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
-"hardening_rate input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
-}
-subgraph cluster_24 {
 label = "hardening_rate input forces"
 bgcolor = lightgrey
 "hardening_rate input forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "hardening_rate input forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
 }
-subgraph cluster_25 {
+subgraph cluster_24 {
 label = "hardening_rate input old_forces"
 bgcolor = lightgrey
 "hardening_rate input old_forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "hardening_rate input old_forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
+}
+subgraph cluster_25 {
+label = "hardening_rate input state"
+bgcolor = lightgrey
+"hardening_rate input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
+"hardening_rate input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
 }
 }
 subgraph cluster_26 {
@@ -146,8 +146,8 @@ bgcolor = lightgrey
 subgraph cluster_27 {
 label = "hardening_rate output state"
 bgcolor = lightgrey
-"hardening_rate output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 "hardening_rate output state cauchy_stress_rate" [style = filled, color = white, shape = Square, label = "cauchy_stress_rate [6]"]
+"hardening_rate output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 }
 }
 "yield_function output" -> "hardening_rate input"[ltail = cluster_19, lhead = cluster_22, penwidth = 2]
@@ -159,22 +159,22 @@ label = "ep_rate input"
 bgcolor = lightgrey
 "ep_rate input" [label = "", style = invis]
 subgraph cluster_30 {
-label = "ep_rate input state"
-bgcolor = lightgrey
-"ep_rate input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
-"ep_rate input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
-}
-subgraph cluster_31 {
 label = "ep_rate input forces"
 bgcolor = lightgrey
 "ep_rate input forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "ep_rate input forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
 }
-subgraph cluster_32 {
+subgraph cluster_31 {
 label = "ep_rate input old_forces"
 bgcolor = lightgrey
 "ep_rate input old_forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "ep_rate input old_forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
+}
+subgraph cluster_32 {
+label = "ep_rate input state"
+bgcolor = lightgrey
+"ep_rate input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
+"ep_rate input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
 }
 }
 subgraph cluster_33 {
@@ -184,8 +184,8 @@ bgcolor = lightgrey
 subgraph cluster_34 {
 label = "ep_rate output state"
 bgcolor = lightgrey
-"ep_rate output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 "ep_rate output state cauchy_stress_rate" [style = filled, color = white, shape = Square, label = "cauchy_stress_rate [6]"]
+"ep_rate output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 }
 }
 "kinematic_hardening output" -> "ep_rate input"[ltail = cluster_5, lhead = cluster_29, penwidth = 2]
@@ -199,22 +199,22 @@ label = "total_strain input"
 bgcolor = lightgrey
 "total_strain input" [label = "", style = invis]
 subgraph cluster_37 {
-label = "total_strain input state"
-bgcolor = lightgrey
-"total_strain input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
-"total_strain input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
-}
-subgraph cluster_38 {
 label = "total_strain input forces"
 bgcolor = lightgrey
 "total_strain input forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "total_strain input forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
 }
-subgraph cluster_39 {
+subgraph cluster_38 {
 label = "total_strain input old_forces"
 bgcolor = lightgrey
 "total_strain input old_forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "total_strain input old_forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
+}
+subgraph cluster_39 {
+label = "total_strain input state"
+bgcolor = lightgrey
+"total_strain input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
+"total_strain input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
 }
 }
 subgraph cluster_40 {
@@ -224,8 +224,8 @@ bgcolor = lightgrey
 subgraph cluster_41 {
 label = "total_strain output state"
 bgcolor = lightgrey
-"total_strain output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 "total_strain output state cauchy_stress_rate" [style = filled, color = white, shape = Square, label = "cauchy_stress_rate [6]"]
+"total_strain output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 }
 }
 }
@@ -236,22 +236,22 @@ label = "plastic_flow_direction input"
 bgcolor = lightgrey
 "plastic_flow_direction input" [label = "", style = invis]
 subgraph cluster_44 {
-label = "plastic_flow_direction input state"
-bgcolor = lightgrey
-"plastic_flow_direction input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
-"plastic_flow_direction input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
-}
-subgraph cluster_45 {
 label = "plastic_flow_direction input forces"
 bgcolor = lightgrey
 "plastic_flow_direction input forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "plastic_flow_direction input forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
 }
-subgraph cluster_46 {
+subgraph cluster_45 {
 label = "plastic_flow_direction input old_forces"
 bgcolor = lightgrey
 "plastic_flow_direction input old_forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "plastic_flow_direction input old_forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
+}
+subgraph cluster_46 {
+label = "plastic_flow_direction input state"
+bgcolor = lightgrey
+"plastic_flow_direction input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
+"plastic_flow_direction input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
 }
 }
 subgraph cluster_47 {
@@ -261,8 +261,8 @@ bgcolor = lightgrey
 subgraph cluster_48 {
 label = "plastic_flow_direction output state"
 bgcolor = lightgrey
-"plastic_flow_direction output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 "plastic_flow_direction output state cauchy_stress_rate" [style = filled, color = white, shape = Square, label = "cauchy_stress_rate [6]"]
+"plastic_flow_direction output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 }
 }
 "kinematic_hardening output" -> "plastic_flow_direction input"[ltail = cluster_5, lhead = cluster_43, penwidth = 2]
@@ -275,22 +275,22 @@ label = "plastic_strain_rate input"
 bgcolor = lightgrey
 "plastic_strain_rate input" [label = "", style = invis]
 subgraph cluster_51 {
-label = "plastic_strain_rate input state"
-bgcolor = lightgrey
-"plastic_strain_rate input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
-"plastic_strain_rate input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
-}
-subgraph cluster_52 {
 label = "plastic_strain_rate input forces"
 bgcolor = lightgrey
 "plastic_strain_rate input forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "plastic_strain_rate input forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
 }
-subgraph cluster_53 {
+subgraph cluster_52 {
 label = "plastic_strain_rate input old_forces"
 bgcolor = lightgrey
 "plastic_strain_rate input old_forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "plastic_strain_rate input old_forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
+}
+subgraph cluster_53 {
+label = "plastic_strain_rate input state"
+bgcolor = lightgrey
+"plastic_strain_rate input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
+"plastic_strain_rate input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
 }
 }
 subgraph cluster_54 {
@@ -300,8 +300,8 @@ bgcolor = lightgrey
 subgraph cluster_55 {
 label = "plastic_strain_rate output state"
 bgcolor = lightgrey
-"plastic_strain_rate output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 "plastic_strain_rate output state cauchy_stress_rate" [style = filled, color = white, shape = Square, label = "cauchy_stress_rate [6]"]
+"plastic_strain_rate output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 }
 }
 "hardening_rate output" -> "plastic_strain_rate input"[ltail = cluster_26, lhead = cluster_50, penwidth = 2]
@@ -314,22 +314,22 @@ label = "elastic_strain_rate input"
 bgcolor = lightgrey
 "elastic_strain_rate input" [label = "", style = invis]
 subgraph cluster_58 {
-label = "elastic_strain_rate input state"
-bgcolor = lightgrey
-"elastic_strain_rate input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
-"elastic_strain_rate input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
-}
-subgraph cluster_59 {
 label = "elastic_strain_rate input forces"
 bgcolor = lightgrey
 "elastic_strain_rate input forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "elastic_strain_rate input forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
 }
-subgraph cluster_60 {
+subgraph cluster_59 {
 label = "elastic_strain_rate input old_forces"
 bgcolor = lightgrey
 "elastic_strain_rate input old_forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "elastic_strain_rate input old_forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
+}
+subgraph cluster_60 {
+label = "elastic_strain_rate input state"
+bgcolor = lightgrey
+"elastic_strain_rate input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
+"elastic_strain_rate input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
 }
 }
 subgraph cluster_61 {
@@ -339,8 +339,8 @@ bgcolor = lightgrey
 subgraph cluster_62 {
 label = "elastic_strain_rate output state"
 bgcolor = lightgrey
-"elastic_strain_rate output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 "elastic_strain_rate output state cauchy_stress_rate" [style = filled, color = white, shape = Square, label = "cauchy_stress_rate [6]"]
+"elastic_strain_rate output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 }
 }
 "total_strain output" -> "elastic_strain_rate input"[ltail = cluster_40, lhead = cluster_57, penwidth = 2]
@@ -353,22 +353,22 @@ label = "elasticity input"
 bgcolor = lightgrey
 "elasticity input" [label = "", style = invis]
 subgraph cluster_65 {
-label = "elasticity input state"
-bgcolor = lightgrey
-"elasticity input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
-"elasticity input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
-}
-subgraph cluster_66 {
 label = "elasticity input forces"
 bgcolor = lightgrey
 "elasticity input forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "elasticity input forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
 }
-subgraph cluster_67 {
+subgraph cluster_66 {
 label = "elasticity input old_forces"
 bgcolor = lightgrey
 "elasticity input old_forces time" [style = filled, color = white, shape = Square, label = "time [1]"]
 "elasticity input old_forces total_strain" [style = filled, color = white, shape = Square, label = "total_strain [6]"]
+}
+subgraph cluster_67 {
+label = "elasticity input state"
+bgcolor = lightgrey
+"elasticity input state cauchy_stress" [style = filled, color = white, shape = Square, label = "cauchy_stress [6]"]
+"elasticity input state equivalent_plastic_strain" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain [1]"]
 }
 }
 subgraph cluster_68 {
@@ -378,8 +378,8 @@ bgcolor = lightgrey
 subgraph cluster_69 {
 label = "elasticity output state"
 bgcolor = lightgrey
-"elasticity output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 "elasticity output state cauchy_stress_rate" [style = filled, color = white, shape = Square, label = "cauchy_stress_rate [6]"]
+"elasticity output state equivalent_plastic_strain_rate" [style = filled, color = white, shape = Square, label = "equivalent_plastic_strain_rate [1]"]
 }
 }
 "elastic_strain_rate output" -> "elasticity input"[ltail = cluster_61, lhead = cluster_64, penwidth = 2]

--- a/tests/regression/models/solid_mechanics/regression_viscoplasticity.cxx
+++ b/tests/regression/models/solid_mechanics/regression_viscoplasticity.cxx
@@ -22,6 +22,11 @@
 
 TEST_CASE("Uniaxial strain regression test", "[StructuralRegressionTests]")
 {
+  NonlinearSolverParameters params = {/*atol =*/1e-10,
+                                      /*rtol =*/1e-8,
+                                      /*miters =*/100,
+                                      /*verbose=*/false};
+
   TorchSize nbatch = 20;
   Scalar E = 1e5;
   Scalar nu = 0.3;
@@ -29,49 +34,38 @@ TEST_CASE("Uniaxial strain regression test", "[StructuralRegressionTests]")
   Scalar K = 1000;
   Scalar eta = 100;
   Scalar n = 2;
-  auto Erate = ForceRate<SymR2>("total_strain");
-  auto Eerate = ElasticStrainRate("elastic_strain_rate");
-  auto elasticity = LinearIsotropicElasticity<true>("elasticity", E, nu);
-  auto kinharden = NoKinematicHardening("kinematic_hardening");
-  auto isoharden = LinearIsotropicHardening("isotropic_hardening", s0, K);
-  auto yield = J2IsotropicYieldFunction("yield_function");
-  auto direction = AssociativePlasticFlowDirection("plastic_flow_direction", yield);
-  auto eprate = AssociativePlasticHardening("ep_rate", yield);
-  auto hrate = PerzynaPlasticFlowRate("hardening_rate", eta, n);
-  auto Eprate = PlasticStrainRate("plastic_strain_rate");
+  auto Erate = std::make_shared<ForceRate<SymR2>>("total_strain");
+  auto Eerate = std::make_shared<ElasticStrainRate>("elastic_strain_rate");
+  auto elasticity = std::make_shared<LinearIsotropicElasticityRate>("elasticity", E, nu);
+  auto kinharden = std::make_shared<NoKinematicHardening>("kinematic_hardening");
+  auto isoharden = std::make_shared<LinearIsotropicHardening>("isotropic_hardening", s0, K);
+  auto yield = std::make_shared<J2IsotropicYieldFunction>("yield_function");
+  auto direction =
+      std::make_shared<AssociativePlasticFlowDirection>("plastic_flow_direction", yield);
+  auto eprate = std::make_shared<AssociativePlasticHardening>("ep_rate", yield);
+  auto hrate = std::make_shared<PerzynaPlasticFlowRate>("hardening_rate", eta, n);
+  auto Eprate = std::make_shared<PlasticStrainRate>("plastic_strain_rate");
 
   // All these dependency registration thingy can be predefined.
-  auto rate = ComposedModel("rate");
-  rate.registerModel(Erate);
-  rate.registerModel(Eerate);
-  rate.registerModel(elasticity);
-  rate.registerModel(kinharden);
-  rate.registerModel(isoharden);
-  rate.registerModel(yield);
-  rate.registerModel(direction);
-  rate.registerModel(hrate);
-  rate.registerModel(eprate);
-  rate.registerModel(Eprate);
-  rate.registerDependency("total_strain", "elastic_strain_rate");
-  rate.registerDependency("kinematic_hardening", "yield_function");
-  rate.registerDependency("isotropic_hardening", "yield_function");
-  rate.registerDependency("kinematic_hardening", "plastic_flow_direction");
-  rate.registerDependency("isotropic_hardening", "plastic_flow_direction");
-  rate.registerDependency("kinematic_hardening", "ep_rate");
-  rate.registerDependency("isotropic_hardening", "ep_rate");
-  rate.registerDependency("hardening_rate", "ep_rate");
-  rate.registerDependency("yield_function", "hardening_rate");
-  rate.registerDependency("hardening_rate", "plastic_strain_rate");
-  rate.registerDependency("plastic_flow_direction", "plastic_strain_rate");
-  rate.registerDependency("plastic_strain_rate", "elastic_strain_rate");
-  rate.registerDependency("elastic_strain_rate", "elasticity");
+  std::vector<std::pair<std::shared_ptr<Model>, std::shared_ptr<Model>>> dependencies = {
+      {Erate, Eerate},
+      {kinharden, yield},
+      {isoharden, yield},
+      {kinharden, direction},
+      {isoharden, direction},
+      {kinharden, eprate},
+      {isoharden, eprate},
+      {hrate, eprate},
+      {yield, hrate},
+      {hrate, Eprate},
+      {direction, Eprate},
+      {Eprate, Eerate},
+      {Eerate, elasticity}};
+  auto rate = std::make_shared<ComposedModel>("rate", dependencies);
 
-  auto implicit_rate = ImplicitTimeIntegration("implicit_time_integration", rate);
-  auto solver = NewtonNonlinearSolver({/*atol =*/1e-10,
-                                       /*rtol =*/1e-8,
-                                       /*miters =*/100,
-                                       /*verbose=*/false});
-  auto model = ImplicitUpdate("viscoplasticity", implicit_rate, solver);
+  auto implicit_rate = std::make_shared<ImplicitTimeIntegration>("implicit_time_integration", rate);
+  auto solver = std::make_shared<NewtonNonlinearSolver>(params);
+  auto model = std::make_shared<ImplicitUpdate>("viscoplasticity", implicit_rate, solver);
 
   TorchSize nsteps = 100;
   Real max_strain = 0.10;
@@ -83,7 +77,7 @@ TEST_CASE("Uniaxial strain regression test", "[StructuralRegressionTests]")
   auto [all_inputs, all_outputs] = driver.run();
 
   std::ofstream ofile;
-  std::string fname = "regression/models/solid_mechanics/" + model.name();
+  std::string fname = "regression/models/solid_mechanics/" + model->name();
 
   // I use this to write csv for visualization purposes.
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/regression/models/solid_mechanics/regression_viscoplasticity.cxx
+++ b/tests/regression/models/solid_mechanics/regression_viscoplasticity.cxx
@@ -73,7 +73,7 @@ TEST_CASE("Uniaxial strain regression test", "[StructuralRegressionTests]")
   Real max_time = 5;
   Scalar max_strains = torch::full({nbatch}, max_strain, TorchDefaults).unsqueeze(-1);
   Scalar end_times = torch::logspace(min_time, max_time, nbatch, 10, TorchDefaults).unsqueeze(-1);
-  UniaxialStrainStructuralDriver driver(model, max_strains, end_times, nsteps);
+  UniaxialStrainStructuralDriver driver(*model, max_strains, end_times, nsteps);
   auto [all_inputs, all_outputs] = driver.run();
 
   std::ofstream ofile;

--- a/tests/src/UniaxialStrainStructuralDriver.cxx
+++ b/tests/src/UniaxialStrainStructuralDriver.cxx
@@ -1,6 +1,6 @@
 #include "UniaxialStrainStructuralDriver.h"
 
-UniaxialStrainStructuralDriver::UniaxialStrainStructuralDriver(std::shared_ptr<Model> model,
+UniaxialStrainStructuralDriver::UniaxialStrainStructuralDriver(const std::shared_ptr<Model> & model,
                                                                Scalar max_strain,
                                                                Scalar end_time,
                                                                TorchSize nsteps)

--- a/tests/src/UniaxialStrainStructuralDriver.cxx
+++ b/tests/src/UniaxialStrainStructuralDriver.cxx
@@ -1,6 +1,6 @@
 #include "UniaxialStrainStructuralDriver.h"
 
-UniaxialStrainStructuralDriver::UniaxialStrainStructuralDriver(const std::shared_ptr<Model> & model,
+UniaxialStrainStructuralDriver::UniaxialStrainStructuralDriver(std::shared_ptr<Model> model,
                                                                Scalar max_strain,
                                                                Scalar end_time,
                                                                TorchSize nsteps)

--- a/tests/src/UniaxialStrainStructuralDriver.cxx
+++ b/tests/src/UniaxialStrainStructuralDriver.cxx
@@ -1,10 +1,10 @@
 #include "UniaxialStrainStructuralDriver.h"
 
-UniaxialStrainStructuralDriver::UniaxialStrainStructuralDriver(Model & model,
+UniaxialStrainStructuralDriver::UniaxialStrainStructuralDriver(const std::shared_ptr<Model> & model,
                                                                Scalar max_strain,
                                                                Scalar end_time,
                                                                TorchSize nsteps)
-  : _model(model),
+  : _model(*model),
     _max_strain(max_strain),
     _end_time(end_time),
     _nsteps(nsteps),

--- a/tests/src/UniaxialStrainStructuralDriver.cxx
+++ b/tests/src/UniaxialStrainStructuralDriver.cxx
@@ -1,10 +1,10 @@
 #include "UniaxialStrainStructuralDriver.h"
 
-UniaxialStrainStructuralDriver::UniaxialStrainStructuralDriver(const std::shared_ptr<Model> & model,
+UniaxialStrainStructuralDriver::UniaxialStrainStructuralDriver(const Model & model,
                                                                Scalar max_strain,
                                                                Scalar end_time,
                                                                TorchSize nsteps)
-  : _model(*model),
+  : _model(model),
     _max_strain(max_strain),
     _end_time(end_time),
     _nsteps(nsteps),

--- a/tests/unit/models/solid_mechanics/test_AssociativePlasticFlowDirection.cxx
+++ b/tests/unit/models/solid_mechanics/test_AssociativePlasticFlowDirection.cxx
@@ -7,13 +7,13 @@
 TEST_CASE("AssociativePlasticFlowDirection", "[AssociativePlasticFlowDirection]")
 {
   TorchSize nbatch = 10;
-  auto yield = J2IsotropicYieldFunction("yield_function");
+  auto yield = std::make_shared<J2IsotropicYieldFunction>("yield_function");
   auto direction = AssociativePlasticFlowDirection("plastic_flow_direction", yield);
 
   SECTION("model definition")
   {
     // My input should be sufficient for me to evaluate the yield function, hence
-    REQUIRE(direction.input() == yield.input());
+    REQUIRE(direction.input() == yield->input());
 
     REQUIRE(direction.output().has_subaxis("state"));
     REQUIRE(direction.output().subaxis("state").has_variable<SymR2>("plastic_flow_direction"));

--- a/tests/unit/models/solid_mechanics/test_AssociativePlasticHardening.cxx
+++ b/tests/unit/models/solid_mechanics/test_AssociativePlasticHardening.cxx
@@ -7,7 +7,7 @@
 TEST_CASE("AssociativePlasticHardening", "[AssociativePlasticHardening]")
 {
   TorchSize nbatch = 1;
-  auto yield = J2IsotropicYieldFunction("yield_function");
+  auto yield = std::make_shared<J2IsotropicYieldFunction>("yield_function");
   auto eprate = AssociativePlasticHardening("ep_rate", yield);
 
   SECTION("model definition")

--- a/tests/unit/models/solid_mechanics/test_ComposedModel.cxx
+++ b/tests/unit/models/solid_mechanics/test_ComposedModel.cxx
@@ -158,7 +158,7 @@ TEST_CASE("send to different device", "[ComposedModel]")
   SECTION("send to CPU")
   {
     model.to(torch::kCPU);
-    for (const auto param : params)
+    for (const auto & param : params)
       REQUIRE(param.value().device().type() == torch::kCPU);
   }
 
@@ -167,7 +167,7 @@ TEST_CASE("send to different device", "[ComposedModel]")
     if (torch::cuda::is_available())
     {
       model.to(torch::kCUDA);
-      for (const auto param : params)
+      for (const auto & param : params)
         REQUIRE(param.value().device().type() == torch::kCUDA);
     }
   }

--- a/tests/unit/models/solid_mechanics/test_LinearIsotropicElasticity.cxx
+++ b/tests/unit/models/solid_mechanics/test_LinearIsotropicElasticity.cxx
@@ -8,7 +8,7 @@ TEST_CASE("LinearIsotropicElasticity", "[LinearIsotropicElasticity]")
   TorchSize nbatch = 10;
   Scalar E = 100;
   Scalar nu = 0.3;
-  auto elasticity = LinearIsotropicElasticity<false>("elasticity", E, nu);
+  auto elasticity = LinearIsotropicElasticity("elasticity", E, nu);
 
   SECTION("model definition")
   {

--- a/tests/unit/models/test_ImplicitTimeIntegration.cxx
+++ b/tests/unit/models/test_ImplicitTimeIntegration.cxx
@@ -7,7 +7,7 @@
 TEST_CASE("ImplicitTimeIntegration", "[ImplicitTimeIntegration]")
 {
   TorchSize nbatch = 10;
-  auto rate = SampleRateModel("sample_rate");
+  auto rate = std::make_shared<SampleRateModel>("sample_rate");
   auto implicit_rate = ImplicitTimeIntegration("implicit_time_integration", rate);
 
   SECTION("model definition")

--- a/tests/unit/tensors/test_LabeledAxis.cxx
+++ b/tests/unit/tensors/test_LabeledAxis.cxx
@@ -235,8 +235,8 @@ TEST_CASE("Miscellaneous modifiers", "[LabeledAxis]")
     test.add<Scalar>("scalar4")
         .remove("r2t1")
         .prefix("foo")
-        .rename("scalar4", "scalar5")
-        .remove("scalar2")
+        .rename("foo_scalar4", "scalar5")
+        .remove("foo_scalar2")
         .suffix("heh");
     test.setup_layout();
 
@@ -246,7 +246,7 @@ TEST_CASE("Miscellaneous modifiers", "[LabeledAxis]")
     REQUIRE(test.storage_size() == 9);
     REQUIRE(test.storage_size("foo_scalar1_heh") == 1);
     REQUIRE(test.storage_size("foo_scalar3_heh") == 1);
-    REQUIRE(test.storage_size("foo_scalar5_heh") == 1);
+    REQUIRE(test.storage_size("scalar5_heh") == 1);
     REQUIRE(test.storage_size("foo_r2t2_heh") == 6);
   }
 }


### PR DESCRIPTION
1. `Model` inherits from torch::nn::Module
2. submodule registration handled internally by `Model` and `ComposedModel`
3. Material properties registered as `Parameter`s

so... all `Model`s should be to-cuda-able. But I'm flying blind here. I still need to properly deal with TorchDefaults before I can test sending a CPU-constructed `Model` to GPU.

ref #4