### PR TITLE
Add a script to check copyright heading

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,13 @@ jobs:
         uses: jidicula/clang-format-action@v4.9.0
         with:
           clang-format-version: '14'
+  copyright:
+    name: Copyright check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check if source files contain the correct copyright heading
+      - run: python scripts/check_copyright.py
   build-test-linux:
     needs: clang-format
     runs-on: ubuntu-latest

--- a/scripts/check_copyright.py
+++ b/scripts/check_copyright.py
@@ -1,0 +1,105 @@
+# This file is part of NEML2
+# https://github.com/reverendbedford/batchedmat.git
+# 
+# All rights reserved, see COPYRIGHT for full restrictions
+# https://github.com/reverendbedford/batchedmat/blob/main/COPYRIGHT
+# 
+# Licensed under LGPL 2.1, please see LICENSE for details
+# https://www.gnu.org/licenses/lgpl-2.1.html
+
+
+from pathlib import Path
+import subprocess
+import sys
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-m",
+    "--modify",
+    help="Modify the files to have the correct copyright heading",
+    action="store_true",
+)
+args = parser.parse_args()
+
+extensions = {".h": "//", ".cxx": "//", ".py": "#", ".sh": "#", ".rst": ".. "}
+additional_files = {}
+
+exclude_dirs = ["extern"]
+exclude_files = []
+
+
+rootdir = Path(".")
+
+
+def should_check(path):
+    for exclude_dir in exclude_dirs:
+        if Path(rootdir) / Path(exclude_dir) in path.parents:
+            return False
+
+    if path.name in exclude_files:
+        return False
+
+    if path.suffix in extensions:
+        return True
+
+    if path.name in additional_files:
+        return True
+
+    return False
+
+
+def generate_copyright_heading(copyright, prefix):
+    return prefix + " " + (prefix + " ").join(copyright.splitlines(True))
+
+
+def has_correct_heading(path, copyright, prefix, modify):
+    heading = generate_copyright_heading(copyright, prefix)
+
+    # First check if it has the correct heading
+    content = path.read_text()
+    correct = content.startswith(heading)
+
+    if not modify:
+        return correct
+
+    # Correct the heading
+    with path.open("w", encoding="utf-8") as file:
+        file.write(heading)
+        file.write("\n")
+        for line in content.splitlines(True):
+            if not line.startswith(prefix):
+                file.write(line)
+
+    print("Corrected copyright heading for " + str(path))
+
+    return True
+
+
+files = subprocess.run(
+    ["git", "ls-tree", "-r", "HEAD", "--name-only"], capture_output=True, text=True
+).stdout
+
+copyright = Path(rootdir / "scripts" / "copyright").with_suffix(".txt").read_text()
+print("The copyright statement is")
+print(copyright)
+
+success = True
+for file in files.splitlines():
+    file_path = Path(file)
+    if should_check(file_path):
+        if file_path.suffix in extensions:
+            prefix = extensions[file_path.suffix]
+        elif file_path.name in additional_files:
+            prefix = additional_files[file_path.name]
+        else:
+            sys.exit("Internal error")
+
+        if not has_correct_heading(file_path, copyright, prefix, args.modify):
+            print(file)
+            success = False
+
+if success:
+    print("All files have the correct copyright heading")
+else:
+    sys.exit("The above files do NOT contain the correct copyright heading")

--- a/scripts/copyright.txt
+++ b/scripts/copyright.txt
@@ -1,0 +1,8 @@
+This file is part of NEML2
+https://github.com/reverendbedford/batchedmat.git
+
+All rights reserved, see COPYRIGHT for full restrictions
+https://github.com/reverendbedford/batchedmat/blob/main/COPYRIGHT
+
+Licensed under LGPL 2.1, please see LICENSE for details
+https://www.gnu.org/licenses/lgpl-2.1.html


### PR DESCRIPTION
for each source file, that is.

Also added a github workflow to enforce it. The workflow should fail now. But when we are ready, I'll run the script locally and add all the appropriate headings.

ref #16