### PR TITLE
Workaround for CUDA initialization testing

### DIFF
--- a/tests/unit/models/test_ADSecDerivModel.cxx
+++ b/tests/unit/models/test_ADSecDerivModel.cxx
@@ -7,6 +7,8 @@ using namespace neml2;
 
 TEST_CASE("ADSecDerivModel", "[ADSecDerivModel]")
 {
+  torch::cuda::is_available();
+
   TorchSize nbatch = 10;
   auto model = SampleSecDerivModel("sample_model");
   auto ad_model = ADSampleSecDerivModel("ad_sample_model");


### PR DESCRIPTION
Fixes fun pytorch initialization order issue that I don't fully understand which is causing test_ADSecDerivModel to fail.

Closes #44