### PR TITLE
Add an interface to take care of side effects of advancing time step

### DIFF
--- a/include/neml2/base/TransientInterface.h
+++ b/include/neml2/base/TransientInterface.h
@@ -24,38 +24,16 @@
 
 #pragma once
 
-#include "neml2/predictors/Predictor.h"
-
 namespace neml2
 {
-class LinearExtrapolationPredictor : public Predictor
+class TransientInterface
 {
 public:
-  static ParameterSet expected_params();
-
-  LinearExtrapolationPredictor(const ParameterSet & params);
-
   /**
-   * Linearly extrapolate the old and older state in time to get the initial guess for the current
-   * state.
+   * Advance to the next step in time. If the object maintains the history of state or force, this
+   * is the opportunity to shift them back in time, i.e., the current state becomes the previous
+   * (old) state.
    */
-  virtual void set_initial_guess(LabeledVector in, LabeledVector guess) const override;
-
-  /**
-   * Cache the current state and time step size
-   */
-  virtual void post_solve(LabeledVector in, LabeledVector out) override;
-
-  /**
-   * Shift the state back in time
-   */
-  virtual void advance_step() override;
-
-protected:
-  LabeledVector _state;
-  LabeledVector _state_n;
-  LabeledVector _state_nm1;
-  Scalar _dt;
-  Scalar _dt_n;
+  virtual void advance_step() {}
 };
 } // namespace neml2

--- a/include/neml2/models/ImplicitUpdate.h
+++ b/include/neml2/models/ImplicitUpdate.h
@@ -39,6 +39,8 @@ public:
 
   const Model & implicit_model() const { return _model; }
 
+  virtual void advance_step() override;
+
 protected:
   virtual void
   set_value(LabeledVector in, LabeledVector out, LabeledMatrix * dout_din = nullptr) const;

--- a/include/neml2/predictors/Predictor.h
+++ b/include/neml2/predictors/Predictor.h
@@ -27,10 +27,11 @@
 #include "neml2/base/NEML2Object.h"
 #include "neml2/base/Registry.h"
 #include "neml2/tensors/LabeledVector.h"
+#include "neml2/base/TransientInterface.h"
 
 namespace neml2
 {
-class Predictor : public NEML2Object
+class Predictor : public NEML2Object, public TransientInterface
 {
 public:
   static ParameterSet expected_params();

--- a/include/neml2/predictors/PreviousStatePredictor.h
+++ b/include/neml2/predictors/PreviousStatePredictor.h
@@ -41,11 +41,17 @@ public:
   virtual void set_initial_guess(LabeledVector in, LabeledVector guess) const override;
 
   /**
-   * Cache the old state
+   * Cache the current state
    */
   virtual void post_solve(LabeledVector in, LabeledVector out) override;
 
+  /**
+   * Shift the state back in time
+   */
+  virtual void advance_step() override;
+
 protected:
+  LabeledVector _state;
   LabeledVector _state_n;
 };
 } // namespace neml2

--- a/src/neml2/models/ImplicitUpdate.cxx
+++ b/src/neml2/models/ImplicitUpdate.cxx
@@ -131,4 +131,11 @@ ImplicitUpdate::set_value(LabeledVector in, LabeledVector out, LabeledMatrix * d
     dout_din->block("state", "old_forces").copy(-Jinv.chain(partials.slice(1, "old_forces")));
   }
 }
+
+void
+ImplicitUpdate::advance_step()
+{
+  Model::advance_step();
+  _predictor->advance_step();
+}
 } // namespace neml2

--- a/src/neml2/models/Model.cxx
+++ b/src/neml2/models/Model.cxx
@@ -81,7 +81,7 @@ Model::register_model(std::shared_ptr<Model> model, bool merge_input)
     _consumed_vars.insert(merged_vars.begin(), merged_vars.end());
   }
 
-  _registered_models.push_back(model);
+  _registered_models.push_back(model.get());
 
   // torch bookkeeping
   register_module(model->name(), model);
@@ -91,6 +91,13 @@ void
 Model::cache_input(LabeledVector in)
 {
   _cached_in = in.clone();
+}
+
+void
+Model::advance_step()
+{
+  for (auto model : registered_models())
+    model->advance_step();
 }
 
 void

--- a/src/neml2/predictors/LinearExtrapolationPredictor.cxx
+++ b/src/neml2/predictors/LinearExtrapolationPredictor.cxx
@@ -76,7 +76,12 @@ LinearExtrapolationPredictor::advance_step()
 {
   if (!_state_n.axes().empty())
     _state_nm1 = _state_n.clone();
-  _state_n = _state.clone();
+
+  if (!_state.axes().empty())
+    _state_n = _state.clone();
+
+  _state = LabeledVector();
+
   _dt_n = _dt.clone();
 }
 } // namespace neml2

--- a/src/neml2/predictors/LinearExtrapolationPredictor.cxx
+++ b/src/neml2/predictors/LinearExtrapolationPredictor.cxx
@@ -67,9 +67,16 @@ LinearExtrapolationPredictor::set_initial_guess(LabeledVector in, LabeledVector 
 void
 LinearExtrapolationPredictor::post_solve(LabeledVector in, LabeledVector out)
 {
+  _state = out.slice("state").clone();
+  _dt = in.slice("forces").get<Scalar>("time") - in.slice("old_forces").get<Scalar>("time");
+}
+
+void
+LinearExtrapolationPredictor::advance_step()
+{
   if (!_state_n.axes().empty())
     _state_nm1 = _state_n.clone();
-  _state_n = out.slice("state").clone();
-  _dt_n = in.slice("forces").get<Scalar>("time") - in.slice("old_forces").get<Scalar>("time");
+  _state_n = _state.clone();
+  _dt_n = _dt.clone();
 }
 } // namespace neml2

--- a/src/neml2/predictors/PreviousStatePredictor.cxx
+++ b/src/neml2/predictors/PreviousStatePredictor.cxx
@@ -50,6 +50,12 @@ PreviousStatePredictor::set_initial_guess(LabeledVector /*in*/, LabeledVector gu
 void
 PreviousStatePredictor::post_solve(LabeledVector /*in*/, LabeledVector out)
 {
-  _state_n = out.slice("state").clone();
+  _state = out.slice("state").clone();
+}
+
+void
+PreviousStatePredictor::advance_step()
+{
+  _state_n = _state.clone();
 }
 } // namespace neml2

--- a/src/neml2/predictors/PreviousStatePredictor.cxx
+++ b/src/neml2/predictors/PreviousStatePredictor.cxx
@@ -56,6 +56,9 @@ PreviousStatePredictor::post_solve(LabeledVector /*in*/, LabeledVector out)
 void
 PreviousStatePredictor::advance_step()
 {
-  _state_n = _state.clone();
+  if (!_state_n.axes().empty())
+    _state_n = _state.clone();
+
+  _state = LabeledVector();
 }
 } // namespace neml2

--- a/src/neml2/predictors/PreviousStatePredictor.cxx
+++ b/src/neml2/predictors/PreviousStatePredictor.cxx
@@ -56,7 +56,7 @@ PreviousStatePredictor::post_solve(LabeledVector /*in*/, LabeledVector out)
 void
 PreviousStatePredictor::advance_step()
 {
-  if (!_state_n.axes().empty())
+  if (!_state.axes().empty())
     _state_n = _state.clone();
 
   _state = LabeledVector();

--- a/tests/include/StructuralDriver.h
+++ b/tests/include/StructuralDriver.h
@@ -30,7 +30,7 @@ class StructuralDriver
 {
 public:
   // TODO: Add temperature as an input
-  StructuralDriver(const neml2::Model & model,
+  StructuralDriver(neml2::Model & model,
                    torch::Tensor time,
                    torch::Tensor driving_force,
                    std::string driving_force_name);
@@ -44,7 +44,7 @@ protected:
                                           std::vector<neml2::LabeledVector> & all_inputs,
                                           std::vector<neml2::LabeledVector> & all_outputs) const;
 
-  const neml2::Model & _model;
+  neml2::Model & _model;
   torch::Tensor _time;
   torch::Tensor _driving_force;
   std::string _driving_force_name;

--- a/tests/include/VerificationTest.h
+++ b/tests/include/VerificationTest.h
@@ -32,7 +32,7 @@ public:
   VerificationTest(std::string fname);
 
   /// Evaluate the comparison between the two models
-  bool compare(const neml2::Model & model) const;
+  bool compare(neml2::Model & model) const;
 
   /// Driving time data
   torch::Tensor time() const { return _time; };

--- a/tests/src/StructuralDriver.cxx
+++ b/tests/src/StructuralDriver.cxx
@@ -26,7 +26,7 @@
 
 using namespace neml2;
 
-StructuralDriver::StructuralDriver(const neml2::Model & model,
+StructuralDriver::StructuralDriver(neml2::Model & model,
                                    torch::Tensor time,
                                    torch::Tensor driving_force,
                                    std::string driving_force_name)
@@ -117,6 +117,8 @@ StructuralDriver::run()
     // current --> old
     LabeledVector(in.slice("old_state")).fill(out.slice("state"));
     LabeledVector(in.slice("old_forces")).fill(in.slice("forces"));
+
+    _model.advance_step();
   }
 
   return {all_inputs, all_outputs};

--- a/tests/src/StructuralDriver.cxx
+++ b/tests/src/StructuralDriver.cxx
@@ -105,6 +105,7 @@ StructuralDriver::run()
   for (TorchSize i = 1; i < _nsteps; i++)
   {
     // Advance the step
+    _model.advance_step();
     current_time = Scalar(_time.index({i}));
     current_driving_force = SymR2(_driving_force.index({i}));
     in.slice("forces").set(current_driving_force, _driving_force_name);
@@ -117,8 +118,6 @@ StructuralDriver::run()
     // current --> old
     LabeledVector(in.slice("old_state")).fill(out.slice("state"));
     LabeledVector(in.slice("old_forces")).fill(in.slice("forces"));
-
-    _model.advance_step();
   }
 
   return {all_inputs, all_outputs};

--- a/tests/src/VerificationTest.cxx
+++ b/tests/src/VerificationTest.cxx
@@ -42,7 +42,7 @@ VerificationTest::VerificationTest(std::string fname)
 }
 
 bool
-VerificationTest::compare(const neml2::Model & model) const
+VerificationTest::compare(neml2::Model & model) const
 {
   // Temperature needs to be added
   auto driver = StructuralDriver(

--- a/tests/unit/models/test_ImplicitUpdate.cxx
+++ b/tests/unit/models/test_ImplicitUpdate.cxx
@@ -139,6 +139,6 @@ TEST_CASE("ImplicitUpdate", "[ImplicitUpdate]")
     finite_differencing_derivative(
         [model](const LabeledVector & x) { return model.value(x); }, in, numerical);
 
-    REQUIRE(torch::allclose(exact.tensor(), numerical.tensor(), /*rtol=*/0, /*atol=*/1e-5));
+    REQUIRE(torch::allclose(exact.tensor(), numerical.tensor()));
   }
 }


### PR DESCRIPTION
Currently, I let the predictor shift the states back in time after every solve. This is fine as long as every "time step" has exactly one "constitutive update".

However, in the context of finite element method and optimization there might be an outer loop, and it is preferrable to let the driver program to tell NEML2 models when to advance the time step.