### PR TITLE
Include what you use

### DIFF
--- a/include/neml2/base/NEML2Object.h
+++ b/include/neml2/base/NEML2Object.h
@@ -23,7 +23,6 @@
 // THE SOFTWARE.
 #pragma once
 
-#include <torch/torch.h>
 #include "neml2/base/OptionSet.h"
 
 namespace neml2

--- a/include/neml2/base/config.h.in
+++ b/include/neml2/base/config.h.in
@@ -22,9 +22,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <cstddef>
-#include <torch/torch.h>
-
 // clang-format off
 #cmakedefine NEML2_DTYPE torch::k@NEML2_DTYPE@
 

--- a/include/neml2/drivers/TransientDriver.h
+++ b/include/neml2/drivers/TransientDriver.h
@@ -25,9 +25,11 @@
 #pragma once
 
 #include "neml2/drivers/Driver.h"
-#include <filesystem>
-
 #include "neml2/tensors/tensors.h"
+
+#include <filesystem>
+#include <torch/nn/modules/container/moduledict.h>
+#include <torch/serialize.h>
 
 namespace neml2
 {

--- a/include/neml2/misc/math.h
+++ b/include/neml2/misc/math.h
@@ -235,6 +235,9 @@ namespace linalg
 /// Vector norm of a vector. Falls back to math::abs is \p v is a Scalar.
 BatchTensor vector_norm(const BatchTensor & v);
 
+/// Inverse of a square matrix
+BatchTensor inv(const BatchTensor & m);
+
 /// Solve the linear system A X = B
 BatchTensor solve(const BatchTensor & A, const BatchTensor & B);
 

--- a/include/neml2/misc/types.h
+++ b/include/neml2/misc/types.h
@@ -26,6 +26,8 @@
 
 #include "neml2/base/config.h"
 
+#include <torch/types.h>
+
 namespace neml2
 {
 typedef double Real;

--- a/include/neml2/models/crystallography/crystallography.h
+++ b/include/neml2/models/crystallography/crystallography.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include <torch/torch.h>
 #include "neml2/tensors/R2.h"
 
 namespace neml2

--- a/include/neml2/tensors/Transformable.h
+++ b/include/neml2/tensors/Transformable.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include <torch/torch.h>
 #include "neml2/misc/types.h"
 
 namespace neml2

--- a/src/neml2/misc/math.cxx
+++ b/src/neml2/misc/math.cxx
@@ -26,6 +26,9 @@
 #include "neml2/misc/error.h"
 #include "neml2/tensors/tensors.h"
 
+#include <torch/autograd.h>
+#include <torch/linalg.h>
+
 namespace neml2
 {
 namespace math
@@ -325,6 +328,12 @@ vector_norm(const BatchTensor & v)
   return BatchTensor(torch::linalg::vector_norm(
                          v, /*order=*/2, /*dim=*/-1, /*keepdim=*/false, /*dtype=*/c10::nullopt),
                      v.batch_dim());
+}
+
+BatchTensor
+inv(const BatchTensor & m)
+{
+  return BatchTensor(torch::linalg::inv(m), m.batch_dim());
 }
 
 BatchTensor

--- a/src/neml2/models/Model.cxx
+++ b/src/neml2/models/Model.cxx
@@ -23,6 +23,7 @@
 // THE SOFTWARE.
 
 #include "neml2/models/Model.h"
+#include <torch/autograd.h>
 
 namespace neml2
 {

--- a/src/neml2/solvers/NewtonWithTrustRegion.cxx
+++ b/src/neml2/solvers/NewtonWithTrustRegion.cxx
@@ -23,8 +23,9 @@
 // THE SOFTWARE.
 
 #include "neml2/solvers/NewtonWithTrustRegion.h"
-#include <iomanip>
 #include "neml2/misc/math.h"
+
+#include <iomanip>
 
 namespace neml2
 {
@@ -174,8 +175,7 @@ NewtonWithTrustRegion::solve_direction(const NonlinearSystem & system)
 
   // Now select between the two... Basically take the full Newton step whenever possible
   auto newton_inside_trust_region =
-      (torch::linalg::vector_norm(p_newton, 2, -1, false, c10::nullopt) <= math::sqrt(2.0 * _delta))
-          .unsqueeze(-1);
+      (math::linalg::vector_norm(p_newton) <= math::sqrt(2.0 * _delta)).unsqueeze(-1);
 
   // Do some printing if verbose
   if (verbose)

--- a/src/neml2/tensors/LabeledMatrix.cxx
+++ b/src/neml2/tensors/LabeledMatrix.cxx
@@ -24,6 +24,7 @@
 
 #include "neml2/tensors/LabeledMatrix.h"
 #include "neml2/tensors/LabeledVector.h"
+#include "neml2/misc/math.h"
 
 using namespace torch::indexing;
 
@@ -77,7 +78,6 @@ LabeledMatrix::inverse() const
   neml_assert_dbg(axis(0).storage_size() == axis(1).storage_size(),
                   "Can only invert square derivatives");
 
-  return LabeledMatrix(BatchTensor(torch::linalg::inv(tensor()), batch_dim()),
-                       {&axis(1), &axis(0)});
+  return LabeledMatrix(math::linalg::inv(tensor()), {&axis(1), &axis(0)});
 }
 } // namespace neml2

--- a/src/neml2/tensors/SSR4.cxx
+++ b/src/neml2/tensors/SSR4.cxx
@@ -123,7 +123,7 @@ SSR4::operator()(TorchSize i, TorchSize j, TorchSize k, TorchSize l) const
 SSR4
 SSR4::inverse() const
 {
-  return SSR4(torch::linalg::inv(*this), batch_dim());
+  return math::linalg::inv(*this);
 }
 
 SSR4

--- a/tests/include/TransientRegression.h
+++ b/tests/include/TransientRegression.h
@@ -27,6 +27,8 @@
 #include "neml2/drivers/Driver.h"
 #include <filesystem>
 
+#include <torch/jit.h>
+
 namespace neml2
 {
 class TransientDriver;

--- a/tests/src/ModelUnitTest.cxx
+++ b/tests/src/ModelUnitTest.cxx
@@ -26,6 +26,8 @@
 #include "utils.h"
 #include "neml2/misc/math.h"
 
+#include <torch/cuda.h>
+
 namespace neml2
 {
 register_NEML2_object(ModelUnitTest);


### PR DESCRIPTION
The one-stop shop <torch/torch.h> is convenient but significantly slows down compilation. However, including exactly only what we need from torch is too much effort and too unstable (when torch internal API changes).

A better middle ground is to include torch headers on-demand by "modules". The "modules" are listed in <torch/all.h>.

This patch should speed up compilation by quite a lot.

ref #156