### PR TITLE
Block merging on missing syntax documentation

### DIFF
--- a/scripts/syntax_to_md.py
+++ b/scripts/syntax_to_md.py
@@ -148,4 +148,7 @@ if __name__ == "__main__":
         if missing == 0:
             log.write("No syntax error, good job! :purple_heart:")
         else:
+            print("*" * 79, file=sys.stderr)
+            print("Syntax errors have been written to", logfile, file=sys.stderr)
+            print("*" * 79, file=sys.stderr)
             exit(1)

--- a/scripts/syntax_to_md.py
+++ b/scripts/syntax_to_md.py
@@ -147,3 +147,5 @@ if __name__ == "__main__":
 
         if missing == 0:
             log.write("No syntax error, good job! :purple_heart:")
+        else:
+            exit(1)

--- a/src/neml2/drivers/solid_mechanics/SolidMechanicsDriver.cxx
+++ b/src/neml2/drivers/solid_mechanics/SolidMechanicsDriver.cxx
@@ -49,6 +49,7 @@ SolidMechanicsDriver::expected_options()
   options.set("temperature").doc() = "Name of temperature";
 
   options.set<VariableName>("fixed_values") = VariableName("forces", "fixed_values");
+  options.set("fixed_values").doc() = "Name of fixed values (when control = MIXED)";
 
   options.set<CrossRef<torch::Tensor>>("prescribed_strains");
   options.set("prescribed_strains").doc() = "Prescribed strain (when control = STRAIN)";


### PR DESCRIPTION
Let syntax_to_md.py return a nonzero exit code when errors are detected.