### PR TITLE
EnumSelection and global settings

### DIFF
--- a/doc/config/DoxygenLayout.xml
+++ b/doc/config/DoxygenLayout.xml
@@ -5,6 +5,7 @@
     <tab type="user" url="@ref install" title="Installation Guide"/>
     <tab type="user" url="@ref getting-started" title="Getting Started"/>
     <tab type="usergroup" title="Syntax Documentation">
+      <tab type="user" url="@ref syntax-settings" title="[Settings]"/>
       <tab type="user" url="@ref syntax-tensors" title="[Tensors]"/>
       <tab type="user" url="@ref syntax-models" title="[Models]"/>
       <tab type="user" url="@ref syntax-solvers" title="[Solvers]"/>
@@ -12,6 +13,7 @@
       <tab type="user" url="@ref syntax-drivers" title="[Drivers]"/>
     </tab>
     <tab type="usergroup" title="System Documentation">
+      <tab type="user" url="@ref system-settings" title="Settings"/>
       <tab type="user" url="@ref system-tensors" title="Tensor"/>
       <tab type="user" url="@ref system-models" title="Model"/>
       <tab type="user" url="@ref system-solvers" title="Solver"/>

--- a/doc/config/DoxygenLayoutPython.xml
+++ b/doc/config/DoxygenLayoutPython.xml
@@ -5,6 +5,7 @@
     <tab type="user" url="../install.html" title="Installation Guide"/>
     <tab type="user" url="../getting-started.html" title="Getting Started"/>
     <tab type="usergroup" title="Syntax Documentation">
+      <tab type="user" url="../syntax-settings.html" title="[Settings]"/>
       <tab type="user" url="../syntax-tensors.html" title="[Tensors]"/>
       <tab type="user" url="../syntax-models.html" title="[Models]"/>
       <tab type="user" url="../syntax-solvers.html" title="[Solvers]"/>
@@ -12,6 +13,7 @@
       <tab type="user" url="../syntax-drivers.html" title="[Drivers]"/>
     </tab>
     <tab type="usergroup" title="System Documentation">
+      <tab type="user" url="../system-settings.html" title="Settings"/>
       <tab type="user" url="../system-tensors.html" title="Tensor"/>
       <tab type="user" url="../system-models.html" title="Model"/>
       <tab type="user" url="../system-solvers.html" title="Solver"/>

--- a/doc/content/install.md
+++ b/doc/content/install.md
@@ -116,8 +116,6 @@ Commonly used configuration options are summarized below. Default options are <u
 | CMAKE_BUILD_TYPE         | <u>Debug</u>, Release, MinSizeRel, RelWithDebInfo, Coverage | CMake [Reference](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)     |
 | CMAKE_INSTALL_PREFIX     |                                                             | CMake [Reference](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html) |
 | CMAKE_UNITY_BUILD        |                                                             | CMake [Reference](https://cmake.org/cmake/help/latest/variable/CMAKE_UNITY_BUILD.html)    |
-| NEML2_DTYPE              | Float16, Float32, <u>Float64</u>                            | Default floating point integral type used in the material models                          |
-| NEML2_INT_DTYPE          | Int8, Int16, Int32, <u>Int64</u>                            | Default fixed point integral type used in the material models                             |
 | NEML2_TESTS              | <u>ON</u>, OFF                                              | Master knob for including/excluding all tests                                             |
 | NEML2_UNIT               | <u>ON</u>, OFF                                              | Create the unit testing target                                                            |
 | NEML2_REGRESSION         | <u>ON</u>, OFF                                              | Create the regression testing target                                                      |

--- a/doc/content/system/settings.md
+++ b/doc/content/system/settings.md
@@ -1,0 +1,5 @@
+# Settings {#system-settings}
+
+Refer to [Syntax Documentation](@ref syntax-settings) for the list of available options.
+
+The settings section allows users to specify global settings such as default tensor options, default device on which to evaluate the material model, verbosity, etc.

--- a/doc/syntax.cxx
+++ b/doc/syntax.cxx
@@ -23,6 +23,7 @@
 // THE SOFTWARE.
 
 #include "neml2/base/Registry.h"
+#include "neml2/base/Settings.h"
 #include <fstream>
 
 int
@@ -31,11 +32,15 @@ main()
   std::ofstream syntax_file;
   syntax_file.open("syntax.yml");
 
+  auto settings = neml2::Settings::expected_options();
+  syntax_file << "neml2::Settings:\n";
+  syntax_file << settings << '\n';
+
   for (auto && [type, options] : neml2::Registry::expected_options())
   {
     options.set<std::string>("type") = type;
     syntax_file << neml2::Registry::syntax_type(type) << ":\n";
-    syntax_file << options << "\n";
+    syntax_file << options << '\n';
   }
 
   syntax_file.close();

--- a/include/neml2/base/EnumSelection.h
+++ b/include/neml2/base/EnumSelection.h
@@ -1,0 +1,103 @@
+// Copyright 2023, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "neml2/misc/error.h"
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <set>
+
+namespace neml2
+{
+// Forward decl
+class EnumSelection;
+std::ostream & operator<<(std::ostream &, const EnumSelection &);
+std::stringstream & operator>>(std::stringstream &, EnumSelection &);
+
+/**
+ * Our poor man's implementation of enum reflection. This is a necessary ingredient for bridging
+ * runtime string parsed from input files and static enum types.
+ *
+ * For developers, this class shall only be used for parsing purposes during the setup phase. Avoid
+ * directly working with this class at model evaluation phase at all cost!
+ */
+class EnumSelection
+{
+public:
+  EnumSelection() = default;
+  EnumSelection(const EnumSelection & other);
+  EnumSelection(const std::vector<std::string> & candidates, const std::string & selection);
+  EnumSelection(const std::vector<std::string> & candidates,
+                const std::vector<int> & values,
+                const std::string & selection);
+
+  /// Assignment operator
+  EnumSelection & operator=(const EnumSelection & other);
+
+  /**
+   * The input stream operator shall be the only entry point to modify the selection other than the
+   * assignment operator
+   */
+  friend std::stringstream & operator>>(std::stringstream & in, EnumSelection &);
+
+  /// Test for (in)equality
+  ///@{
+  bool operator==(const EnumSelection & other) const;
+  bool operator!=(const EnumSelection & other) const;
+  ///@}
+
+  /// Poor man's reflection implementation
+  operator std::string() const { return _selection; }
+
+  /// Implicit conversion to int to let it behave more like a enum
+  operator int() const { return _value; }
+
+  /// Candidates
+  const std::unordered_map<std::string, int> & candidates() const { return _values; }
+
+  /// Stringified candidates
+  std::string candidates_str() const;
+
+  /// Statically cast the enum value to a C++ enum class
+  template <typename T>
+  T as() const
+  {
+    return static_cast<T>(_value);
+  }
+
+private:
+  /// Mapping enum options to int
+  std::unordered_map<std::string, int> _values;
+
+  /// Current selection
+  std::string _selection;
+
+  /// Current selection's integral value
+  int _value;
+};
+
+} // namespace neml2

--- a/include/neml2/base/Factory.h
+++ b/include/neml2/base/Factory.h
@@ -25,6 +25,7 @@
 
 #include "neml2/base/Registry.h"
 #include "neml2/base/NEML2Object.h"
+#include "neml2/base/Settings.h"
 #include "neml2/misc/error.h"
 #include "neml2/base/OptionCollection.h"
 
@@ -38,9 +39,6 @@ namespace neml2
 class Factory
 {
 public:
-  /// The sequence which we use to manufacture objects.
-  static std::vector<std::string> pipeline;
-
   /// Get the global Factory singleton.
   static Factory & get();
 
@@ -122,9 +120,14 @@ private:
   /// The collection of all the options of the objects to be manufactured.
   OptionCollection _all_options;
 
-  // Manufactured objects. The key of the outer map is the section name, and the key of the inner
-  // map is the object name.
+  /**
+   * Manufactured objects. The key of the outer map is the section name, and the key of the inner
+   * map is the object name.
+   */
   std::map<std::string, std::map<std::string, std::vector<std::shared_ptr<NEML2Object>>>> _objects;
+
+  /// Global settings
+  Settings _settings;
 };
 
 template <class T>

--- a/include/neml2/base/OptionCollection.h
+++ b/include/neml2/base/OptionCollection.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "neml2/base/OptionSet.h"
+#include "neml2/base/Settings.h"
 
 namespace neml2
 {
@@ -39,6 +40,12 @@ class OptionCollection
 public:
   OptionCollection() = default;
 
+  /// Get global settings
+  ///@{
+  OptionSet & settings() { return _settings; }
+  const OptionSet & settings() const { return _settings; }
+  ///@}
+
   /// Implicit conversion to an STL map.
   operator std::map<std::string, std::map<std::string, OptionSet>>() const { return _data; }
 
@@ -49,6 +56,10 @@ public:
   const std::map<std::string, std::map<std::string, OptionSet>> & data() const { return _data; }
 
 private:
+  /// Global settings under the [Settings] section
+  OptionSet _settings = Settings::expected_options();
+
+  /// Collection of options for all manufacturable objects
   std::map<std::string, std::map<std::string, OptionSet>> _data;
 };
 

--- a/include/neml2/base/Settings.h
+++ b/include/neml2/base/Settings.h
@@ -21,56 +21,20 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
 #pragma once
 
-#include <filesystem>
-
-#include "neml2/base/OptionCollection.h"
+#include "neml2/base/OptionSet.h"
 
 namespace neml2
 {
-enum ParserType
-{
-  HIT,
-  XML,
-  YAML,
-  AUTO
-};
-
-/**
- * @brief A convenient function to parse all options from an input file
- *
- * @param path Path to the input file to be parsed
- * @param additional_input Additional cliargs to pass to the parser
- * @param ptype Input file format
- */
-void load_model(const std::string & path,
-                const std::string & additional_input = "",
-                ParserType ptype = ParserType::AUTO);
-
-/**
- * @brief A parser is responsible for parsing an input file into a collection of options which
- * can be used by the Factory to manufacture corresponding objects.
- *
- */
-class Parser
+class Settings
 {
 public:
-  Parser() = default;
+  static OptionSet expected_options();
 
-  /// Known top-level sections in the input file
-  static std::vector<std::string> sections;
+  Settings() = default;
 
-  /**
-   * @brief Deserialize a file.
-   *
-   * @param filename Name/path of the input file.
-   * @param additional_input  Additional content of the input file not included in the input file
-   * itself, e.g., from command line.
-   * @return OptionCollection The extracted object options.
-   */
-  virtual OptionCollection parse(const std::filesystem::path & filename,
-                                 const std::string & additional_input = "") const = 0;
+  Settings(const OptionSet & options);
 };
-
 } // namespace neml2

--- a/include/neml2/base/config.h.in
+++ b/include/neml2/base/config.h.in
@@ -24,13 +24,3 @@
 
 #include <cstddef>
 #include <torch/torch.h>
-
-/**
- * TODO: make the following constants configurable
- */
-/// The machine precision
-#define NEML2_EPS 1E-15
-/// The tolerance used in various algorithms
-#define NEML2_TOL 1E-6
-/// A tighter tolerance used in various algorithms
-#define NEML2_TOL2 1E-12

--- a/include/neml2/base/config.h.in
+++ b/include/neml2/base/config.h.in
@@ -25,12 +25,6 @@
 #include <cstddef>
 #include <torch/torch.h>
 
-// clang-format off
-#cmakedefine NEML2_DTYPE torch::k@NEML2_DTYPE@
-
-#cmakedefine NEML2_INT_DTYPE torch::k@NEML2_INT_DTYPE@
-// clang-format on
-
 /**
  * TODO: make the following constants configurable
  */
@@ -39,4 +33,4 @@
 /// The tolerance used in various algorithms
 #define NEML2_TOL 1E-6
 /// A tighter tolerance used in various algorithms
-#define NEML2_TOL2 1e-12
+#define NEML2_TOL2 1E-12

--- a/include/neml2/misc/parser_utils.h
+++ b/include/neml2/misc/parser_utils.h
@@ -28,6 +28,7 @@
 #include "neml2/misc/error.h"
 #include "neml2/tensors/Variable.h"
 #include "neml2/base/CrossRef.h"
+#include "neml2/base/EnumSelection.h"
 
 namespace neml2
 {
@@ -61,46 +62,72 @@ bool start_with(std::string_view str, std::string_view prefix);
 bool end_with(std::string_view str, std::string_view suffix);
 
 template <typename T>
-T
-parse(const std::string & raw_str)
+void
+parse_(T & val, const std::string & raw_str)
 {
-  T val;
   std::stringstream ss(trim(raw_str));
   ss >> val;
   if (ss.fail() || !ss.eof())
     throw ParserException("Failed to parse '" + raw_str + "' as a " + demangle(typeid(T).name()));
+}
+
+template <typename T>
+T
+parse(const std::string & raw_str)
+{
+  T val;
+  parse_(val, raw_str);
   return val;
+}
+
+template <typename T>
+void
+parse_vector_(std::vector<T> & vals, const std::string & raw_str)
+{
+  auto tokens = split(raw_str, " \t\n\v\f\r");
+  vals.resize(tokens.size());
+  for (size_t i = 0; i < tokens.size(); i++)
+    parse_<T>(vals[i], tokens[i]);
 }
 
 template <typename T>
 std::vector<T>
 parse_vector(const std::string & raw_str)
 {
-  auto tokens = split(raw_str, " \t\n\v\f\r");
-  std::vector<T> ret(tokens.size());
-  for (size_t i = 0; i < tokens.size(); i++)
-    ret[i] = parse<T>(tokens[i]);
-  return ret;
+  std::vector<T> vals;
+  parse_vector_(vals, raw_str);
+  return vals;
+}
+
+template <typename T>
+void
+parse_vector_vector_(std::vector<std::vector<T>> & vals, const std::string & raw_str)
+{
+  auto token_vecs = split(raw_str, ";");
+  vals.resize(token_vecs.size());
+  for (size_t i = 0; i < token_vecs.size(); i++)
+    parse_vector_<T>(vals[i], token_vecs[i]);
 }
 
 template <typename T>
 std::vector<std::vector<T>>
 parse_vector_vector(const std::string & raw_str)
 {
-  auto token_vecs = split(raw_str, ";");
-  std::vector<std::vector<T>> ret(token_vecs.size());
-  for (size_t i = 0; i < token_vecs.size(); i++)
-    ret[i] = parse_vector<T>(token_vecs[i]);
-  return ret;
+  std::vector<std::vector<T>> vals;
+  parse_vector_vector_(vals, raw_str);
+  return vals;
 }
 
 // @{ template specializations for parse
 template <>
-bool parse<bool>(const std::string & raw_str);
+void parse_<bool>(bool &, const std::string & raw_str);
+/// This special one is for the evil std::vector<bool>!
 template <>
-TorchShape parse<TorchShape>(const std::string & raw_str);
+void parse_vector_<bool>(std::vector<bool> &, const std::string & raw_str);
 template <>
-VariableName parse<VariableName>(const std::string & raw_str);
+void parse_<TorchShape>(TorchShape &, const std::string & raw_str);
+template <>
+void parse_<VariableName>(VariableName &, const std::string & raw_str);
 // @}
 } // namespace utils
 } // namespace neml2

--- a/include/neml2/misc/types.h
+++ b/include/neml2/misc/types.h
@@ -49,11 +49,11 @@ typedef std::vector<at::indexing::TensorIndex> TorchSlice;
 /// Default floating point tensor options
 torch::TensorOptions & default_tensor_options();
 /// Default integral tensor options
-torch::TensorOptions & default_int_tensor_options();
+torch::TensorOptions & default_integer_tensor_options();
 /// Default floating point type
 torch::Dtype & default_dtype();
 /// Default integral type
-torch::Dtype & default_int_dtype();
+torch::Dtype & default_integer_dtype();
 /// Default device
 torch::Device & default_device();
 ///@}

--- a/include/neml2/misc/types.h
+++ b/include/neml2/misc/types.h
@@ -38,15 +38,23 @@ typedef std::vector<at::indexing::TensorIndex> TorchSlice;
 
 /**
  * The factory methods like `torch::arange`, `torch::ones`, `torch::zeros`, `torch::rand` etc.
- * accept a common argument to configure the properties of the tensor being created. We predefine a
- * default tensor configuration in NEML2. This default configuration is consistently used throughout
- * NEML2. This default can be configured by CMake.
+ * accept a common argument to configure the properties of the tensor being created. We predefine
+ * a default tensor configuration in NEML2. This default configuration is consistently used
+ * throughout NEML2.
  *
  * See https://pytorch.org/cppdocs/notes/tensor_creation.html#configuring-properties-of-the-tensor
  * for more details.
  */
-const torch::TensorOptions default_tensor_options();
-
-/// We similarly want to have a default integer scalar type for some types of tensors
-const torch::TensorOptions default_integer_tensor_options();
+///@{
+/// Default floating point tensor options
+torch::TensorOptions & default_tensor_options();
+/// Default integral tensor options
+torch::TensorOptions & default_int_tensor_options();
+/// Default floating point type
+torch::Dtype & default_dtype();
+/// Default integral type
+torch::Dtype & default_int_dtype();
+/// Default device
+torch::Device & default_device();
+///@}
 } // namespace neml2

--- a/include/neml2/misc/types.h
+++ b/include/neml2/misc/types.h
@@ -57,4 +57,17 @@ torch::Dtype & default_integer_dtype();
 /// Default device
 torch::Device & default_device();
 ///@}
+
+/// Machine precision
+// TODO: make this depend on the current dtype
+Real & machine_precision();
+
+/// The tolerance used in various algorithms
+// TODO: make this depend on the current dtype
+Real & tolerance();
+
+/// A tighter tolerance used in various algorithms
+// TODO: make this depend on the current dtype
+Real & tighter_tolerance();
+
 } // namespace neml2

--- a/include/neml2/models/Model.h
+++ b/include/neml2/models/Model.h
@@ -91,8 +91,8 @@ public:
    */
   virtual void reinit(TorchShapeRef batch_shape,
                       int deriv_order = 0,
-                      const torch::Device & device = torch::kCPU,
-                      const torch::Dtype & dtype = NEML2_DTYPE);
+                      const torch::Device & device = default_device(),
+                      const torch::Dtype & dtype = default_dtype());
 
   /**
    * @brief Allocate storage and setup views for all the variables of this model and recursively all

--- a/include/neml2/models/crystallography/MillerIndex.h
+++ b/include/neml2/models/crystallography/MillerIndex.h
@@ -43,7 +43,7 @@ public:
   static MillerIndex fill(Integer a,
                           Integer b,
                           Integer c,
-                          const torch::TensorOptions & options = default_int_tensor_options());
+                          const torch::TensorOptions & options = default_integer_tensor_options());
 
   /// Reduce to the greatest common demoninator
   MillerIndex reduce() const;

--- a/include/neml2/models/crystallography/MillerIndex.h
+++ b/include/neml2/models/crystallography/MillerIndex.h
@@ -43,7 +43,7 @@ public:
   static MillerIndex fill(Integer a,
                           Integer b,
                           Integer c,
-                          const torch::TensorOptions & options = default_integer_tensor_options());
+                          const torch::TensorOptions & options = default_int_tensor_options());
 
   /// Reduce to the greatest common demoninator
   MillerIndex reduce() const;

--- a/python/neml2/misc/types.h
+++ b/python/neml2/misc/types.h
@@ -37,8 +37,8 @@ namespace py = pybind11;
   torch::TensorOptions().dtype(dtype).device(device).requires_grad(requires_grad)
 
 #define PY_ARG_TENSOR_OPTIONS                                                                      \
-  py::arg("dtype") = torch::Dtype(NEML2_DTYPE), py::arg("device") = torch::Device(torch::kCPU),    \
-  py::arg("requires_grad") = false
+  py::arg("dtype") = torch::Dtype(torch::kFloat64),                                                \
+  py::arg("device") = torch::Device(torch::kCPU), py::arg("requires_grad") = false
 
 namespace pybind11
 {

--- a/python/neml2/models/Model.cxx
+++ b/python/neml2/models/Model.cxx
@@ -40,8 +40,8 @@ def_Model(py::module_ & m)
                &Model::reinit),
            py::arg("batch_shape"),
            py::arg("deriv_order") = 0,
-           py::arg("device") = torch::Device(torch::kCPU),
-           py::arg("dtype") = torch::Dtype(NEML2_DTYPE))
+           py::arg("device") = torch::Device(default_device()),
+           py::arg("dtype") = torch::Dtype(default_dtype()))
       .def(
           "input_axis",
           [](const Model & self) { return &self.input_axis(); },

--- a/src/neml2/CMakeLists.txt
+++ b/src/neml2/CMakeLists.txt
@@ -5,22 +5,6 @@ file(GLOB_RECURSE SRCS *.cxx)
 add_library(neml2 SHARED ${SRCS})
 set_target_properties(neml2 PROPERTIES INSTALL_RPATH "${EXEC_DIR};${Torch_LINK_DIRECTORIES}")
 
-# Make scalar type configurable:
-if(NOT NEML2_DTYPE)
-  set(NEML2_DTYPE "Float64" CACHE STRING "Default NEML2 scalar type." FORCE)
-  set_property(CACHE NEML2_DTYPE PROPERTY STRINGS "Float16" "Float32" "Float64")
-endif()
-
-message(STATUS "Configuring with default scalar type: ${NEML2_DTYPE}")
-
-# Also want to configure an int type for specialized int tensors
-if(NOT NEML2_INT_DTYPE)
-  set(NEML2_INT_DTYPE "Int64" CACHE STRING "Default NEML2 integer scalar type." FORCE)
-  set_property(CACHE NEML2_INT_DTYPE PROPERTY STRINGS "Int8" "Int16" "Int32" "Int64")
-endif()
-
-message(STATUS "Configuring with default integer scalar type: ${NEML2_INT_DTYPE}")
-
 configure_file(
   ${NEML2_SOURCE_DIR}/include/neml2/base/config.h.in
   ${NEML2_SOURCE_DIR}/include/neml2/base/config.h

--- a/src/neml2/base/EnumSelection.cxx
+++ b/src/neml2/base/EnumSelection.cxx
@@ -1,0 +1,132 @@
+// Copyright 2023, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "neml2/base/EnumSelection.h"
+#include "neml2/misc/parser_utils.h"
+
+namespace neml2
+{
+std::ostream &
+operator<<(std::ostream & os, const EnumSelection & es)
+{
+  os << std::string(es);
+  return os;
+}
+
+std::stringstream &
+operator>>(std::stringstream & ss, EnumSelection & es)
+{
+  ss >> es._selection;
+
+  if (!es._values.count(es._selection))
+    throw ParserException("Invalid selection '" + es._selection +
+                          "', candidates are: " + es.candidates_str());
+
+  // Also update the enum integral value
+  es._value = es._values[es._selection];
+
+  return ss;
+}
+
+EnumSelection::EnumSelection(const EnumSelection & other)
+  : _values(other._values),
+    _selection(other._selection),
+    _value(other._value)
+{
+}
+
+EnumSelection::EnumSelection(const std::vector<std::string> & candidates,
+                             const std::string & selection)
+  : _selection(selection)
+{
+  std::set<std::string> candidates_set(candidates.begin(), candidates.end());
+  neml_assert(candidates_set.size() == candidates.size(),
+              "Candidates of EnumSelection must be unique.");
+
+  int count = 0;
+  for (const auto & candidate : candidates)
+    _values.emplace(candidate, count++);
+
+  neml_assert(_values.count(_selection),
+              "Invalid default selection for EnumSelection. Candidates are ",
+              candidates_str());
+
+  _value = _values[_selection];
+}
+
+EnumSelection::EnumSelection(const std::vector<std::string> & candidates,
+                             const std::vector<int> & values,
+                             const std::string & selection)
+  : _selection(selection)
+{
+  neml_assert(candidates.size() == values.size(),
+              "In EnumSelection, number of candidates must match the number of values.");
+
+  std::set<std::string> candidates_set(candidates.begin(), candidates.end());
+  neml_assert(candidates_set.size() == candidates.size(),
+              "Candidates of EnumSelection must be unique.");
+
+  std::set<int> values_set(values.begin(), values.end());
+  neml_assert(values_set.size() == values.size(), "Values of EnumSelection must be unique.");
+
+  for (size_t i = 0; i < candidates.size(); i++)
+    _values.emplace(candidates[i], values[i]);
+
+  neml_assert(_values.count(_selection),
+              "Invalid default selection for EnumSelection. Candidates are ",
+              candidates_str());
+
+  _value = _values[_selection];
+}
+
+EnumSelection &
+EnumSelection::operator=(const EnumSelection & other)
+{
+  _values = other._values;
+  _selection = other._selection;
+  _value = other._value;
+  return *this;
+}
+
+bool
+EnumSelection::operator==(const EnumSelection & other) const
+{
+  return _values == other._values && _selection == other._selection && _value == other._value;
+}
+
+bool
+EnumSelection::operator!=(const EnumSelection & other) const
+{
+  return !(*this == other);
+}
+
+std::string
+EnumSelection::candidates_str() const
+{
+  std::stringstream ss;
+  for (const auto & [e, v] : _values)
+    ss << e << " ";
+  return ss.str();
+}
+} // namesace neml2

--- a/src/neml2/base/Factory.cxx
+++ b/src/neml2/base/Factory.cxx
@@ -26,8 +26,6 @@
 
 namespace neml2
 {
-std::vector<std::string> Factory::pipeline = {"Tensors", "Solvers", "Data", "Models", "Drivers"};
-
 Factory &
 Factory::get()
 {
@@ -38,7 +36,12 @@ Factory::get()
 void
 Factory::load(const OptionCollection & all_options)
 {
-  get()._all_options = all_options;
+  auto & factory = get();
+
+  factory._all_options = all_options;
+
+  // Also apply global settings
+  factory._settings = Settings(all_options.settings());
 }
 
 void

--- a/src/neml2/base/Parser.cxx
+++ b/src/neml2/base/Parser.cxx
@@ -28,6 +28,8 @@
 
 namespace neml2
 {
+std::vector<std::string> Parser::sections = {"Tensors", "Solvers", "Data", "Models", "Drivers"};
+
 void
 load_model(const std::string & path, const std::string & additional_input, ParserType ptype)
 {

--- a/src/neml2/base/Settings.cxx
+++ b/src/neml2/base/Settings.cxx
@@ -62,14 +62,14 @@ Settings::expected_options()
       "device='cpu' sets the target compute device to be CPU, and device='cuda:1' sets the target "
       "compute device to be CUDA with device ID 1.";
 
-  options.set<Real>("machine_precision") = machine_precision();
+  options.set<Real>("machine_precision") = 1E-15;
   options.set("machine_precision").doc() =
       "Machine precision used at various places to workaround singularities like division-by-zero.";
 
-  options.set<Real>("tolerance") = tolerance();
+  options.set<Real>("tolerance") = 1e-6;
   options.set("tolerance").doc() = "Tolerance used in various algorithms.";
 
-  options.set<Real>("tighter_tolerance") = tighter_tolerance();
+  options.set<Real>("tighter_tolerance") = 1E-12;
   options.set("tighter_tolerance").doc() = "A tighter tolerance used in various algorithms.";
 
   return options;

--- a/src/neml2/base/Settings.cxx
+++ b/src/neml2/base/Settings.cxx
@@ -72,7 +72,7 @@ Settings::Settings(const OptionSet & options)
   torch::set_default_dtype(scalarTypeToTypeMeta(default_dtype()));
 
   // Default integral dtype
-  default_int_dtype() = options.get<EnumSelection>("default_integer_type").as<torch::Dtype>();
+  default_integer_dtype() = options.get<EnumSelection>("default_integer_type").as<torch::Dtype>();
 
   // Default device
   default_device() = torch::Device(options.get<std::string>("default_device"));

--- a/src/neml2/base/Settings.cxx
+++ b/src/neml2/base/Settings.cxx
@@ -62,6 +62,16 @@ Settings::expected_options()
       "device='cpu' sets the target compute device to be CPU, and device='cuda:1' sets the target "
       "compute device to be CUDA with device ID 1.";
 
+  options.set<Real>("machine_precision") = machine_precision();
+  options.set("machine_precision").doc() =
+      "Machine precision used at various places to workaround singularities like division-by-zero.";
+
+  options.set<Real>("tolerance") = tolerance();
+  options.set("tolerance").doc() = "Tolerance used in various algorithms.";
+
+  options.set<Real>("tighter_tolerance") = tighter_tolerance();
+  options.set("tighter_tolerance").doc() = "A tighter tolerance used in various algorithms.";
+
   return options;
 }
 
@@ -76,5 +86,12 @@ Settings::Settings(const OptionSet & options)
 
   // Default device
   default_device() = torch::Device(options.get<std::string>("default_device"));
+
+  // Machine precision
+  machine_precision() = options.get<Real>("machine_precision");
+
+  // Tolerances
+  tolerance() = options.get<Real>("tolerance");
+  tighter_tolerance() = options.get<Real>("tighter_tolerance");
 }
 } // namespace neml2

--- a/src/neml2/base/Settings.cxx
+++ b/src/neml2/base/Settings.cxx
@@ -31,23 +31,36 @@ Settings::expected_options()
 {
   OptionSet options;
   options.section() = "Settings";
+  options.doc() = "Global settings for tensors, models, etc.";
 
-  options.set<EnumSelection>("default_floating_point_type") =
-      EnumSelection({"Float16", "Float32", "Float64"},
-                    {static_cast<int>(torch::kFloat16),
-                     static_cast<int>(torch::kFloat32),
-                     static_cast<int>(torch::kFloat64)},
-                    "Float64");
+  options.set<std::string>("type") = "Settings";
 
-  options.set<EnumSelection>("default_integer_type") =
-      EnumSelection({"Int8", "Int16", "Int32", "Int64"},
-                    {static_cast<int>(torch::kInt8),
-                     static_cast<int>(torch::kInt16),
-                     static_cast<int>(torch::kInt32),
-                     static_cast<int>(torch::kInt64)},
-                    "Int64");
+  EnumSelection dtype_selection({"Float16", "Float32", "Float64"},
+                                {static_cast<int>(torch::kFloat16),
+                                 static_cast<int>(torch::kFloat32),
+                                 static_cast<int>(torch::kFloat64)},
+                                "Float64");
+  options.set<EnumSelection>("default_floating_point_type") = dtype_selection;
+  options.set("default_floating_point_type").doc() =
+      "Default floating point type for tensors. Options are " + dtype_selection.candidates_str();
+
+  EnumSelection int_dtype_selection({"Int8", "Int16", "Int32", "Int64"},
+                                    {static_cast<int>(torch::kInt8),
+                                     static_cast<int>(torch::kInt16),
+                                     static_cast<int>(torch::kInt32),
+                                     static_cast<int>(torch::kInt64)},
+                                    "Int64");
+  options.set<EnumSelection>("default_integer_type") = int_dtype_selection;
+  options.set("default_integer_type").doc() =
+      "Default integer type for tensors. Options are " + int_dtype_selection.candidates_str();
 
   options.set<std::string>("default_device") = "cpu";
+  options.set("default_device").doc() =
+      "Default device on which tensors are created and models are evaluated. The string supplied "
+      "must follow the following schema: (cpu|cuda)[:<device-index>] where cpu or cuda specifies "
+      "the device type, and :<device-index> optionally specifies a device index. For example, "
+      "device='cpu' sets the target compute device to be CPU, and device='cuda:1' sets the target "
+      "compute device to be CUDA with device ID 1.";
 
   return options;
 }

--- a/src/neml2/misc/math.cxx
+++ b/src/neml2/misc/math.cxx
@@ -32,18 +32,19 @@ namespace math
 {
 ConstantTensors::ConstantTensors()
 {
-  _full_to_mandel_map = torch::tensor({0, 4, 8, 5, 2, 1}, default_int_tensor_options());
+  _full_to_mandel_map = torch::tensor({0, 4, 8, 5, 2, 1}, default_integer_tensor_options());
 
-  _mandel_to_full_map = torch::tensor({0, 5, 4, 5, 1, 3, 4, 3, 2}, default_int_tensor_options());
+  _mandel_to_full_map =
+      torch::tensor({0, 5, 4, 5, 1, 3, 4, 3, 2}, default_integer_tensor_options());
 
   _full_to_mandel_factor = torch::tensor({1.0, 1.0, 1.0, sqrt2, sqrt2, sqrt2});
 
   _mandel_to_full_factor =
       torch::tensor({1.0, invsqrt2, invsqrt2, invsqrt2, 1.0, invsqrt2, invsqrt2, invsqrt2, 1.0});
 
-  _full_to_skew_map = torch::tensor({7, 2, 3}, default_int_tensor_options());
+  _full_to_skew_map = torch::tensor({7, 2, 3}, default_integer_tensor_options());
 
-  _skew_to_full_map = torch::tensor({0, 2, 1, 2, 0, 0, 1, 0, 0}, default_int_tensor_options());
+  _skew_to_full_map = torch::tensor({0, 2, 1, 2, 0, 0, 1, 0, 0}, default_integer_tensor_options());
 
   _full_to_skew_factor = torch::tensor({1.0, 1.0, 1.0});
 
@@ -163,7 +164,7 @@ full_to_mandel(const BatchTensor & full, TorchSize dim)
 {
   return full_to_reduced(
       full,
-      ConstantTensors::full_to_mandel_map().to(full.options().dtype(default_int_dtype())),
+      ConstantTensors::full_to_mandel_map().to(full.options().dtype(default_integer_dtype())),
       ConstantTensors::full_to_mandel_factor().to(full.options()),
       dim);
 }
@@ -173,7 +174,7 @@ mandel_to_full(const BatchTensor & mandel, TorchSize dim)
 {
   return reduced_to_full(
       mandel,
-      ConstantTensors::mandel_to_full_map().to(mandel.options().dtype(default_int_dtype())),
+      ConstantTensors::mandel_to_full_map().to(mandel.options().dtype(default_integer_dtype())),
       ConstantTensors::mandel_to_full_factor().to(mandel.options()),
       dim);
 }
@@ -183,7 +184,7 @@ full_to_skew(const BatchTensor & full, TorchSize dim)
 {
   return full_to_reduced(
       full,
-      ConstantTensors::full_to_skew_map().to(full.options().dtype(default_int_dtype())),
+      ConstantTensors::full_to_skew_map().to(full.options().dtype(default_integer_dtype())),
       ConstantTensors::full_to_skew_factor().to(full.options()),
       dim);
 }
@@ -193,7 +194,7 @@ skew_to_full(const BatchTensor & skew, TorchSize dim)
 {
   return reduced_to_full(
       skew,
-      ConstantTensors::skew_to_full_map().to(skew.options().dtype(default_int_dtype())),
+      ConstantTensors::skew_to_full_map().to(skew.options().dtype(default_integer_dtype())),
       ConstantTensors::skew_to_full_factor().to(skew.options()),
       dim);
 }

--- a/src/neml2/misc/math.cxx
+++ b/src/neml2/misc/math.cxx
@@ -32,26 +32,22 @@ namespace math
 {
 ConstantTensors::ConstantTensors()
 {
-  _full_to_mandel_map = torch::tensor({0, 4, 8, 5, 2, 1}, default_integer_tensor_options());
+  _full_to_mandel_map = torch::tensor({0, 4, 8, 5, 2, 1}, default_int_tensor_options());
 
-  _mandel_to_full_map =
-      torch::tensor({0, 5, 4, 5, 1, 3, 4, 3, 2}, default_integer_tensor_options());
+  _mandel_to_full_map = torch::tensor({0, 5, 4, 5, 1, 3, 4, 3, 2}, default_int_tensor_options());
 
-  _full_to_mandel_factor =
-      torch::tensor({1.0, 1.0, 1.0, sqrt2, sqrt2, sqrt2}, default_tensor_options());
+  _full_to_mandel_factor = torch::tensor({1.0, 1.0, 1.0, sqrt2, sqrt2, sqrt2});
 
   _mandel_to_full_factor =
-      torch::tensor({1.0, invsqrt2, invsqrt2, invsqrt2, 1.0, invsqrt2, invsqrt2, invsqrt2, 1.0},
-                    default_tensor_options());
+      torch::tensor({1.0, invsqrt2, invsqrt2, invsqrt2, 1.0, invsqrt2, invsqrt2, invsqrt2, 1.0});
 
-  _full_to_skew_map = torch::tensor({7, 2, 3}, default_integer_tensor_options());
+  _full_to_skew_map = torch::tensor({7, 2, 3}, default_int_tensor_options());
 
-  _skew_to_full_map = torch::tensor({0, 2, 1, 2, 0, 0, 1, 0, 0}, default_integer_tensor_options());
+  _skew_to_full_map = torch::tensor({0, 2, 1, 2, 0, 0, 1, 0, 0}, default_int_tensor_options());
 
-  _full_to_skew_factor = torch::tensor({1.0, 1.0, 1.0}, default_tensor_options());
+  _full_to_skew_factor = torch::tensor({1.0, 1.0, 1.0});
 
-  _skew_to_full_factor =
-      torch::tensor({0.0, -1.0, 1.0, 1.0, 0.0, -1.0, -1.0, 1.0, 0.0}, default_tensor_options());
+  _skew_to_full_factor = torch::tensor({0.0, -1.0, 1.0, 1.0, 0.0, -1.0, -1.0, 1.0, 0.0});
 }
 
 ConstantTensors &
@@ -167,7 +163,7 @@ full_to_mandel(const BatchTensor & full, TorchSize dim)
 {
   return full_to_reduced(
       full,
-      ConstantTensors::full_to_mandel_map().to(full.options().dtype(NEML2_INT_DTYPE)),
+      ConstantTensors::full_to_mandel_map().to(full.options().dtype(default_int_dtype())),
       ConstantTensors::full_to_mandel_factor().to(full.options()),
       dim);
 }
@@ -177,7 +173,7 @@ mandel_to_full(const BatchTensor & mandel, TorchSize dim)
 {
   return reduced_to_full(
       mandel,
-      ConstantTensors::mandel_to_full_map().to(mandel.options().dtype(NEML2_INT_DTYPE)),
+      ConstantTensors::mandel_to_full_map().to(mandel.options().dtype(default_int_dtype())),
       ConstantTensors::mandel_to_full_factor().to(mandel.options()),
       dim);
 }
@@ -187,7 +183,7 @@ full_to_skew(const BatchTensor & full, TorchSize dim)
 {
   return full_to_reduced(
       full,
-      ConstantTensors::full_to_skew_map().to(full.options().dtype(NEML2_INT_DTYPE)),
+      ConstantTensors::full_to_skew_map().to(full.options().dtype(default_int_dtype())),
       ConstantTensors::full_to_skew_factor().to(full.options()),
       dim);
 }
@@ -197,7 +193,7 @@ skew_to_full(const BatchTensor & skew, TorchSize dim)
 {
   return reduced_to_full(
       skew,
-      ConstantTensors::skew_to_full_map().to(skew.options().dtype(NEML2_INT_DTYPE)),
+      ConstantTensors::skew_to_full_map().to(skew.options().dtype(default_int_dtype())),
       ConstantTensors::skew_to_full_factor().to(skew.options()),
       dim);
 }

--- a/src/neml2/misc/types.cxx
+++ b/src/neml2/misc/types.cxx
@@ -26,27 +26,40 @@
 
 namespace neml2
 {
-const torch::TensorOptions
+torch::TensorOptions &
 default_tensor_options()
 {
-  return torch::TensorOptions()
-      .dtype(NEML2_DTYPE)
-      .layout(torch::kStrided)
-      .memory_format(torch::MemoryFormat::Contiguous)
-      .pinned_memory(false)
-      .device(torch::kCPU)
-      .requires_grad(false);
+  static torch::TensorOptions _default_tensor_options =
+      torch::TensorOptions().dtype(default_dtype()).device(default_device());
+  return _default_tensor_options;
 }
 
-const torch::TensorOptions
-default_integer_tensor_options()
+torch::TensorOptions &
+default_int_tensor_options()
 {
-  return torch::TensorOptions()
-      .dtype(NEML2_INT_DTYPE)
-      .layout(torch::kStrided)
-      .memory_format(torch::MemoryFormat::Contiguous)
-      .pinned_memory(false)
-      .device(torch::kCPU)
-      .requires_grad(false);
+  static torch::TensorOptions _default_int_tensor_options =
+      torch::TensorOptions().dtype(default_int_dtype()).device(default_device());
+  return _default_int_tensor_options;
+}
+
+torch::Dtype &
+default_dtype()
+{
+  static torch::Dtype _default_dtype = torch::kFloat64;
+  return _default_dtype;
+}
+
+torch::Dtype &
+default_int_dtype()
+{
+  static torch::Dtype _default_int_dtype = torch::kInt64;
+  return _default_int_dtype;
+}
+
+torch::Device &
+default_device()
+{
+  static torch::Device _default_device = torch::kCPU;
+  return _default_device;
 }
 } // namespace neml2

--- a/src/neml2/misc/types.cxx
+++ b/src/neml2/misc/types.cxx
@@ -35,11 +35,11 @@ default_tensor_options()
 }
 
 torch::TensorOptions &
-default_int_tensor_options()
+default_integer_tensor_options()
 {
-  static torch::TensorOptions _default_int_tensor_options =
-      torch::TensorOptions().dtype(default_int_dtype()).device(default_device());
-  return _default_int_tensor_options;
+  static torch::TensorOptions _default_integer_tensor_options =
+      torch::TensorOptions().dtype(default_integer_dtype()).device(default_device());
+  return _default_integer_tensor_options;
 }
 
 torch::Dtype &
@@ -50,10 +50,10 @@ default_dtype()
 }
 
 torch::Dtype &
-default_int_dtype()
+default_integer_dtype()
 {
-  static torch::Dtype _default_int_dtype = torch::kInt64;
-  return _default_int_dtype;
+  static torch::Dtype _default_integer_dtype = torch::kInt64;
+  return _default_integer_dtype;
 }
 
 torch::Device &

--- a/src/neml2/misc/types.cxx
+++ b/src/neml2/misc/types.cxx
@@ -62,4 +62,25 @@ default_device()
   static torch::Device _default_device = torch::kCPU;
   return _default_device;
 }
+
+Real &
+machine_precision()
+{
+  static Real _machine_precision = 1E-15;
+  return _machine_precision;
+}
+
+Real &
+tolerance()
+{
+  static Real _tolerance = 1E-6;
+  return _tolerance;
+}
+
+Real &
+tighter_tolerance()
+{
+  static Real _tighter_tolerance = 1E-12;
+  return _tighter_tolerance;
+}
 } // namespace neml2

--- a/src/neml2/models/SR2Invariant.cxx
+++ b/src/neml2/models/SR2Invariant.cxx
@@ -91,7 +91,7 @@ SR2Invariant::set_value(bool out, bool dout_din, bool d2out_din2)
   else if (_type == "VONMISES")
   {
     auto S = A.dev();
-    Scalar vm = std::sqrt(3.0 / 2.0) * S.norm(NEML2_EPS);
+    Scalar vm = std::sqrt(3.0 / 2.0) * S.norm(machine_precision());
 
     if (out)
       _invariant = vm;
@@ -110,7 +110,7 @@ SR2Invariant::set_value(bool out, bool dout_din, bool d2out_din2)
   }
   else if (_type == "EFFECTIVE_STRAIN")
   {
-    Scalar r = std::sqrt(2.0 / 3.0) * A.norm(NEML2_EPS);
+    Scalar r = std::sqrt(2.0 / 3.0) * A.norm(machine_precision());
 
     if (out)
       _invariant = r;

--- a/src/neml2/models/crystallography/user_tensors/FillMillerIndex.cxx
+++ b/src/neml2/models/crystallography/user_tensors/FillMillerIndex.cxx
@@ -55,7 +55,7 @@ FillMillerIndex::fill(const std::vector<Integer> & values) const
   if ((values.size() % 3) != 0)
     neml_assert(false, "Number of provided values must be a multiple of three!");
 
-  return MillerIndex(torch::tensor(values, default_int_tensor_options()).reshape({-1, 3}));
+  return MillerIndex(torch::tensor(values, default_integer_tensor_options()).reshape({-1, 3}));
 }
 } // namespace crystallography
 } // namespace neml2

--- a/src/neml2/models/solid_mechanics/ChabochePlasticHardening.cxx
+++ b/src/neml2/models/solid_mechanics/ChabochePlasticHardening.cxx
@@ -82,7 +82,7 @@ ChabochePlasticHardening::set_value(bool out, bool dout_din, bool d2out_din2)
   neml_assert_dbg(!d2out_din2, "Chaboche model doesn't implement second derivatives.");
 
   // The effective stress
-  auto s = SR2(_X).norm(NEML2_EPS);
+  auto s = SR2(_X).norm(machine_precision());
   // The part that's proportional to the plastic strain rate
   auto g_term = 2.0 / 3.0 * _C * _NM - _g * _X;
 

--- a/tests/include/TorchScriptFlowRate.h
+++ b/tests/include/TorchScriptFlowRate.h
@@ -51,8 +51,8 @@ public:
    */
   virtual void reinit(TorchShapeRef batch_shape,
                       int deriv_order = 0,
-                      const torch::Device & device = torch::kCPU,
-                      const torch::Dtype & dtype = NEML2_DTYPE) override;
+                      const torch::Device & device = default_device(),
+                      const torch::Dtype & dtype = default_dtype()) override;
 
 protected:
   virtual void set_value(bool out, bool dout_din, bool d2out_din2) override;

--- a/tests/src/J2FlowDirection.cxx
+++ b/tests/src/J2FlowDirection.cxx
@@ -51,7 +51,7 @@ J2FlowDirection::set_value(bool out, bool dout_din, bool d2out_din2)
   neml_assert_dbg(!d2out_din2, "Second derivatives not implemented");
 
   auto S = SR2(_M).dev();
-  auto vm = std::sqrt(3.0 / 2.0) * S.norm(NEML2_EPS);
+  auto vm = std::sqrt(3.0 / 2.0) * S.norm(machine_precision());
   auto dvm_dM = 3.0 / 2.0 * S / vm;
 
   if (out)

--- a/tests/src/ModelUnitTest.cxx
+++ b/tests/src/ModelUnitTest.cxx
@@ -128,7 +128,7 @@ ModelUnitTest::run()
 
   if (_check_cuda && torch::cuda::is_available())
   {
-    _in = _in.to(default_tensor_options().device(torch::kCUDA));
+    _in = _in.to(torch::kCUDA);
     _model.reinit(_in, _deriv_order);
     check_all();
   }

--- a/tests/unit/base/test_EnumSelection.cxx
+++ b/tests/unit/base/test_EnumSelection.cxx
@@ -1,0 +1,117 @@
+// Copyright 2023, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include "neml2/base/EnumSelection.h"
+
+using namespace neml2;
+
+TEST_CASE("EnumSelection", "[base]")
+{
+  SECTION("Construct from candidate strings")
+  {
+    EnumSelection es1({"a", "b", "c"}, "b");
+    REQUIRE(std::string(es1) == "b");
+    REQUIRE(int(es1) == 1);
+
+    EnumSelection es2({"a", "bb", "cccc"}, "cccc");
+    REQUIRE(std::string(es2) == "cccc");
+    REQUIRE(int(es2) == 2);
+  }
+
+  SECTION("Construct from candidate strings and values")
+  {
+    EnumSelection es1({"a", "b", "c"}, {5, 2, 1}, "b");
+    REQUIRE(std::string(es1) == "b");
+    REQUIRE(int(es1) == 2);
+
+    EnumSelection es2({"a", "bb", "cccc"}, {-1, -2, -5}, "cccc");
+    REQUIRE(std::string(es2) == "cccc");
+    REQUIRE(int(es2) == -5);
+  }
+
+  SECTION("Modify selection")
+  {
+    EnumSelection es({"a", "b", "c"}, {5, 2, 1}, "b");
+    REQUIRE(std::string(es) == "b");
+    REQUIRE(int(es) == 2);
+
+    std::stringstream ss("c");
+    ss >> es;
+    REQUIRE(std::string(es) == "c");
+    REQUIRE(int(es) == 1);
+  }
+
+  SECTION("Test for (in)equality")
+  {
+    EnumSelection es1({"a", "b", "c"}, {5, 2, 1}, "a");
+    EnumSelection es2({"a", "b", "c"}, {5, 2, 1}, "b");
+    EnumSelection es3({"a", "b", "c"}, {5, 2, 1}, "c");
+    EnumSelection es4({"a", "b", "c"}, {5, 2, 3}, "c");
+    EnumSelection es5({"a", "d", "c"}, {5, 2, 1}, "c");
+    EnumSelection es6({"b", "a", "c"}, {2, 5, 1}, "a");
+
+    REQUIRE(es1 != es2);
+    REQUIRE(es1 != es3);
+    REQUIRE(es2 != es3);
+    REQUIRE(es3 != es4);
+    REQUIRE(es3 != es5);
+    REQUIRE(es1 == es6);
+  }
+
+  SECTION("Cast to enum class")
+  {
+    enum class SomeEnum : int
+    {
+      a = 5,
+      b = 2,
+      c = 1
+    };
+
+    EnumSelection es1({"a", "b", "c"}, {5, 2, 1}, "a");
+    auto value = es1.as<SomeEnum>();
+    REQUIRE(value == SomeEnum::a);
+  }
+
+  SECTION("Errors")
+  {
+    REQUIRE_THROWS_WITH(
+        EnumSelection({"a", "a", "b"}, "a"),
+        Catch::Matchers::ContainsSubstring("Candidates of EnumSelection must be unique"));
+    REQUIRE_THROWS_WITH(
+        EnumSelection({"a", "b", "c"}, "d"),
+        Catch::Matchers::ContainsSubstring("Invalid default selection for EnumSelection"));
+    REQUIRE_THROWS_WITH(
+        EnumSelection({"a", "b", "c"}, {1, 2, 3}, "d"),
+        Catch::Matchers::ContainsSubstring("Invalid default selection for EnumSelection"));
+    REQUIRE_THROWS_WITH(
+        EnumSelection({"a", "b", "c"}, {2, 2}, "a"),
+        Catch::Matchers::ContainsSubstring("number of candidates must match the number of values"));
+    REQUIRE_THROWS_WITH(
+        EnumSelection({"a", "b", "c"}, {2, 2, 3}, "a"),
+        Catch::Matchers::ContainsSubstring("Values of EnumSelection must be unique"));
+  }
+}

--- a/tests/unit/base/test_HITParser.cxx
+++ b/tests/unit/base/test_HITParser.cxx
@@ -56,6 +56,9 @@ TEST_CASE("HITParser", "[base]")
         REQUIRE(settings.get<EnumSelection>("default_integer_type").as<torch::Dtype>() ==
                 torch::kInt32);
         REQUIRE(settings.get<std::string>("default_device") == "cuda:1");
+        REQUIRE(settings.get<Real>("machine_precision") == Catch::Approx(0.5));
+        REQUIRE(settings.get<Real>("tolerance") == Catch::Approx(0.1));
+        REQUIRE(settings.get<Real>("tighter_tolerance") == Catch::Approx(0.01));
       }
 
       SECTION("default values")

--- a/tests/unit/base/test_HITParser.cxx
+++ b/tests/unit/base/test_HITParser.cxx
@@ -48,6 +48,16 @@ TEST_CASE("HITParser", "[base]")
         REQUIRE(options.doc() == "This model tests the correctness of parsed options.");
       }
 
+      SECTION("global settings")
+      {
+        auto & settings = all_options.settings();
+        REQUIRE(settings.get<EnumSelection>("default_floating_point_type").as<torch::Dtype>() ==
+                torch::kFloat16);
+        REQUIRE(settings.get<EnumSelection>("default_integer_type").as<torch::Dtype>() ==
+                torch::kInt32);
+        REQUIRE(settings.get<std::string>("default_device") == "cuda:1");
+      }
+
       SECTION("default values")
       {
         REQUIRE(options.get<bool>("_use_AD_first_derivative") == false);

--- a/tests/unit/base/test_HITParser1.i
+++ b/tests/unit/base/test_HITParser1.i
@@ -6,6 +6,9 @@ day = 'day'
   default_floating_point_type = 'Float16'
   default_integer_type = 'Int32'
   default_device = 'cuda:1'
+  machine_precision = 0.5
+  tolerance = 0.1
+  tighter_tolerance = 0.01
 []
 
 [Models]

--- a/tests/unit/base/test_HITParser1.i
+++ b/tests/unit/base/test_HITParser1.i
@@ -2,6 +2,12 @@ x = 5
 pi = 3.14159
 day = 'day'
 
+[Settings]
+  default_floating_point_type = 'Float16'
+  default_integer_type = 'Int32'
+  default_device = 'cuda:1'
+[]
+
 [Models]
   [foo]
     type = SampleParserTestingModel

--- a/tests/unit/base/test_Settings.cxx
+++ b/tests/unit/base/test_Settings.cxx
@@ -23,6 +23,7 @@
 // THE SOFTWARE.
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
 
 #include "neml2/base/Settings.h"
 #include "neml2/base/HITParser.h"
@@ -38,10 +39,16 @@ TEST_CASE("Settings", "[Settings]")
   REQUIRE(default_dtype() == torch::kFloat64);
   REQUIRE(default_integer_dtype() == torch::kInt64);
   REQUIRE(default_device() == torch::kCPU);
+  REQUIRE(machine_precision() == Catch::Approx(1e-15));
+  REQUIRE(tolerance() == Catch::Approx(1e-6));
+  REQUIRE(tighter_tolerance() == Catch::Approx(1e-12));
 
   // Apply the global settings
   Settings(all_options.settings());
   REQUIRE(default_dtype() == torch::kFloat16);
   REQUIRE(default_integer_dtype() == torch::kInt32);
   REQUIRE(default_device() == torch::Device("cuda:1"));
+  REQUIRE(machine_precision() == Catch::Approx(0.5));
+  REQUIRE(tolerance() == Catch::Approx(0.1));
+  REQUIRE(tighter_tolerance() == Catch::Approx(0.01));
 }

--- a/tests/unit/base/test_Settings.cxx
+++ b/tests/unit/base/test_Settings.cxx
@@ -36,12 +36,12 @@ TEST_CASE("Settings", "[Settings]")
 
   // Before applying the global settings
   REQUIRE(default_dtype() == torch::kFloat64);
-  REQUIRE(default_int_dtype() == torch::kInt64);
+  REQUIRE(default_integer_dtype() == torch::kInt64);
   REQUIRE(default_device() == torch::kCPU);
 
   // Apply the global settings
   Settings(all_options.settings());
   REQUIRE(default_dtype() == torch::kFloat16);
-  REQUIRE(default_int_dtype() == torch::kInt32);
+  REQUIRE(default_integer_dtype() == torch::kInt32);
   REQUIRE(default_device() == torch::Device("cuda:1"));
 }

--- a/tests/unit/base/test_Settings.cxx
+++ b/tests/unit/base/test_Settings.cxx
@@ -24,24 +24,24 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "utils.h"
-#include "neml2/models/crystallography/user_tensors/FillMillerIndex.h"
+#include "neml2/base/Settings.h"
+#include "neml2/base/HITParser.h"
 
 using namespace neml2;
-using namespace neml2::crystallography;
 
-TEST_CASE("FillMillerIndex", "[crystallography/user_tensors]")
+TEST_CASE("Settings", "[Settings]")
 {
-  load_model("unit/crystallography/user_tensors/test_FillMillerIndex.i");
+  HITParser parser;
+  auto all_options = parser.parse("unit/base/test_HITParser1.i");
 
-  const auto valid_1 = Factory::get_object_ptr<MillerIndex>("Tensors", "v1");
-  const auto correct_1 = MillerIndex::fill(1, 2, 3);
-  REQUIRE(torch::allclose(*valid_1, correct_1));
+  // Before applying the global settings
+  REQUIRE(default_dtype() == torch::kFloat64);
+  REQUIRE(default_int_dtype() == torch::kInt64);
+  REQUIRE(default_device() == torch::kCPU);
 
-  const auto valid_4 = Factory::get_object_ptr<MillerIndex>("Tensors", "v4");
-  const auto correct_4 = MillerIndex(
-      torch::tensor({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}}, default_int_tensor_options()));
-  REQUIRE(torch::allclose(*valid_4, correct_4));
-
-  REQUIRE_THROWS(Factory::get_object<MillerIndex>("Tensors", "invalid"));
+  // Apply the global settings
+  Settings(all_options.settings());
+  REQUIRE(default_dtype() == torch::kFloat16);
+  REQUIRE(default_int_dtype() == torch::kInt32);
+  REQUIRE(default_device() == torch::Device("cuda:1"));
 }

--- a/tests/unit/crystallography/test_MillerIndex.cxx
+++ b/tests/unit/crystallography/test_MillerIndex.cxx
@@ -33,7 +33,7 @@ TEST_CASE("MillerIndex", "[crystallography]")
 {
   torch::manual_seed(42);
   const auto & DTO = default_tensor_options();
-  const auto & IDTO = default_integer_tensor_options();
+  const auto & IDTO = default_int_tensor_options();
 
   TorchShape B = {5, 3, 1, 2}; // batch shape
 

--- a/tests/unit/crystallography/test_MillerIndex.cxx
+++ b/tests/unit/crystallography/test_MillerIndex.cxx
@@ -33,7 +33,7 @@ TEST_CASE("MillerIndex", "[crystallography]")
 {
   torch::manual_seed(42);
   const auto & DTO = default_tensor_options();
-  const auto & IDTO = default_int_tensor_options();
+  const auto & IDTO = default_integer_tensor_options();
 
   TorchShape B = {5, 3, 1, 2}; // batch shape
 

--- a/tests/unit/crystallography/user_tensors/test_FillMillerIndex.cxx
+++ b/tests/unit/crystallography/user_tensors/test_FillMillerIndex.cxx
@@ -39,8 +39,8 @@ TEST_CASE("FillMillerIndex", "[crystallography/user_tensors]")
   REQUIRE(torch::allclose(*valid_1, correct_1));
 
   const auto valid_4 = Factory::get_object_ptr<MillerIndex>("Tensors", "v4");
-  const auto correct_4 = MillerIndex(
-      torch::tensor({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}}, default_int_tensor_options()));
+  const auto correct_4 = MillerIndex(torch::tensor({{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}},
+                                                   default_integer_tensor_options()));
   REQUIRE(torch::allclose(*valid_4, correct_4));
 
   REQUIRE_THROWS(Factory::get_object<MillerIndex>("Tensors", "invalid"));


### PR DESCRIPTION
* Add global settings
* Better default tensor options handling
* Add unit testing -- actually uncovered some bugs

The `EnumSelection` class is a much lighter version of MOOSE's `MooseEnum` which allows parsing enum from input file string.

The `Settings` class holds global settings such as default dtype and device. As a result, I also removed the `NEML2_DTYPE` and `NEML2_INT_DTYPE` configure options from CMake.

The doc syntax target should fail as I haven't taken care of those...

close #113