### PR TITLE
Fix a bug on recursive parameter declaration

### DIFF
--- a/include/neml2/models/ComposedModel.h
+++ b/include/neml2/models/ComposedModel.h
@@ -40,7 +40,7 @@ public:
 
 protected:
   /// Recursively register sub-model's nonlinar parameters
-  void register_nonlinear_params(const Model & m);
+  void register_nonlinear_params(Model & m);
 
   virtual void allocate_variables(int deriv_order, bool options_changed) override;
 

--- a/src/neml2/models/ParameterStore.cxx
+++ b/src/neml2/models/ParameterStore.cxx
@@ -85,8 +85,10 @@ ParameterStore::declare_parameter(const std::string & name, const std::string & 
                     "However, nonlinear parameter should only be declared by a model, and this "
                     "object does not appear to be a model.");
 
+        OptionSet extra_opts;
+        extra_opts.set<NEML2Object *>("_host") = model->host();
         auto & nl_param = Factory::get_object<NonlinearParameter<T>>(
-            "Models", _options.get<CrossRef<T>>(input_option_name).raw());
+            "Models", _options.get<CrossRef<T>>(input_option_name).raw(), extra_opts);
         _nl_params[name] = &nl_param.param();
         return nl_param.param().value();
       }

--- a/tests/unit/models/test_ParameterStore.cxx
+++ b/tests/unit/models/test_ParameterStore.cxx
@@ -137,13 +137,11 @@ TEST_CASE("Nested parameter registration")
   auto & model = Factory::get_object<Model>("Models", "model");
 
   const auto & params = model.named_parameters();
-  // REQUIRE(params.has_key("E1.value"));
-  // REQUIRE(params.has_key("E2.value"));
-  // REQUIRE(params.has_key("E3.value"));
-  // REQUIRE(params.has_key("elasticity1.nu"));
-  // REQUIRE(params.has_key("elasticity2.nu"));
-  // REQUIRE(params.has_key("elasticity3.nu"));
-
-  for (auto && [pname, pval] : params)
-    std::cout << pname << std::endl;
+  REQUIRE(params.has_key("E1.value"));
+  REQUIRE(params.has_key("E2.value"));
+  REQUIRE(params.has_key("E3.value"));
+  REQUIRE(params.has_key("elasticity1.nu"));
+  REQUIRE(params.has_key("elasticity2.nu"));
+  REQUIRE(params.has_key("elasticity2_another.nu"));
+  REQUIRE(params.has_key("elasticity3.nu"));
 }

--- a/tests/unit/models/test_ParameterStore.cxx
+++ b/tests/unit/models/test_ParameterStore.cxx
@@ -130,3 +130,20 @@ TEST_CASE("ParameterStore", "[models]")
     }
   }
 }
+
+TEST_CASE("Nested parameter registration")
+{
+  load_model("unit/models/test_ParameterStore.i");
+  auto & model = Factory::get_object<Model>("Models", "model");
+
+  const auto & params = model.named_parameters();
+  // REQUIRE(params.has_key("E1.value"));
+  // REQUIRE(params.has_key("E2.value"));
+  // REQUIRE(params.has_key("E3.value"));
+  // REQUIRE(params.has_key("elasticity1.nu"));
+  // REQUIRE(params.has_key("elasticity2.nu"));
+  // REQUIRE(params.has_key("elasticity3.nu"));
+
+  for (auto && [pname, pval] : params)
+    std::cout << pname << std::endl;
+}

--- a/tests/unit/models/test_ParameterStore.i
+++ b/tests/unit/models/test_ParameterStore.i
@@ -1,0 +1,50 @@
+[Models]
+  [E1]
+    type = ScalarConstantParameter
+    value = 1e3
+  []
+  [E2]
+    type = ScalarConstantParameter
+    value = 2e3
+  []
+  [E3]
+    type = ScalarConstantParameter
+    value = 3e3
+  []
+  [elasticity1]
+    type = LinearIsotropicElasticity
+    youngs_modulus = 'E1'
+    poisson_ratio = 0.3
+    stress = 'state/S1'
+  []
+  [elasticity2]
+    type = LinearIsotropicElasticity
+    youngs_modulus = 'E2'
+    poisson_ratio = 0.3
+    stress = 'state/S2'
+  []
+  [elasticity2_another]
+    type = LinearIsotropicElasticity
+    youngs_modulus = 'E2'
+    poisson_ratio = 0.3
+    stress = 'state/S2_another'
+  []
+  [elasticity3]
+    type = LinearIsotropicElasticity
+    youngs_modulus = 'E3'
+    poisson_ratio = 0.3
+    stress = 'state/S3'
+  []
+  [model1]
+    type = ComposedModel
+    models = 'elasticity1 elasticity2'
+  []
+  [model2]
+    type = ComposedModel
+    models = 'elasticity2_another elasticity3'
+  []
+  [model]
+    type = ComposedModel
+    models = 'model1 model2'
+  []
+[]

--- a/tests/unit/models/test_models.cxx
+++ b/tests/unit/models/test_models.cxx
@@ -40,7 +40,8 @@ TEST_CASE("models")
   std::vector<fs::path> tests;
   using rdi = fs::recursive_directory_iterator;
   for (const auto & entry : rdi(search_path))
-    if (entry.path().extension() == ".i")
+    if (entry.path().extension() == ".i" &&
+        !utils::start_with(entry.path().filename().string(), "test_"))
       tests.push_back(entry.path().lexically_relative(pwd));
 
   for (auto test : tests)


### PR DESCRIPTION
There is a bug causing the _host of NonlinearParameter to not being set correctly. This patch fixes that bug by passing the correct extra options when retrieving nonlinear parameters from the factory.