### PR TITLE
Fix assign_output_derivative bug

### DIFF
--- a/include/neml2/misc/types.h
+++ b/include/neml2/misc/types.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <torch/types.h>
+#include <variant>
 
 namespace neml2
 {

--- a/include/neml2/misc/utils.h
+++ b/include/neml2/misc/utils.h
@@ -130,7 +130,7 @@ TraceableTensorShape extract_batch_sizes(const torch::Tensor & tensor, Size batc
 Size storage_size(TensorShapeRef shape);
 
 template <typename... S>
-TensorShape add_shapes(S &&... shape);
+TensorShape add_shapes(const S &... shape);
 
 template <typename... S>
 TraceableTensorShape add_traceable_shapes(S &&... shape);
@@ -154,7 +154,7 @@ std::string stringify(const T & t);
 namespace details
 {
 template <typename... S>
-TensorShape add_shapes_impl(TensorShape &, TensorShapeRef, S &&...);
+TensorShape add_shapes_impl(TensorShape &, TensorShapeRef, const S &...);
 TensorShape add_shapes_impl(TensorShape &);
 
 template <typename... S>
@@ -298,10 +298,10 @@ broadcast_sizes(const T &... shapes)
 
 template <typename... S>
 TensorShape
-add_shapes(S &&... shape)
+add_shapes(const S &... shape)
 {
   TensorShape net;
-  return details::add_shapes_impl(net, std::forward<S>(shape)...);
+  return details::add_shapes_impl(net, shape...);
 }
 
 template <typename... S>
@@ -332,10 +332,10 @@ namespace details
 {
 template <typename... S>
 TensorShape
-add_shapes_impl(TensorShape & net, TensorShapeRef s, S &&... rest)
+add_shapes_impl(TensorShape & net, TensorShapeRef s, const S &... rest)
 {
   net.insert(net.end(), s.begin(), s.end());
-  return add_shapes_impl(net, std::forward<S>(rest)...);
+  return add_shapes_impl(net, rest...);
 }
 
 template <typename... S>

--- a/src/neml2/models/VariableStore.cxx
+++ b/src/neml2/models/VariableStore.cxx
@@ -138,7 +138,11 @@ void
 VariableStore::assign_output_derivatives(const DerivMap & derivs)
 {
   for (const auto & [yvar, deriv] : derivs)
-    output_variable(yvar).derivatives().insert(deriv.begin(), deriv.end());
+  {
+    auto & y = output_variable(yvar);
+    for (const auto & [xvar, val] : deriv)
+      y.derivatives().insert_or_assign(xvar, val.clone());
+  }
 }
 
 ValueMap


### PR DESCRIPTION
The `std::map::insert` does not replace the value if a key already exists. This prevents IFT from updating derivatives if the variable derivative cache is not cleared after _every_ forward evaluation.