### PR TITLE
Remove -Werror

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -36,6 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        btype: [Debug, Release]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: applied-material-modeling/neml2-ci@main
@@ -44,7 +45,11 @@ jobs:
           cmake-version: 3.26
           torch-version: 2.5.1
       - name: Configure
-        run: cmake --preset dev -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Werror" -S .
+        if: matrix.btype == 'Release'
+        run: cmake --preset dev -GNinja -DCMAKE_BUILD_TYPE=Release -S .
+      - name: Configure (Werror)
+        if: matrix.btype != 'Release'
+        run: cmake --preset dev -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.btype }} -DCMAKE_CXX_FLAGS="-Werror" -S .
       - name: Build
         run: cmake --build --preset dev-cpp
       - name: Run tests

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -36,7 +36,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        btype: [Release, Debug]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: applied-material-modeling/neml2-ci@main
@@ -45,7 +44,7 @@ jobs:
           cmake-version: 3.26
           torch-version: 2.5.1
       - name: Configure
-        run: cmake --preset dev -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.btype }} -S .
+        run: cmake --preset dev -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Werror" -S .
       - name: Build
         run: cmake --build --preset dev-cpp
       - name: Run tests

--- a/src/neml2/CMakeLists.txt
+++ b/src/neml2/CMakeLists.txt
@@ -107,10 +107,6 @@ function(neml2_add_submodule mname TYPE mdir)
 
   target_compile_options(${mname} PRIVATE -Wall -Wextra -pedantic)
 
-  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    target_compile_options(${mname} PRIVATE -Werror)
-  endif()
-
   if(NEML2_CPU_PROFILER)
     target_link_libraries(${mname} PRIVATE Gperftools::profiler)
   endif()


### PR DESCRIPTION
This PR removes "-Werror" entirely from CMakeLists.txt in hope of making building neml2 on other platforms (with older compilers for example) easier.

Note that this PR preserves the -Werror flag in our github workflow, so we are not introducing any slack into our daily development.