### PR TITLE
Allow test suites to specify additional devices

### DIFF
--- a/doc/tutorials/contributing.md
+++ b/doc/tutorials/contributing.md
@@ -26,18 +26,16 @@ A Catch test refers to a test directly written in C++ source code within the Cat
 
 ### Unit tests {#testing-unit-tests}
 
-A model unit test examines the outputs of a `Model` given a predefined set of inputs. Model unit tests can be directly designed using the input file syntax with the `ModelUnitTest` type. A variety of checks can be turned on and off based on input file options. To list a few: `check_first_derivatives` compares the implemented first order derivatives of the model against finite-differencing results, and the test is marked as passing only if the two derivatives are within tolerances specified with `derivative_abs_tol` and `derivative_rel_tol`; if `check_cuda` is set to `true`, all checks are repeated a second time on GPU (if available).
+A model unit test examines the outputs of a `Model` given a predefined set of inputs. Model unit tests can be directly designed using the input file syntax with the `ModelUnitTest` type. A variety of checks can be turned on and off based on input file options. To list a few: `check_first_derivatives` compares the implemented first order derivatives of the model against finite-differencing results, and the test is marked as passing only if the two derivatives are within tolerances specified with `derivative_abs_tol` and `derivative_rel_tol`.
 
 All input files for model unit tests should be stored inside `tests/unit/models`. Every input file with the `.i` extension will be automatically discovered and executed. To run all the model unit tests, use the following commands
 ```
-cd tests
-../build/dev/unit/unit_tests models
+./build/dev/unit/unit_tests models
 ```
 
 To run a specific model unit test, use the `-c` command line option followed by the relative location of the input file, i.e.
 ```
-cd tests
-../build/dev/unit/unit_tests models -c solid_mechanics/LinearIsotropicElasticity.i
+./build/dev/unit/unit_tests models -c solid_mechanics/LinearIsotropicElasticity.i
 ```
 
 ### Regression tests {#testing-regression-tests}
@@ -46,13 +44,11 @@ A model regression test runs a `Model` using a user specified driver. The result
 
 Each input file for model regression tests should be stored inside a separate folder inside `tests/regression`. Every input file with the `.i` extension will be automatically discovered and executed. To run all the model regression tests, use the `regression_tests` executable followed by the physics module, i.e.
 ```
-cd tests
-../build/dev/regression/regression_tests "solid mechanics"
+./build/dev/regression/regression_tests "solid mechanics"
 ```
 To run a specific model regression test, use the `-c` command line option followed by the relative location of the input file, i.e.
 ```
-cd tests
-../build/dev/regression/regression_tests "solid mechanics" -c viscoplasticity/chaboche/model.i
+./build/dev/regression/regression_tests "solid mechanics" -c viscoplasticity/chaboche/model.i
 ```
 Note that the regression test expects an option `reference` which specifies the relative location to the reference solution.
 
@@ -62,16 +58,20 @@ The model verification test is similar to the model regression test in terms of 
 
 Each input file for model verification tests should be stored inside a separate folder inside `tests/verification`. Every input file with the `.i` extension will be automatically discovered and executed. To run all the model verification tests, use the `verification_tests` executable followed by the physics module, i.e.
 ```
-cd tests
 ../build/dev/verification/verification_tests "solid mechanics"
 ```
 
 To run a specific model verification test, use the `-c` command line option followed by the relative location of the input file, i.e.
 ```
-cd tests
-../build/dev/verification/verification_tests "solid mechanics" -c chaboche/chaboche.i
+./build/dev/verification/verification_tests "solid mechanics" -c chaboche/chaboche.i
 ```
 The regression test compares variables (specified using the `variables` option) against reference values (specified using the `references` option). The reference variables can be read using input objects with type `VTestTimeSeries`.
+
+### Command-line arguments
+
+The above test suites, including unit tests, regression tests, verification tests, and dispatcher tests, support a variety of configuration options that can be controlled from the command line. See [Catch2 command line](https://github.com/catchorg/Catch2/blob/devel/docs/command-line.md) documentation for a list of useful command-line options. In addition, NEML2 test suites additionally support the following options:
+- `-p`, `--path`: working directory. This argument is optional and is only needed when the default guessing mechanism fails to locate the test input files.
+- `-d`, `--devices`: list of additional (non-CPU) devices to test.
 
 ## Python package
 

--- a/src/neml2/base/Parser.cxx
+++ b/src/neml2/base/Parser.cxx
@@ -115,8 +115,17 @@ bool
 parse_(Device & val, const std::string & raw_str)
 {
   const auto str_val = parse<std::string>(raw_str);
-  val = Device(str_val);
-  return true;
+  try
+  {
+    val = Device(str_val);
+    return true;
+  }
+  catch (const std::exception & e)
+  {
+    std::cerr << "Failed to parse '" << raw_str << "' as a device. Error message:\n"
+              << e.what() << std::endl;
+    return false;
+  }
 }
 } // namespace utils
 } // namespace neml2

--- a/tests/dispatchers/CMakeLists.txt
+++ b/tests/dispatchers/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB_RECURSE srcs CONFIGURE_DEPENDS *.cxx)
 add_executable(dispatcher_tests ${srcs})
-target_link_libraries(dispatcher_tests PRIVATE testutils Catch2::Catch2)
+target_link_libraries(dispatcher_tests PRIVATE testutils)
 target_compile_options(dispatcher_tests PRIVATE -Wall -Wextra -pedantic)
 set_target_properties(dispatcher_tests PROPERTIES INSTALL_RPATH_USE_LINK_PATH ON)

--- a/tests/dispatchers/main.cxx
+++ b/tests/dispatchers/main.cxx
@@ -22,37 +22,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <catch2/catch_session.hpp>
-
-#include <filesystem>
 #include "utils.h"
 
 int
 main(int argc, char * argv[])
 {
-  Catch::Session session;
-
-  // Add path cli arg
-  using namespace Catch::Clara;
-  std::string working_dir;
-  auto cli = session.cli() | Opt(working_dir, ".")["-p"]["--path"]("path to the test input files");
-  session.cli(cli);
-
-  // Let Catch2 parse the command line
-  auto err = session.applyCommandLine(argc, argv);
-  if (err)
-    return err;
-
-  // Set the working directory
-  auto exec_prefix = std::filesystem::path(argv[0]).parent_path();
-  err = guess_test_dir("dispatchers", working_dir, exec_prefix);
-  if (err)
-    return err;
-  std::cout << "Working directory: " << working_dir << std::endl;
-  std::filesystem::current_path(working_dir);
-
-  // Set default tensor options
-  neml2::set_default_dtype(neml2::kFloat64);
-
-  return session.run();
+  return test_main(argc, argv, "dispatchers");
 }

--- a/tests/include/ModelUnitTest.h
+++ b/tests/include/ModelUnitTest.h
@@ -51,7 +51,6 @@ private:
   const bool _check_derivs;
   const bool _check_secderivs;
   const bool _check_AD_param_derivs;
-  const bool _check_cuda;
 
   ValueMap _in;
   ValueMap _out;

--- a/tests/include/utils.h
+++ b/tests/include/utils.h
@@ -30,6 +30,9 @@
 #include "neml2/tensors/functions/abs.h"
 #include "neml2/tensors/functions/stack.h"
 
+/// Generic main function for the test suite of name \p name.
+int test_main(int argc, char * argv[], const std::string & name);
+
 /**
  * @brief A utility function to guess the path to the test directory based on a hint and some
  * heuristics.
@@ -55,6 +58,20 @@
  */
 int
 guess_test_dir(const std::string & stem, std::string & hint, const std::string & exec_prefix = "");
+
+/// Get test suite additional devices
+const std::unordered_set<neml2::Device> & get_test_suite_additional_devices();
+
+/**
+ * @brief Parse the cliarg (a comma-separated list of device specs) into a set of devices
+ *
+ * @return int Error code:
+ * 0: success
+ * 1: invalid device spec
+ * 2: invalid device type (e.g., contains CPU)
+ * 3: duplicate device spec
+ */
+int init_test_devices(const std::string & additional_devs);
 
 /**
  * @brief A simple finite-differencing helper to numerically approximate the derivative of the

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB_RECURSE srcs CONFIGURE_DEPENDS *.cxx)
 add_executable(regression_tests ${srcs})
-target_link_libraries(regression_tests PRIVATE testutils Catch2::Catch2)
+target_link_libraries(regression_tests PRIVATE testutils)
 target_compile_options(regression_tests PRIVATE -Wall -Wextra -pedantic)
 set_target_properties(regression_tests PROPERTIES INSTALL_RPATH_USE_LINK_PATH ON)

--- a/tests/regression/main.cxx
+++ b/tests/regression/main.cxx
@@ -22,37 +22,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <catch2/catch_session.hpp>
-
-#include <filesystem>
 #include "utils.h"
 
 int
 main(int argc, char * argv[])
 {
-  Catch::Session session;
-
-  // Add path cli arg
-  using namespace Catch::Clara;
-  std::string working_dir;
-  auto cli = session.cli() | Opt(working_dir, ".")["-p"]["--path"]("path to the test input files");
-  session.cli(cli);
-
-  // Let Catch2 parse the command line
-  auto err = session.applyCommandLine(argc, argv);
-  if (err)
-    return err;
-
-  // Set the working directory
-  auto exec_prefix = std::filesystem::path(argv[0]).parent_path();
-  err = guess_test_dir("regression", working_dir, exec_prefix);
-  if (err)
-    return err;
-  std::cout << "Working directory: " << working_dir << std::endl;
-  std::filesystem::current_path(working_dir);
-
-  // Set default tensor options
-  neml2::set_default_dtype(neml2::kFloat64);
-
-  return session.run();
+  return test_main(argc, argv, "regression");
 }

--- a/tests/src/CMakeLists.txt
+++ b/tests/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB_RECURSE srcs CONFIGURE_DEPENDS *.cxx)
 add_library(testutils OBJECT ${srcs})
 target_include_directories(testutils PUBLIC ${NEML2_SOURCE_DIR}/tests/include)
-target_link_libraries(testutils PUBLIC neml2)
+target_link_libraries(testutils PUBLIC neml2 Catch2::Catch2)
 target_compile_options(testutils PRIVATE -Wall -Wextra -pedantic)

--- a/tests/src/ModelUnitTest.cxx
+++ b/tests/src/ModelUnitTest.cxx
@@ -27,8 +27,6 @@
 #include "neml2/tensors/functions/jacrev.h"
 #include "neml2/misc/assertions.h"
 
-#include <torch/cuda.h>
-
 namespace neml2
 {
 template <typename T>
@@ -62,7 +60,6 @@ ModelUnitTest::expected_options()
   options.set<bool>("check_derivatives") = true;
   options.set<bool>("check_second_derivatives") = false;
   options.set<bool>("check_AD_parameter_derivatives") = true;
-  options.set<bool>("check_cuda") = true;
 
   options.set<Real>("value_rel_tol") = 1e-5;
   options.set<Real>("value_abs_tol") = 1e-8;
@@ -97,7 +94,6 @@ ModelUnitTest::ModelUnitTest(const OptionSet & options)
     _check_derivs(options.get<bool>("check_derivatives")),
     _check_secderivs(options.get<bool>("check_second_derivatives")),
     _check_AD_param_derivs(options.get<bool>("check_AD_parameter_derivatives")),
-    _check_cuda(options.get<bool>("check_cuda")),
 
     _val_rtol(options.get<Real>("value_rel_tol")),
     _val_atol(options.get<Real>("value_abs_tol")),
@@ -138,11 +134,11 @@ ModelUnitTest::run()
 
   check_all();
 
-  if (_check_cuda && torch::cuda::is_available())
+  for (const auto & device : get_test_suite_additional_devices())
   {
-    _model.to(kCUDA);
+    _model.to(device);
     for (auto && [name, tensor] : _in)
-      _in[name] = tensor.to(kCUDA);
+      _in[name] = tensor.to(device);
 
     check_all();
   }

--- a/tests/src/utils.cxx
+++ b/tests/src/utils.cxx
@@ -22,9 +22,87 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <catch2/catch_session.hpp>
 #include <sstream>
 #include <filesystem>
 #include "utils.h"
+
+std::unordered_set<neml2::Device> &
+set_test_suite_additional_devices()
+{
+  static std::unordered_set<neml2::Device> _test_suite_additional_devices;
+  return _test_suite_additional_devices;
+}
+
+const std::unordered_set<neml2::Device> &
+get_test_suite_additional_devices()
+{
+  return set_test_suite_additional_devices();
+}
+
+int
+test_main(int argc, char * argv[], const std::string & name)
+{
+  Catch::Session session;
+
+  // Add path cli arg
+  using namespace Catch::Clara;
+  std::string working_dir;
+  std::string additional_devs;
+  auto cli = session.cli() | Opt(working_dir, ".")["-p"]["--path"]("path to the test input files") |
+             Opt(additional_devs, "")["-d"]["--devices"](
+                 "additional (non-CPU) devices to provide to the test suite");
+  session.cli(cli);
+
+  // Let Catch2 parse the command line
+  auto err = session.applyCommandLine(argc, argv);
+  if (err)
+    return err;
+
+  // Set the working directory
+  auto exec_prefix = std::filesystem::path(argv[0]).parent_path();
+  err = guess_test_dir(name, working_dir, exec_prefix);
+  if (err)
+    return err;
+  std::filesystem::current_path(working_dir);
+
+  // Get additional devices
+  err = init_test_devices(additional_devs);
+  if (err)
+  {
+    std::cerr << "Failed to parse additional devices: " << additional_devs << ". Reason: ";
+    switch (err)
+    {
+      case 1:
+        std::cerr << "Invalid device specification.";
+        break;
+      case 2:
+        std::cerr << "Invalid device type (e.g., contains CPU).";
+        break;
+      case 3:
+        std::cerr << "Duplicate device specification.";
+        break;
+      default:
+        std::cerr << "Unknown error.";
+        break;
+    }
+    std::cerr << std::endl;
+
+    return err;
+  }
+
+  // Set default tensor options
+  neml2::set_default_dtype(neml2::kFloat64);
+
+  // Print test suite configuration
+  std::cout << "Working directory: " << std::string(std::filesystem::current_path()) << std::endl;
+  std::cout << "Additional devices: ";
+  for (const auto & device : get_test_suite_additional_devices())
+    std::cout << device << " ";
+  std::cout << std::endl;
+
+  return session.run();
+}
 
 int
 try_hint(const std::string & stem, std::string & hint)
@@ -92,4 +170,27 @@ guess_test_dir(const std::string & stem, std::string & hint, const std::string &
     return 0;
 
   return 1;
+}
+
+int
+init_test_devices(const std::string & additional_devs)
+{
+  auto & devs = set_test_suite_additional_devices();
+  auto tokens = neml2::utils::split(additional_devs, ",");
+  for (const auto & token : tokens)
+  {
+    neml2::Device device = neml2::kCPU;
+    auto success = neml2::utils::parse_<neml2::Device>(device, token);
+    if (!success)
+      return 1;
+
+    if (device == neml2::kCPU)
+      return 2;
+
+    if (devs.find(device) != devs.end())
+      return 3;
+
+    devs.insert(device);
+  }
+  return 0;
 }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB_RECURSE srcs CONFIGURE_DEPENDS *.cxx)
 add_executable(unit_tests ${srcs})
-target_link_libraries(unit_tests PRIVATE testutils Catch2::Catch2)
+target_link_libraries(unit_tests PRIVATE testutils)
 target_compile_options(unit_tests PRIVATE -Wall -Wextra -pedantic)
 set_target_properties(unit_tests PROPERTIES INSTALL_RPATH_USE_LINK_PATH ON)

--- a/tests/unit/main.cxx
+++ b/tests/unit/main.cxx
@@ -22,37 +22,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <catch2/catch_session.hpp>
-
-#include <filesystem>
 #include "utils.h"
 
 int
 main(int argc, char * argv[])
 {
-  Catch::Session session;
-
-  // Add path cli arg
-  using namespace Catch::Clara;
-  std::string working_dir;
-  auto cli = session.cli() | Opt(working_dir, ".")["-p"]["--path"]("path to the test input files");
-  session.cli(cli);
-
-  // Let Catch2 parse the command line
-  auto err = session.applyCommandLine(argc, argv);
-  if (err)
-    return err;
-
-  // Set the working directory
-  auto exec_prefix = std::filesystem::path(argv[0]).parent_path();
-  err = guess_test_dir("unit", working_dir, exec_prefix);
-  if (err)
-    return err;
-  std::cout << "Working directory: " << working_dir << std::endl;
-  std::filesystem::current_path(working_dir);
-
-  // Set default tensor options
-  neml2::set_default_dtype(neml2::kFloat64);
-
-  return session.run();
+  return test_main(argc, argv, "unit");
 }

--- a/tests/unit/tensors/test_TensorBase.cxx
+++ b/tests/unit/tensors/test_TensorBase.cxx
@@ -25,6 +25,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
 
+#include "utils.h"
+
 #include "neml2/tensors/Tensor.h"
 #include "neml2/tensors/functions/pow.h"
 #include "neml2/tensors/functions/sign.h"
@@ -69,6 +71,17 @@ TEST_CASE("TensorBase", "[tensors]")
         REQUIRE(a.batch_sizes() == B);
         REQUIRE(a.base_sizes() == D);
         REQUIRE(a.base_storage() == L);
+      }
+
+      SECTION("to")
+      {
+        for (const auto & dev : get_test_suite_additional_devices())
+        {
+          auto a = Tensor(at::zeros(BD, dev), B.size());
+          // Let b make a round trip from default device to dev and back to default device
+          auto b = a.to(dev).to(DTO);
+          REQUIRE(at::allclose(a, b));
+        }
       }
 
       SECTION("copy")

--- a/tests/verification/CMakeLists.txt
+++ b/tests/verification/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB_RECURSE srcs CONFIGURE_DEPENDS *.cxx)
 add_executable(verification_tests ${srcs})
-target_link_libraries(verification_tests PRIVATE testutils Catch2::Catch2)
+target_link_libraries(verification_tests PRIVATE testutils)
 target_compile_options(verification_tests PRIVATE -Wall -Wextra -pedantic)
 set_target_properties(verification_tests PROPERTIES INSTALL_RPATH_USE_LINK_PATH ON)

--- a/tests/verification/main.cxx
+++ b/tests/verification/main.cxx
@@ -22,37 +22,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <catch2/catch_session.hpp>
-
-#include <filesystem>
 #include "utils.h"
 
 int
 main(int argc, char * argv[])
 {
-  Catch::Session session;
-
-  // Add path cli arg
-  using namespace Catch::Clara;
-  std::string working_dir;
-  auto cli = session.cli() | Opt(working_dir, ".")["-p"]["--path"]("path to the test input files");
-  session.cli(cli);
-
-  // Let Catch2 parse the command line
-  auto err = session.applyCommandLine(argc, argv);
-  if (err)
-    return err;
-
-  // Set the working directory
-  auto exec_prefix = std::filesystem::path(argv[0]).parent_path();
-  err = guess_test_dir("verification", working_dir, exec_prefix);
-  if (err)
-    return err;
-  std::cout << "Working directory: " << working_dir << std::endl;
-  std::filesystem::current_path(working_dir);
-
-  // Set default tensor options
-  neml2::set_default_dtype(neml2::kFloat64);
-
-  return session.run();
+  return test_main(argc, argv, "verification");
 }


### PR DESCRIPTION
Add a cliarg `-d`/`--devices` to specify a list of additional (non-CPU) devices that the test suite can use.

ModelUnitTest now loops through this list to repeat all unit tests.