### PR TITLE
Fix FindTIMPI.cmake

### DIFF
--- a/cmake/Modules/DownloadTIMPI.cmake
+++ b/cmake/Modules/DownloadTIMPI.cmake
@@ -26,8 +26,10 @@ FetchContent_MakeAvailable(timpi)
 # build type
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(TIMPI_BUILD_TYPE "dbg")
-else()
+elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
   set(TIMPI_BUILD_TYPE "devel")
+else()
+  set(TIMPI_BUILD_TYPE "opt")
 endif()
 
 # cxx11 abi

--- a/cmake/Modules/FindTIMPI.cmake
+++ b/cmake/Modules/FindTIMPI.cmake
@@ -17,7 +17,15 @@ find_path(TIMPI_INCLUDE_DIR timpi NO_CACHE)
 # -----------------------------------------------------------------------------
 # libraries
 # -----------------------------------------------------------------------------
-find_library(TIMPI_LIBRARY NAMES timpi_dbg timpi_devel timpi_opt NO_CACHE)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(TIMPI_BUILD_TYPE dbg)
+elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+  set(TIMPI_BUILD_TYPE devel)
+else()
+  set(TIMPI_BUILD_TYPE opt)
+endif()
+
+find_library(TIMPI_LIBRARY NAMES timpi_${TIMPI_BUILD_TYPE} NO_CACHE)
 
 # -----------------------------------------------------------------------------
 # Check if we found everything


### PR DESCRIPTION
I am currently listing timpi with all possible build type variants as search candidates. This results in ambiguity when multiple timpi, e.g., libtimpi_opt and libtimpi_dbg, coexist.

The solution is to explicitly list the candidate with the expected suffix.