### PR TITLE
Fix compile warnings with older gcc/g++

### DIFF
--- a/include/neml2/tensors/functions/operators.h
+++ b/include/neml2/tensors/functions/operators.h
@@ -33,7 +33,7 @@
 namespace neml2
 {
 // Forward declaration
-#define FORWARD_DECLARATION(T) class T;
+#define FORWARD_DECLARATION(T) class T
 FOR_ALL_TENSORBASE(FORWARD_DECLARATION);
 
 // Define macros (let's be responsible and undefine them afterwards)

--- a/include/neml2/tensors/tensors_fwd.h
+++ b/include/neml2/tensors/tensors_fwd.h
@@ -28,7 +28,7 @@
 
 namespace neml2
 {
-#define DECLARE_TENSOR(T) class T;
+#define DECLARE_TENSOR(T) class T
 FOR_ALL_TENSORBASE(DECLARE_TENSOR);
 #undef DECLARE_TENSOR
 } // namespace neml2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "cmake>=3.26", "ninja"]
+requires = ["setuptools>=42", "cmake==3.26", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "cmake==3.26", "ninja"]
+requires = ["setuptools>=42", "cmake>=3.26,<4.0", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/src/neml2/base/TensorName.cxx
+++ b/src/neml2/base/TensorName.cxx
@@ -71,6 +71,6 @@ TensorName<T>::resolve_number(Real val) const
 
 // Explicit instantiations
 template struct TensorName<ATensor>;
-#define INSTANTIATE(T) template struct TensorName<T>;
+#define INSTANTIATE(T) template struct TensorName<T>
 FOR_ALL_TENSORBASE(INSTANTIATE);
 } // namesace neml2

--- a/src/neml2/models/VariableStore.cxx
+++ b/src/neml2/models/VariableStore.cxx
@@ -174,7 +174,7 @@ VariableStore::create_variable(VariableStorage & variables,
 }
 #define INSTANTIATE_CREATE_VARIABLE(T)                                                             \
   template Variable<T> * VariableStore::create_variable<T>(                                        \
-      VariableStorage &, const VariableName &, TensorShapeRef);
+      VariableStorage &, const VariableName &, TensorShapeRef)
 FOR_ALL_PRIMITIVETENSOR(INSTANTIATE_CREATE_VARIABLE);
 
 VariableBase &

--- a/src/neml2/tensors/tensors.cxx
+++ b/src/neml2/tensors/tensors.cxx
@@ -30,7 +30,7 @@
 namespace neml2
 {
 // Explicitly instantiate TensorBase
-#define INSTANTIATE_TENSORBASE(T) template class TensorBase<T>;
+#define INSTANTIATE_TENSORBASE(T) template class TensorBase<T>
 FOR_ALL_TENSORBASE(INSTANTIATE_TENSORBASE);
 
 std::ostream &


### PR DESCRIPTION
With gcc/g++<10, there are some harmless warnings about redundant semicolon with macro expansion. Those warnings however prevent moose dbg mode (with -Werror) from building. So I will have to fix them here.

This will not be covered with github runners, because it's kinda difficult to pick an older compiler there. In the future, when we make the switch to CIVET for CI, we can add the test coverage back.