### PR TITLE
Make nlohmann/json an optional dependency

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -84,6 +84,20 @@ jobs:
       - name: Build
         run: cmake --build --preset dev-cpp
 
+  no-json:
+    needs: clang-format
+    runs-on: macos-latest
+    steps:
+      - uses: applied-material-modeling/neml2-ci@main
+        with:
+          python-version: 3.9
+          cmake-version: 3.26
+          torch-version: 2.5.1
+      - name: Configure
+        run: cmake --preset dev -GNinja -DNEML2_JSON=OFF -S .
+      - name: Build
+        run: cmake --build --preset dev-cpp
+
   runner:
     needs: clang-format
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(NEML2_DOC OFF CACHE BOOL "Build NEML2 documentation (html)")
 set(NEML2_CPU_PROFILER OFF CACHE BOOL "Link against gperftools profiler to enable CPU profiling")
 set(NEML2_WORK_DISPATCHER OFF CACHE BOOL "Enable NEML2 work dispatcher")
 set(NEML2_THREAD_SANITIZER OFF CACHE BOOL "Enable ThreadSanitizer")
+set(NEML2_JSON OFF CACHE BOOL "Enable JSON support")
 
 # ----------------------------------------------------------------------------
 # Dependencies and 3rd party packages

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,6 +16,7 @@
         "NEML2_DOC": "OFF",
         "NEML2_CPU_PROFILER": "OFF",
         "NEML2_WORK_DISPATCHER": "ON",
+        "NEML2_JSON": "ON",
         "NEML2_THREAD_SANITIZER": "OFF"
       }
     },

--- a/include/neml2/base/TracingInterface.h
+++ b/include/neml2/base/TracingInterface.h
@@ -29,12 +29,17 @@
 #include <mutex>
 #include <unordered_map>
 
+#ifdef NEML2_HAS_JSON
 #include "nlohmann/json.hpp"
+#endif
+
 #include "neml2/base/OptionSet.h"
 
 namespace neml2
 {
+#ifdef NEML2_HAS_JSON
 using json = nlohmann::json;
+#endif
 
 struct TraceWriter
 {
@@ -55,6 +60,7 @@ struct TraceWriter
   /// Output stream for the trace file
   std::ofstream out;
 
+#ifdef NEML2_HAS_JSON
   void trace_duration_begin(const std::string & name,
                             const std::string & category,
                             const json & args = {},
@@ -68,8 +74,10 @@ struct TraceWriter
                      const json & args = {},
                      const std::string & scope = "t",
                      unsigned int pid = 0);
+#endif
 
 private:
+#ifdef NEML2_HAS_JSON
   /// Define common event fields
   void write_event_common(json & event,
                           const std::string & name,
@@ -79,6 +87,7 @@ private:
                           unsigned int pid);
   /// Write the event to the trace file
   void dump_event(const json & event, bool last = false);
+#endif
 
   /// Trace epoch
   const std::chrono::high_resolution_clock::time_point _epoch;

--- a/src/neml2/CMakeLists.txt
+++ b/src/neml2/CMakeLists.txt
@@ -96,16 +96,18 @@ endif()
 # ----------------------------------------------------------------------------
 # nlohmann json
 # ----------------------------------------------------------------------------
-set(JSON_MultipleHeaders OFF)
-find_package(nlohmann_json QUIET)
+if(NEML2_JSON)
+  set(JSON_MultipleHeaders OFF)
+  find_package(nlohmann_json QUIET)
 
-if(NOT TARGET nlohmann_json::nlohmann_json)
-  include(FetchContent)
-  FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v${NLOHMANN_JSON_VERSION}/json.tar.xz)
-  message(STATUS "Downloading/updating nlohmann/json")
-  set(JSON_Install ON)
-  set(JSON_SystemInclude ON)
-  FetchContent_MakeAvailable(json)
+  if(NOT TARGET nlohmann_json::nlohmann_json)
+    include(FetchContent)
+    FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v${NLOHMANN_JSON_VERSION}/json.tar.xz)
+    message(STATUS "Downloading/updating nlohmann/json")
+    set(JSON_Install ON)
+    set(JSON_SystemInclude ON)
+    FetchContent_MakeAvailable(json)
+  endif()
 endif()
 
 # ----------------------------------------------------------------------------
@@ -160,8 +162,14 @@ add_library(neml2 INTERFACE)
 
 # libneml2_misc
 neml2_add_submodule(neml2_misc SHARED misc)
-target_link_libraries(neml2_misc PUBLIC Torch::Torch nlohmann_json::nlohmann_json)
+target_link_libraries(neml2_misc PUBLIC Torch::Torch)
 set_target_properties(neml2_misc PROPERTIES INSTALL_RPATH_USE_LINK_PATH ON)
+
+if(NEML2_JSON)
+  target_compile_definitions(neml2_misc PUBLIC NEML2_HAS_JSON)
+  target_link_libraries(neml2_misc PUBLIC nlohmann_json::nlohmann_json)
+endif()
+
 target_link_libraries(neml2 INTERFACE neml2_misc)
 
 if(NEML2_PCH)

--- a/tests/src/SampleEventTracer.cxx
+++ b/tests/src/SampleEventTracer.cxx
@@ -38,6 +38,7 @@ SampleEventTracer::SampleEventTracer(std::string filename,
 void
 SampleEventTracer::dump()
 {
+#ifdef NEML2_HAS_JSON
   if (event_tracing_enabled())
   {
     auto & writer = event_trace_writer();
@@ -45,5 +46,6 @@ SampleEventTracer::dump()
     writer.trace_instant(_instant_event, "SampleEventTracer");
     writer.trace_duration_end(_duration_event, "SampleEventTracer");
   }
+#endif
 }
 } // namespace neml2

--- a/tests/unit/base/test_TracingInterface.cxx
+++ b/tests/unit/base/test_TracingInterface.cxx
@@ -30,6 +30,7 @@
 
 using namespace neml2;
 
+#ifdef NEML2_HAS_JSON
 TEST_CASE("TracingInterface", "[base]")
 {
   SECTION("single writer")
@@ -134,3 +135,4 @@ TEST_CASE("TracingInterface", "[base]")
     REQUIRE(data2[4]["ph"] == "E");
   }
 }
+#endif


### PR DESCRIPTION
- Make nlohmann/json optional. This is needed to workaround the current MOOSE configuration problem.
- Add a github workflow job to prevent regression