### PR TITLE
Miscellaneous improvements

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -27,7 +27,8 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "NEML2_PCH": "OFF",
-        "NEML2_TESTS": "OFF"
+        "NEML2_RUNNER": "ON",
+        "NEML2_PYBIND": "ON"
       }
     },
     {
@@ -37,7 +38,6 @@
       "inherits": "default",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "NEML2_PYBIND": "ON",
         "NEML2_DOC": "ON"
       }

--- a/include/neml2/base/EnumSelectionBase.h
+++ b/include/neml2/base/EnumSelectionBase.h
@@ -27,7 +27,6 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
-#include <set>
 
 namespace neml2
 {

--- a/include/neml2/base/HITParser.h
+++ b/include/neml2/base/HITParser.h
@@ -23,7 +23,7 @@
 // THE SOFTWARE.
 #pragma once
 
-#include "hit/hit.h"
+#include "hit/parse.h"
 #include "neml2/base/Parser.h"
 
 namespace neml2

--- a/include/neml2/base/LabeledAxis.h
+++ b/include/neml2/base/LabeledAxis.h
@@ -28,6 +28,7 @@
 
 #include "neml2/misc/types.h"
 #include "neml2/base/LabeledAxisAccessor.h"
+#include "neml2/tensors/indexing.h"
 
 namespace neml2
 {

--- a/include/neml2/base/LabeledAxis.h
+++ b/include/neml2/base/LabeledAxis.h
@@ -26,7 +26,7 @@
 
 #include <map>
 
-#include "neml2/misc/string_utils.h"
+#include "neml2/misc/types.h"
 #include "neml2/base/LabeledAxisAccessor.h"
 
 namespace neml2

--- a/include/neml2/base/Parser.h
+++ b/include/neml2/base/Parser.h
@@ -26,7 +26,8 @@
 #include <filesystem>
 
 #include "neml2/misc/string_utils.h"
-#include "neml2/misc/defaults.h"
+#include "neml2/misc/errors.h"
+#include "neml2/misc/types.h"
 
 namespace neml2
 {

--- a/include/neml2/base/guards.h
+++ b/include/neml2/base/guards.h
@@ -28,8 +28,6 @@
 #include <map>
 #include <chrono>
 
-#include "neml2/misc/types.h"
-
 namespace neml2
 {
 // Timed section

--- a/include/neml2/jit/types.h
+++ b/include/neml2/jit/types.h
@@ -27,7 +27,6 @@
 #include <torch/csrc/jit/frontend/tracer.h>
 #include <torch/csrc/jit/api/function_impl.h>
 #include <torch/csrc/jit/serialization/import.h>
-#include "neml2/jit/TraceableTensorShape.h"
 
 namespace neml2::jit
 {

--- a/include/neml2/jit/utils.h
+++ b/include/neml2/jit/utils.h
@@ -25,8 +25,13 @@
 #pragma once
 
 #include "neml2/misc/types.h"
-#include "neml2/misc/errors.h"
-#include "neml2/jit/types.h"
+#include "neml2/jit/TraceableTensorShape.h"
+#include <torch/csrc/jit/api/function_impl.h>
+
+namespace neml2::jit
+{
+using namespace torch::jit;
+}
 
 namespace neml2
 {

--- a/include/neml2/misc/string_utils.h
+++ b/include/neml2/misc/string_utils.h
@@ -28,9 +28,6 @@
 #include <vector>
 #include <sstream>
 
-#include "neml2/misc/errors.h"
-#include "neml2/misc/types.h"
-
 namespace neml2::utils
 {
 template <typename T, typename... Args>

--- a/include/neml2/misc/types.h
+++ b/include/neml2/misc/types.h
@@ -30,11 +30,6 @@
 namespace at
 {
 class Tensor;
-namespace indexing
-{
-struct Slice;
-struct TensorIndex;
-}
 } // namespace at
 
 namespace neml2
@@ -70,13 +65,6 @@ using Size = int64_t;
 using Integer = int64_t;
 using TensorShape = c10::SmallVector<Size, 8>;
 using TensorShapeRef = c10::ArrayRef<Size>;
-
-namespace indexing
-{
-using namespace at::indexing;
-using TensorIndices = c10::SmallVector<TensorIndex, 8>;
-using TensorIndicesRef = c10::ArrayRef<TensorIndex>;
-} // namespace indexing
 
 /**
  * @brief Role in a function definition

--- a/include/neml2/models/BufferStore.h
+++ b/include/neml2/models/BufferStore.h
@@ -24,9 +24,11 @@
 
 #pragma once
 
-#include <memory>
+#include <map>
 
-#include "neml2/jit/types.h"
+#include <torch/csrc/jit/frontend/tracer.h>
+
+#include "neml2/misc/types.h"
 
 namespace neml2
 {
@@ -36,6 +38,11 @@ struct TensorName;
 class TensorValueBase;
 template <typename T>
 class TensorBase;
+
+namespace jit
+{
+using namespace torch::jit;
+}
 
 /// Interface for object which can store buffers
 class BufferStore

--- a/include/neml2/models/ParameterStore.h
+++ b/include/neml2/models/ParameterStore.h
@@ -24,9 +24,11 @@
 
 #pragma once
 
-#include <memory>
+#include <map>
 
-#include "neml2/jit/types.h"
+#include <torch/csrc/jit/frontend/tracer.h>
+
+#include "neml2/misc/types.h"
 
 namespace neml2
 {
@@ -40,6 +42,11 @@ class TensorValueBase;
 template <typename T>
 class TensorBase;
 class Tensor;
+
+namespace jit
+{
+using namespace torch::jit;
+}
 
 /// Interface for object which can store parameters
 class ParameterStore

--- a/include/neml2/models/VariableStore.h
+++ b/include/neml2/models/VariableStore.h
@@ -28,6 +28,7 @@
 
 #include "neml2/models/map_types_fwd.h"
 #include "neml2/base/LabeledAxisAccessor.h"
+#include "neml2/misc/types.h"
 #include "neml2/jit/types.h"
 
 namespace neml2

--- a/include/neml2/tensors/PrimitiveTensor.h
+++ b/include/neml2/tensors/PrimitiveTensor.h
@@ -27,7 +27,9 @@
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/api/include/torch/detail/TensorDataContainer.h>
 
+#include "neml2/misc/errors.h"
 #include "neml2/tensors/Tensor.h"
+#include "neml2/tensors/shape_utils.h"
 
 namespace neml2
 {
@@ -55,10 +57,10 @@ public:
   PrimitiveTensor() = default;
 
   /// Construct from another ATensor given batch dimension
-  explicit PrimitiveTensor(const ATensor & tensor, Size batch_dim);
+  PrimitiveTensor(const ATensor & tensor, Size batch_dim);
 
   /// Construct from another ATensor given batch shape
-  explicit PrimitiveTensor(const ATensor & tensor, const TraceableTensorShape & batch_shape);
+  PrimitiveTensor(const ATensor & tensor, const TraceableTensorShape & batch_shape);
 
   /// Copy constructor
   PrimitiveTensor(const Tensor & tensor);

--- a/include/neml2/tensors/SWR4.h
+++ b/include/neml2/tensors/SWR4.h
@@ -40,6 +40,7 @@ class SWR4 : public PrimitiveTensor<SWR4, 6, 3>
 {
 public:
   using PrimitiveTensor<SWR4, 6, 3>::PrimitiveTensor;
+
   SWR4(const R4 & F);
 };
 

--- a/include/neml2/tensors/Tensor.h
+++ b/include/neml2/tensors/Tensor.h
@@ -26,9 +26,9 @@
 
 #include <torch/csrc/api/include/torch/detail/TensorDataContainer.h>
 
+#include "neml2/misc/types.h"
 #include "neml2/tensors/TensorBase.h"
 #include "neml2/misc/defaults.h"
-#include "neml2/jit/types.h"
 
 namespace neml2
 {

--- a/include/neml2/tensors/TensorBase.h
+++ b/include/neml2/tensors/TensorBase.h
@@ -25,9 +25,10 @@
 #pragma once
 
 #include <ATen/core/Tensor.h>
+
 #include "neml2/jit/TraceableTensorShape.h"
-#include "neml2/tensors/shape_utils.h"
 #include "neml2/tensors/functions/operators.h"
+#include "neml2/tensors/indexing.h"
 
 namespace neml2
 {
@@ -215,7 +216,7 @@ public:
   neml2::Tensor base_flatten() const;
   ///@}
 
-private:
+protected:
   /// Number of batch dimensions. The first `_batch_dim` dimensions are considered batch dimensions.
   Size _batch_dim = {};
 

--- a/include/neml2/tensors/TensorBaseImpl.h
+++ b/include/neml2/tensors/TensorBaseImpl.h
@@ -29,11 +29,17 @@
 
 #pragma once
 
+#include <torch/csrc/jit/frontend/tracer.h>
+
 #include "neml2/tensors/TensorBase.h"
 #include "neml2/tensors/Scalar.h"
 #include "neml2/tensors/assertions.h"
-#include "neml2/jit/types.h"
 #include "neml2/jit/utils.h"
+
+namespace neml2::jit
+{
+using namespace torch::jit;
+}
 
 namespace neml2
 {
@@ -56,7 +62,7 @@ TensorBase<Derived>::TensorBase(const ATensor & tensor, const TraceableTensorSha
     _batch_dim(Size(batch_shape.size())),
     _batch_sizes(batch_shape)
 {
-  neml_assert_dbg(batch_sizes() == batch_shape,
+  neml_assert_dbg(batch_sizes() == tensor.sizes().slice(0, batch_dim()),
                   "Tensor of shape ",
                   sizes(),
                   " cannot be constructed with batch shape ",

--- a/include/neml2/tensors/WSR4.h
+++ b/include/neml2/tensors/WSR4.h
@@ -40,6 +40,7 @@ class WSR4 : public PrimitiveTensor<WSR4, 3, 6>
 {
 public:
   using PrimitiveTensor<WSR4, 3, 6>::PrimitiveTensor;
+
   WSR4(const R4 & F);
 };
 

--- a/include/neml2/tensors/WWR4.h
+++ b/include/neml2/tensors/WWR4.h
@@ -40,6 +40,7 @@ class WWR4 : public PrimitiveTensor<WWR4, 3, 3>
 {
 public:
   using PrimitiveTensor<WWR4, 3, 3>::PrimitiveTensor;
+
   WWR4(const R4 & F);
 
   /// Create the identity tensor \f$\delta_{ij}\delta_{kl}\f$

--- a/include/neml2/tensors/indexing.h
+++ b/include/neml2/tensors/indexing.h
@@ -25,4 +25,16 @@
 #pragma once
 
 #include <ATen/TensorIndexing.h>
-#include "neml2/misc/types.h"
+
+namespace at::indexing
+{
+struct Slice;
+struct TensorIndex;
+} // namespace at::indexing
+
+namespace neml2::indexing
+{
+using namespace at::indexing;
+using TensorIndices = c10::SmallVector<TensorIndex, 8>;
+using TensorIndicesRef = c10::ArrayRef<TensorIndex>;
+} // namespace neml2::indexing

--- a/include/neml2/tensors/shape_utils.h
+++ b/include/neml2/tensors/shape_utils.h
@@ -24,8 +24,7 @@
 
 #pragma once
 
-#include <vector>
-#include "neml2/tensors/indexing.h"
+#include "neml2/misc/types.h"
 #include "neml2/misc/errors.h"
 
 namespace neml2::utils

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -23,10 +23,13 @@ find_package(pybind11 CONFIG REQUIRED)
 # ----------------------------------------------------------------------------
 macro(add_submodule mname msrcs)
   pybind11_add_module(${mname} MODULE ${msrcs})
-  set_target_properties(${mname} PROPERTIES LIBRARY_OUTPUT_DIRECTORY neml2)
+  set_target_properties(${mname} PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY neml2
+    INSTALL_RPATH_USE_LINK_PATH ON
+  )
 
   target_include_directories(${mname} PUBLIC ${NEML2_SOURCE_DIR})
-  target_link_libraries(${mname} PRIVATE pybind11::headers)
+  target_link_libraries(${mname} PRIVATE pybind11::headers Torch::PythonBinding)
 
   install(TARGETS ${mname} LIBRARY DESTINATION . COMPONENT libneml2-python)
 
@@ -35,6 +38,14 @@ macro(add_submodule mname msrcs)
 
   # add to the stub generation
   add_dependencies(python_stub ${mname})
+
+  # pch
+  if(NEML2_PCH)
+    target_precompile_headers(${mname} PUBLIC
+      ${pybind11_INCLUDE_DIR}/pybind11/pybind11.h
+      ${pybind11_INCLUDE_DIR}/pybind11/operators.h
+    )
+  endif()
 endmacro()
 
 # ----------------------------------------------------------------------------
@@ -53,26 +64,21 @@ add_custom_target(python_stub
 add_library(pyneml2 INTERFACE)
 
 add_submodule(reserved neml2/reserved.cxx)
-target_link_libraries(reserved PRIVATE neml2_base Torch::PythonBinding)
-set_target_properties(reserved PROPERTIES INSTALL_RPATH_USE_LINK_PATH ON)
+target_link_libraries(reserved PRIVATE neml2_base)
 
 add_submodule(core neml2/core.cxx)
-target_link_libraries(core PRIVATE neml2 Torch::PythonBinding)
-set_target_properties(core PROPERTIES INSTALL_RPATH_USE_LINK_PATH ON)
+target_link_libraries(core PRIVATE neml2)
 
 file(GLOB_RECURSE tensors_srcs CONFIGURE_DEPENDS neml2/tensors/*.cxx)
 list(APPEND tensors_srcs neml2/tensors.cxx)
 add_submodule(tensors "${tensors_srcs}")
-target_link_libraries(tensors PRIVATE neml2_tensor Torch::PythonBinding)
-set_target_properties(tensors PROPERTIES INSTALL_RPATH_USE_LINK_PATH ON)
+target_link_libraries(tensors PRIVATE neml2_tensor)
 
 add_submodule(math neml2/math.cxx)
-target_link_libraries(math PRIVATE neml2_tensor Torch::PythonBinding)
-set_target_properties(math PROPERTIES INSTALL_RPATH_USE_LINK_PATH ON)
+target_link_libraries(math PRIVATE neml2_tensor)
 
 add_submodule(crystallography neml2/crystallography.cxx)
-target_link_libraries(crystallography PRIVATE neml2_tensor Torch::PythonBinding)
-set_target_properties(crystallography PROPERTIES INSTALL_RPATH_USE_LINK_PATH ON)
+target_link_libraries(crystallography PRIVATE neml2_tensor)
 
 # ----------------------------------------------------------------------------
 # Artifacts

--- a/python/neml2/crystallography.cxx
+++ b/python/neml2/crystallography.cxx
@@ -39,7 +39,7 @@ PYBIND11_MODULE(crystallography, m)
 
   m.def(
       "symmetry_operations_from_orbifold",
-      [](std::string orbifold, NEML2_TENSOR_OPTIONS_VARGS)
+      [](const std::string & orbifold, NEML2_TENSOR_OPTIONS_VARGS)
       {
         return crystallography::symmetry_operations_from_orbifold(orbifold, NEML2_TENSOR_OPTIONS);
       },

--- a/python/neml2/indexing.h
+++ b/python/neml2/indexing.h
@@ -27,9 +27,7 @@
 #include <torch/python.h>
 #include <torch/csrc/autograd/python_variable_indexing.h>
 
-namespace pybind11
-{
-namespace detail
+namespace pybind11::detail
 {
 /**
  * @brief Type conversion between Python object <--> at::indexing::Slice
@@ -142,5 +140,4 @@ public:
     return {};
   }
 };
-}
 }

--- a/python/neml2/math.cxx
+++ b/python/neml2/math.cxx
@@ -25,9 +25,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include "python/neml2/indexing.h"
-#include "python/neml2/types.h"
 #include "neml2/tensors/tensors.h"
+#include "neml2/tensors/mandel_notation.h"
 
 #include "neml2/tensors/functions/bmm.h"
 #include "neml2/tensors/functions/bmv.h"
@@ -49,7 +48,7 @@
 #include "neml2/tensors/functions/log.h"
 #include "neml2/tensors/functions/clip.h"
 
-#include "neml2/tensors/mandel_notation.h"
+#include "python/neml2/types.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/reserved.cxx
+++ b/python/neml2/reserved.cxx
@@ -26,8 +26,6 @@
 #include <pybind11/stl.h>
 #include "neml2/base/LabeledAxisAccessor.h"
 
-namespace py = pybind11;
-
 PYBIND11_MODULE(reserved, m)
 {
   m.doc() = "Reserved subaxis names";

--- a/python/neml2/tensors.cxx
+++ b/python/neml2/tensors.cxx
@@ -24,12 +24,13 @@
 
 #include <pybind11/pybind11.h>
 
-#include "neml2/tensors/macros.h"
+#include "neml2/tensors/tensors.h"
 
 #include "python/neml2/tensors/TensorBase.h"
 #include "python/neml2/tensors/PrimitiveTensor.h"
 #include "python/neml2/tensors/VecBase.h"
 #include "python/neml2/tensors/R2Base.h"
+#include "python/neml2/indexing.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/MillerIndex.cxx
+++ b/python/neml2/tensors/MillerIndex.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/MillerIndex.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/PrimitiveTensor.h
+++ b/python/neml2/tensors/PrimitiveTensor.h
@@ -26,7 +26,10 @@
 
 #include <pybind11/operators.h>
 
-#include "python/neml2/tensors/TensorBase.h"
+#include "neml2/misc/types.h"
+#include "neml2/tensors/Tensor.h"
+
+#include "python/neml2/types.h"
 
 namespace py = pybind11;
 

--- a/python/neml2/tensors/Quaternion.cxx
+++ b/python/neml2/tensors/Quaternion.cxx
@@ -22,7 +22,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/Quaternion.h"
+#include "neml2/tensors/Rot.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/R2.cxx
+++ b/python/neml2/tensors/R2.cxx
@@ -22,7 +22,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/R2Base.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include "neml2/tensors/R2.h"
+#include "neml2/tensors/Vec.h"
+#include "neml2/tensors/SR2.h"
+#include "neml2/tensors/WR2.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/R2Base.h
+++ b/python/neml2/tensors/R2Base.h
@@ -24,7 +24,9 @@
 
 #pragma once
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/Rot.h"
 
 namespace py = pybind11;
 

--- a/python/neml2/tensors/R3.cxx
+++ b/python/neml2/tensors/R3.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/R3.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/R4.cxx
+++ b/python/neml2/tensors/R4.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/R4.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/R5.cxx
+++ b/python/neml2/tensors/R5.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/R5.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/R8.cxx
+++ b/python/neml2/tensors/R8.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/R8.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/Rot.cxx
+++ b/python/neml2/tensors/Rot.cxx
@@ -22,7 +22,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/VecBase.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include "neml2/tensors/Rot.h"
+#include "neml2/tensors/Vec.h"
+#include "neml2/tensors/R3.h"
+
+#include "python/neml2/types.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/SFFR4.cxx
+++ b/python/neml2/tensors/SFFR4.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/SFFR4.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/SFR3.cxx
+++ b/python/neml2/tensors/SFR3.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/SFR3.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/SFR4.cxx
+++ b/python/neml2/tensors/SFR4.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/SFR4.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/SR2.cxx
+++ b/python/neml2/tensors/SR2.cxx
@@ -26,6 +26,7 @@
 
 #include "neml2/tensors/SR2.h"
 #include "neml2/tensors/R2.h"
+#include "neml2/tensors/Scalar.h"
 
 #include "python/neml2/types.h"
 

--- a/python/neml2/tensors/SR2.cxx
+++ b/python/neml2/tensors/SR2.cxx
@@ -22,7 +22,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/SR2.h"
+#include "neml2/tensors/R2.h"
+
+#include "python/neml2/types.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/SSFR5.cxx
+++ b/python/neml2/tensors/SSFR5.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/SSFR5.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/SSR4.cxx
+++ b/python/neml2/tensors/SSR4.cxx
@@ -22,7 +22,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include "neml2/tensors/SSR4.h"
+#include "neml2/tensors/SR2.h"
+#include "neml2/tensors/Rot.h"
+
+#include "python/neml2/types.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/SSSSR8.cxx
+++ b/python/neml2/tensors/SSSSR8.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/SSSSR8.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/SWR4.cxx
+++ b/python/neml2/tensors/SWR4.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/SWR4.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/Scalar.cxx
+++ b/python/neml2/tensors/Scalar.cxx
@@ -22,7 +22,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include "neml2/tensors/Scalar.h"
+#include "neml2/tensors/tensors.h"
+
+#include "python/neml2/types.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/Tensor.cxx
+++ b/python/neml2/tensors/Tensor.cxx
@@ -22,10 +22,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/TensorBase.h"
+#include <pybind11/pybind11.h>
 
-#include "neml2/tensors/macros.h"
+#include "neml2/tensors/Tensor.h"
+#include "neml2/tensors/tensors.h"
 #include "neml2/tensors/functions/pow.h"
+
+#include "python/neml2/types.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/TensorBase.h
+++ b/python/neml2/tensors/TensorBase.h
@@ -26,10 +26,8 @@
 
 #include <pybind11/operators.h>
 
-#include "python/neml2/indexing.h"
 #include "python/neml2/types.h"
-#include "neml2/tensors/tensors.h"
-#include "neml2/tensors/macros.h"
+#include "neml2/tensors/Scalar.h"
 #include "neml2/tensors/functions/pow.h"
 #include "neml2/misc/string_utils.h"
 

--- a/python/neml2/tensors/Vec.cxx
+++ b/python/neml2/tensors/Vec.cxx
@@ -22,7 +22,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/VecBase.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/Vec.h"
+#include "neml2/tensors/Rot.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/VecBase.h
+++ b/python/neml2/tensors/VecBase.h
@@ -26,7 +26,10 @@
 
 #include <pybind11/operators.h>
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include "neml2/misc/types.h"
+#include "neml2/tensors/Rot.h"
+
+#include "python/neml2/types.h"
 
 namespace py = pybind11;
 

--- a/python/neml2/tensors/WFR4.cxx
+++ b/python/neml2/tensors/WFR4.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/WFR4.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/WR2.cxx
+++ b/python/neml2/tensors/WR2.cxx
@@ -22,7 +22,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/VecBase.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/WR2.h"
+#include "neml2/tensors/R2.h"
+#include "neml2/tensors/Rot.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/WSR4.cxx
+++ b/python/neml2/tensors/WSR4.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/WSR4.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/tensors/WWR4.cxx
+++ b/python/neml2/tensors/WWR4.cxx
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "python/neml2/tensors/PrimitiveTensor.h"
+#include <pybind11/pybind11.h>
+
+#include "neml2/tensors/WWR4.h"
 
 namespace py = pybind11;
 using namespace neml2;

--- a/python/neml2/types.h
+++ b/python/neml2/types.h
@@ -29,8 +29,7 @@
 #include <torch/csrc/utils/tensor_dtypes.h>
 #include <torch/csrc/DynamicTypes.h>
 
-#include "neml2/misc/types.h"
-#include "neml2/base/LabeledAxisAccessor.h"
+#include "neml2/tensors/indexing.h"
 
 #define NEML2_TENSOR_OPTIONS_VARGS const Dtype &dtype, const Device &device, bool requires_grad
 
@@ -41,9 +40,7 @@
   pybind11::arg("dtype") = Dtype(torch::kFloat64), pybind11::arg("device") = Device(torch::kCPU),  \
   pybind11::arg("requires_grad") = false
 
-namespace pybind11
-{
-namespace detail
+namespace pybind11::detail
 {
 #if TORCH_VERSION_MAJOR < 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR < 4)
 /**
@@ -116,5 +113,4 @@ public:
     return l;
   }
 };
-}
-}
+} // namespace pybind11::detail

--- a/scripts/filter_cc.py
+++ b/scripts/filter_cc.py
@@ -40,9 +40,12 @@ def batch(alist, n=1):
         yield alist[ndx : min(ndx + n, l)]
 
 
-def filter_compile_commands(compile_commands, srcs, headers):
+def filter_compile_commands(compile_commands, srcs, headers, include_dirs):
+    included = lambda f: any(f.startswith(d) for d in include_dirs)
     filtered = []
     for cmd in compile_commands:
+        if not included(cmd["file"]):
+            continue
         if cmd["file"] in srcs:
             filtered.append(cmd)
             print(cmd["file"])
@@ -89,6 +92,13 @@ if __name__ == "__main__":
         default=["HEAD", "origin/main"],
         help="Only include compile commands for files that are different between two SHAs.",
     )
+    parser.add_argument(
+        "-i",
+        "--include-dirs",
+        type=str,
+        default="src/neml2",
+        help="A comma-separated list of directories. Only include compile commands for files in these directories. Specify these directories relative to the root of the repository.",
+    )
 
     # parse cliargs
     args = parser.parse_args()
@@ -99,6 +109,9 @@ if __name__ == "__main__":
     output = Path(args.output)
     sha1 = args.diff[0]
     sha2 = args.diff[1]
+    root = Path(__file__).parent.parent
+    include_dirs = args.include_dirs.split(",")
+    include_dirs = [str((root / d).resolve()) for d in include_dirs]
 
     # get list of files that are different between two SHAs
     diff_files = subprocess.run(
@@ -119,7 +132,7 @@ if __name__ == "__main__":
     print("Files to be included in compile_commands.json:")
     executor = concurrent.futures.ProcessPoolExecutor(multiprocessing.cpu_count())
     futures = [
-        executor.submit(filter_compile_commands, group, srcs, headers)
+        executor.submit(filter_compile_commands, group, srcs, headers, include_dirs)
         for group in batch(compile_commands, 10)
     ]
     concurrent.futures.wait(futures)

--- a/src/neml2/base/DiagnosticsInterface.cxx
+++ b/src/neml2/base/DiagnosticsInterface.cxx
@@ -24,7 +24,6 @@
 
 #include "neml2/base/DiagnosticsInterface.h"
 #include "neml2/base/NEML2Object.h"
-#include "neml2/misc/assertions.h"
 
 namespace neml2
 {

--- a/src/neml2/base/EnumSelection.cxx
+++ b/src/neml2/base/EnumSelection.cxx
@@ -23,7 +23,6 @@
 // THE SOFTWARE.
 
 #include "neml2/base/EnumSelection.h"
-#include "neml2/misc/string_utils.h"
 #include "neml2/misc/assertions.h"
 
 namespace neml2

--- a/src/neml2/base/EnumSelectionBase.cxx
+++ b/src/neml2/base/EnumSelectionBase.cxx
@@ -22,8 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "neml2/base/EnumSelection.h"
-#include "neml2/misc/string_utils.h"
+#include <set>
+
+#include "neml2/base/EnumSelectionBase.h"
 #include "neml2/misc/assertions.h"
 
 namespace neml2

--- a/src/neml2/base/HITParser.cxx
+++ b/src/neml2/base/HITParser.cxx
@@ -22,6 +22,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include "hit/braceexpr.h"
+
 #include "neml2/base/HITParser.h"
 #include "neml2/base/Registry.h"
 #include "neml2/base/Factory.h"

--- a/src/neml2/base/LabeledAxis.cxx
+++ b/src/neml2/base/LabeledAxis.cxx
@@ -23,10 +23,9 @@
 // THE SOFTWARE.
 
 #include "neml2/base/LabeledAxis.h"
-#include "neml2/tensors/indexing.h"
 #include "neml2/tensors/shape_utils.h"
-#include "neml2/misc/assertions.h"
 #include "neml2/tensors/tensors.h"
+#include "neml2/misc/assertions.h"
 
 namespace neml2
 {

--- a/src/neml2/base/LabeledAxisAccessor.cxx
+++ b/src/neml2/base/LabeledAxisAccessor.cxx
@@ -109,7 +109,7 @@ LabeledAxisAccessor::slice(int64_t n1, int64_t n2) const
 }
 
 LabeledAxisAccessor
-LabeledAxisAccessor::remount(const LabeledAxisAccessor & axis, Size n) const
+LabeledAxisAccessor::remount(const LabeledAxisAccessor & axis, int64_t n) const
 {
   return slice(n).prepend(axis);
 }

--- a/src/neml2/base/Parser.cxx
+++ b/src/neml2/base/Parser.cxx
@@ -25,8 +25,7 @@
 #include <iostream>
 
 #include "neml2/base/Parser.h"
-#include "neml2/base/OptionCollection.h"
-#include "neml2/models/Variable.h"
+#include "neml2/base/LabeledAxisAccessor.h"
 
 namespace neml2
 {

--- a/src/neml2/base/TensorName.cxx
+++ b/src/neml2/base/TensorName.cxx
@@ -27,7 +27,6 @@
 #include "neml2/base/TensorName.h"
 #include "neml2/base/Factory.h"
 #include "neml2/base/Parser.h"
-#include "neml2/base/LabeledAxisAccessor.h"
 
 namespace neml2
 {

--- a/src/neml2/dispatchers/derivmap_helpers.cxx
+++ b/src/neml2/dispatchers/derivmap_helpers.cxx
@@ -23,6 +23,7 @@
 // THE SOFTWARE.
 
 #include "neml2/dispatchers/derivmap_helpers.h"
+#include "neml2/misc/errors.h"
 #include "neml2/tensors/functions/cat.h"
 
 namespace neml2

--- a/src/neml2/models/LinearInterpolation.cxx
+++ b/src/neml2/models/LinearInterpolation.cxx
@@ -27,6 +27,7 @@
 #include "neml2/tensors/Scalar.h"
 #include "neml2/tensors/Vec.h"
 #include "neml2/tensors/SR2.h"
+#include "neml2/tensors/indexing.h"
 
 namespace neml2
 {

--- a/src/neml2/tensors/Tensor.cxx
+++ b/src/neml2/tensors/Tensor.cxx
@@ -24,7 +24,9 @@
 
 #include <torch/csrc/autograd/variable.h>
 #include "neml2/tensors/Tensor.h"
-#include "neml2/tensors/assertions.h"
+#include "neml2/tensors/shape_utils.h"
+#include "neml2/misc/assertions.h"
+#include "neml2/jit/types.h"
 
 namespace neml2
 {

--- a/src/neml2/tensors/functions/diff.cxx
+++ b/src/neml2/tensors/functions/diff.cxx
@@ -28,7 +28,7 @@
 namespace neml2
 {
 #define DEFINE_DIFF(T)                                                                             \
-  T diff(const T & a, Size n, Size dim) { return T(at::diff(a, n, dim), a.batch_sizes()); }        \
+  T diff(const T & a, Size n, Size dim) { return T(at::diff(a, n, dim), a.batch_dim()); }          \
   static_assert(true)
 FOR_ALL_TENSORBASE(DEFINE_DIFF);
 } // namespace neml2

--- a/src/neml2/tensors/mandel_notation.cxx
+++ b/src/neml2/tensors/mandel_notation.cxx
@@ -24,6 +24,7 @@
 
 #include "neml2/tensors/mandel_notation.h"
 #include "neml2/tensors/TensorCache.h"
+#include "neml2/tensors/shape_utils.h"
 
 namespace neml2
 {

--- a/src/neml2/tensors/shape_utils.cxx
+++ b/src/neml2/tensors/shape_utils.cxx
@@ -22,6 +22,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <numeric>
+
 #include "neml2/tensors/shape_utils.h"
 
 namespace neml2::utils

--- a/tests/include/TransientRegression.h
+++ b/tests/include/TransientRegression.h
@@ -24,9 +24,10 @@
 
 #pragma once
 
-#include "neml2/drivers/Driver.h"
-
 #include <filesystem>
+
+#include "neml2/drivers/Driver.h"
+#include "neml2/jit/types.h"
 
 namespace neml2
 {

--- a/tests/include/VTestVerification.h
+++ b/tests/include/VTestVerification.h
@@ -64,9 +64,4 @@ private:
   Real _rtol;
   Real _atol;
 };
-
-std::string diff(const jit::named_buffer_list & res,
-                 const std::map<std::string, ATensor> & ref_map,
-                 Real rtol,
-                 Real atol);
 } // namespace neml2

--- a/tests/include/utils.h
+++ b/tests/include/utils.h
@@ -26,6 +26,7 @@
 
 #include "neml2/base/Parser.h"
 #include "neml2/base/Factory.h"
+#include "neml2/tensors/indexing.h"
 #include "neml2/tensors/Scalar.h"
 #include "neml2/tensors/functions/abs.h"
 #include "neml2/tensors/functions/stack.h"

--- a/tests/src/ModelUnitTest.cxx
+++ b/tests/src/ModelUnitTest.cxx
@@ -36,8 +36,8 @@ set_variable(ValueMap & storage,
              const std::string & option_vars,
              const std::string & option_vals)
 {
-  const auto vars = options.get<std::vector<VariableName>>(option_vars);
-  const auto vals = options.get<std::vector<TensorName<T>>>(option_vals);
+  const auto & vars = options.get<std::vector<VariableName>>(option_vars);
+  const auto & vals = options.get<std::vector<TensorName<T>>>(option_vals);
   neml_assert(vars.size() == vals.size(),
               "Trying to assign ",
               vals.size(),

--- a/tests/src/VTestVerification.cxx
+++ b/tests/src/VTestVerification.cxx
@@ -32,6 +32,11 @@
 
 namespace neml2
 {
+static std::string diff(const torch::jit::named_buffer_list & res,
+                        const std::map<std::string, ATensor> & ref_map,
+                        Real rtol,
+                        Real atol);
+
 register_NEML2_object(VTestVerification);
 
 OptionSet
@@ -80,7 +85,7 @@ VTestVerification::run()
 {
   _driver.run();
 
-  auto res = jit::load(_driver.save_as_path());
+  auto res = torch::jit::load(_driver.save_as_path());
   auto err_msg = diff(res.named_buffers(), _ref, _rtol, _atol);
 
   neml_assert(err_msg.empty(), err_msg);
@@ -89,7 +94,7 @@ VTestVerification::run()
 }
 
 std::string
-diff(const jit::named_buffer_list & res,
+diff(const torch::jit::named_buffer_list & res,
      const std::map<std::string, ATensor> & ref_map,
      Real rtol,
      Real atol)

--- a/tests/unit/models/test_LabeledAxis.cxx
+++ b/tests/unit/models/test_LabeledAxis.cxx
@@ -27,6 +27,7 @@
 #include <catch2/matchers/catch_matchers_templated.hpp>
 
 #include "neml2/base/LabeledAxis.h"
+#include "neml2/misc/string_utils.h"
 #include "neml2/tensors/tensors.h"
 
 using namespace neml2;


### PR DESCRIPTION
- ~`Tensor::operator=(torch::Tensor)` assumes the original (LHS) batch shape~
- ~`Tensor::operator=(neml2::TensorBase)` makes no assumption~
- ~`PrimitiveTensor::operator=(torch::Tensor)` infers batch shape~
- ~`PrimitiveTensor::operator=(neml2::TensorBase)` makes no assumption~

~Basic error checks are added to make sure shapes are compatible.~

~Note `PrimitiveTensor::operator=(torch::Tensor)` is disabled during tracing, because inferring batch shape makes it difficult to optimize the traced function graph.~

* More forward declaration
* Only include necessary header files