### PR TITLE
Make torch_python an optional dependency

### DIFF
--- a/cmake/Modules/FindTorch.cmake
+++ b/cmake/Modules/FindTorch.cmake
@@ -21,7 +21,7 @@
 #
 # This module defines the following imported targets:
 # - Torch::Torch, the C++ backend of pytorch
-# - Torch::PythonBinding, the python binding of pytorch
+# - Torch::TorchWithPybind, the python binding of pytorch
 
 # -----------------------------------------------------------------------------
 # Hints to the find_path and find_library commands
@@ -56,6 +56,21 @@ find_library(Torch_CUDA_LIBRARY NAMES torch_cuda PATHS ${Torch_LINK_DIR} NO_CACH
 find_library(Torch_CUDA_LINALG_LIBRARY NAMES torch_cuda_linalg PATHS ${Torch_LINK_DIR} NO_CACHE)
 
 # -----------------------------------------------------------------------------
+# optional components
+# -----------------------------------------------------------------------------
+if(Torch_FIND_COMPONENTS)
+  foreach(component IN LISTS Torch_FIND_COMPONENTS)
+    if(component STREQUAL "PythonBinding")
+      find_library(Torch_PYTHON_LIBRARY NAMES torch_python HINTS ${Torch_LINK_DIR_HINTS} NO_CACHE)
+
+      if(Torch_PYTHON_LIBRARY)
+        set(Torch_PythonBinding_FOUND TRUE)
+      endif()
+    endif()
+  endforeach()
+endif()
+
+# -----------------------------------------------------------------------------
 # Check if we found everything
 # -----------------------------------------------------------------------------
 include(FindPackageHandleStandardArgs)
@@ -67,7 +82,7 @@ find_package_handle_standard_args(
   C10_LIBRARY
   Torch_LIBRARY
   Torch_CPU_LIBRARY
-  Torch_PYTHON_LIBRARY
+  HANDLE_COMPONENTS
 )
 
 if(Torch_FOUND)
@@ -152,8 +167,10 @@ if(Torch_FOUND)
     target_link_libraries(Torch::Torch INTERFACE ${Torch_LIBRARIES})
   endif()
 
-  if(NOT TARGET Torch::PythonBinding)
-    add_library(Torch::PythonBinding INTERFACE IMPORTED)
-    target_link_libraries(Torch::PythonBinding INTERFACE Torch::Torch ${Torch_PYTHON_LIBRARY})
+  if(Torch_PythonBinding_FOUND)
+    if(NOT TARGET Torch::TorchWithPybind)
+      add_library(Torch::TorchWithPybind INTERFACE IMPORTED)
+      target_link_libraries(Torch::TorchWithPybind INTERFACE Torch::Torch ${Torch_PYTHON_LIBRARY})
+    endif()
   endif()
 endif()

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,3 +1,9 @@
+if(NOT NEML2_PYBIND)
+  message(WARNING "Documentation generation requires Python bindings to be built. Reverting NEML2_DOC to OFF.")
+  set(NEML2_DOC OFF CACHE BOOL "Build NEML2 documentation (html)" FORCE)
+  return()
+endif()
+
 # ----------------------------------------------------------------------------
 # Python
 # ----------------------------------------------------------------------------

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,6 +7,14 @@ if(NOT Torch_IS_PYTHON_PACKAGE)
   return()
 endif()
 
+find_package(Torch OPTIONAL_COMPONENTS PythonBinding)
+
+if(NOT Torch_PythonBinding_FOUND)
+  message(WARNING "Torch Python bindings not found. If you built torch from source, you need to build it with the Python bindings enabled. Reverting NEML2_PYBIND to OFF.")
+  set(NEML2_PYBIND OFF CACHE BOOL "Build Python bindings" FORCE)
+  return()
+endif()
+
 # ----------------------------------------------------------------------------
 # pybind11
 # ----------------------------------------------------------------------------
@@ -29,7 +37,7 @@ macro(add_submodule mname msrcs)
   )
 
   target_include_directories(${mname} PUBLIC ${NEML2_SOURCE_DIR})
-  target_link_libraries(${mname} PRIVATE pybind11::headers Torch::PythonBinding)
+  target_link_libraries(${mname} PRIVATE pybind11::headers Torch::TorchWithPybind)
 
   install(TARGETS ${mname} LIBRARY DESTINATION . COMPONENT libneml2-python)
 


### PR DESCRIPTION
We currently always require the presence of torch_python. But technically speaking, we only need that library if NEML2_PYBIND is true.

- Add an optional component in FindTorch.cmake
- Handle Torch_PythonBinding_FOUND appropriately in python/CMakeLists.txt
- Make NEML2_DOC depend on NEML2_PYBIND