### PR TITLE
hotfix for export config and pch

### DIFF
--- a/.github/workflows/cmake_integration.yml
+++ b/.github/workflows/cmake_integration.yml
@@ -42,7 +42,7 @@ jobs:
           torch-version: 2.5.1
       - name: Install neml2
         run: |
-          cmake --preset release -GNinja -S neml2-src -B neml2-build
+          cmake --preset release -GNinja -S neml2-src -B neml2-build -DNEML2_PYBIND=OFF
           cmake --build neml2-build
           cmake --install neml2-build --prefix neml2-install --component libneml2
       - name: Create an example CMake project

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ contrib/doxygen-awesome-css*
 contrib/hit*
 contrib/json*
 contrib/timpi*
-contrib/Torch*
+contrib/torch*
 contrib/wasp*
 contrib/gperftools*
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(NEML2_WHEEL OFF CACHE INTERNAL "Build NEML2 as a Python wheel. This is suppo
 # Dependencies and 3rd party packages
 # ----------------------------------------------------------------------------
 set(torch_VERSION "2.5.1" CACHE STRING "Default libTorch/PyTorch version to download")
+set(torch_SEARCH_SITE_PACKAGES ON CACHE BOOL "Search for libTorch in Python site-packages")
 set(Doxygen_VERSION "1.12.0" CACHE STRING "Default doxygen version to download")
 set(doxygen_awesome_css_VERSION "v2.3.4" CACHE STRING "Default doxygen-awesome version to download")
 set(wasp_VERSION "cf46fbd0d224cc2a70edbc668d3e65d45bec9e16" CACHE STRING "Default WASP version to download (if not found)")
@@ -135,7 +136,8 @@ if(NOT torch_FOUND)
 
       if(torch_URL)
             download_from_url(torch ${torch_URL} ${NEML2_CONTRIB_PREFIX})
-            find_package(torch REQUIRED OPTIONAL_COMPONENTS cuda python PATHS ${torch_SOURCE_DIR} NO_DEFAULT_PATH)
+            set(torch_ROOT ${NEML2_CONTRIB_PREFIX}/torch-src)
+            find_package(torch MODULE REQUIRED OPTIONAL_COMPONENTS cuda python)
       else()
             message(FATAL_ERROR "Torch not found and no download URL provided.")
       endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,14 @@ include(DepUtils)
 # Python3
 # ----------------------------------------------------------------------------
 find_package(Python3 COMPONENTS Interpreter OPTIONAL_COMPONENTS Development.Module)
+# If Python3 is found, let's also find the user site-packages (in case torch is installed there)
+if(Python3_EXECUTABLE)
+      execute_process(
+            COMMAND ${Python3_EXECUTABLE} -m site --user-site
+            OUTPUT_VARIABLE Python3_USER_SITE
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+endif()
 
 # ----------------------------------------------------------------------------
 # The following blocks are used to find and download 3rd party dependencies

--- a/cmake/Modules/Findtorch.cmake
+++ b/cmake/Modules/Findtorch.cmake
@@ -37,6 +37,10 @@ if(NEML2_CONTRIB_PREFIX)
   list(APPEND _torch_search_paths ${NEML2_CONTRIB_PREFIX}/torch-src)
 endif()
 
+if(torch_SEARCH_SITE_PACKAGES AND Python3_USER_SITE)
+  list(APPEND _torch_search_paths ${Python3_USER_SITE}/torch)
+endif()
+
 if(torch_SEARCH_SITE_PACKAGES AND Python3_SITEARCH)
   list(APPEND _torch_search_paths ${Python3_SITEARCH}/torch)
 endif()

--- a/cmake/Modules/Findtorch.cmake
+++ b/cmake/Modules/Findtorch.cmake
@@ -34,10 +34,10 @@ set(_torch_search_paths
 )
 
 if(NEML2_CONTRIB_PREFIX)
-  list(APPEND _torch_search_paths ${NEML2_CONTRIB_PREFIX}/torch)
+  list(APPEND _torch_search_paths ${NEML2_CONTRIB_PREFIX}/torch-src)
 endif()
 
-if(Python3_SITEARCH)
+if(torch_SEARCH_SITE_PACKAGES AND Python3_SITEARCH)
   list(APPEND _torch_search_paths ${Python3_SITEARCH}/torch)
 endif()
 

--- a/cmake/neml2Config.cmake.in
+++ b/cmake/neml2Config.cmake.in
@@ -5,6 +5,15 @@ include(CMakeFindDependencyMacro)
 include("${CMAKE_CURRENT_LIST_DIR}/neml2targets.cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/Modules")
 
+# Compute the installation prefix relative to this file.
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+if(_IMPORT_PREFIX STREQUAL "/")
+  set(_IMPORT_PREFIX "")
+endif()
+
 # torch
 set(torch_ROOT @torch_ROOT@)
 if(@torch_cuda_FOUND@)
@@ -14,27 +23,27 @@ else()
 endif()
 
 # wasp
-set(wasp_ROOT @wasp_ROOT@)
+set(wasp_ROOT ${_IMPORT_PREFIX})
 find_dependency(wasp MODULE REQUIRED COMPONENTS core hit)
 
 # hit
-set(hit_ROOT @hit_ROOT@)
+set(hit_ROOT ${_IMPORT_PREFIX})
 find_dependency(hit MODULE REQUIRED)
 
 # timpi
 if(@timpi_FOUND@)
   set(timpi_BUILD_TYPE @timpi_BUILD_TYPE@)
-  set(timpi_ROOT @timpi_ROOT@)
+  set(timpi_ROOT ${_IMPORT_PREFIX})
   find_dependency(timpi MODULE REQUIRED)
 endif()
 
 # json
 if(@NEML2_JSON@)
-  find_dependency(nlohmann_json CONFIG REQUIRED PATHS @nlohmann_json_DIR@ NO_DEFAULT_PATH)
+  find_dependency(nlohmann_json CONFIG REQUIRED PATHS ${_IMPORT_PREFIX} NO_DEFAULT_PATH)
 endif()
 
 # gperftools
 if(@gperftools_FOUND@)
-  set(gperftools_ROOT @gperftools_ROOT@)
+  set(gperftools_ROOT ${_IMPORT_PREFIX})
   find_dependency(gperftools MODULE REQUIRED COMPONENTS profiler)
 endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 get_target_property(torch_LINK_DIR torch::python INTERFACE_LINK_DIRECTORIES)
 
-if(NOT ${torch_LINK_DIR} STREQUAL ${Python3_SITEARCH}/torch/lib)
+if(NOT ${torch_LINK_DIR} STREQUAL ${Python3_SITEARCH}/torch/lib AND NOT ${torch_LINK_DIR} STREQUAL ${Python3_USER_SITE}/torch/lib)
   message(WARNING "Python bindings can only be built against a Torch python package. Although a Torch is found, it does not appear to come from Python site packages. Reverting NEML2_PYBIND to OFF.")
   set(NEML2_PYBIND OFF CACHE BOOL "Build Python bindings" FORCE)
   return()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -55,14 +55,6 @@ macro(add_submodule mname malias msrcs)
 
   # add to the stub generation
   add_dependencies(python_stub ${mname})
-
-  # pch
-  if(NEML2_PCH)
-    target_precompile_headers(${mname} PUBLIC
-      ${pybind11_INCLUDE_DIR}/pybind11/pybind11.h
-      ${pybind11_INCLUDE_DIR}/pybind11/operators.h
-    )
-  endif()
 endmacro()
 
 # ----------------------------------------------------------------------------

--- a/src/neml2/CMakeLists.txt
+++ b/src/neml2/CMakeLists.txt
@@ -61,8 +61,8 @@ endif()
 
 if(NEML2_PCH)
   target_precompile_headers(misc PUBLIC
-    ${NEML2_SOURCE_DIR}/include/neml2/misc/types.h
-    ${NEML2_SOURCE_DIR}/include/neml2/misc/assertions.h
+    <neml2/misc/types.h>
+    <neml2/misc/assertions.h>
   )
 endif()
 
@@ -71,7 +71,7 @@ neml2_add_submodule(jit SHARED jit)
 target_link_libraries(jit PUBLIC misc)
 
 if(NEML2_PCH)
-  target_precompile_headers(jit PUBLIC ${NEML2_SOURCE_DIR}/include/neml2/jit/types.h)
+  target_precompile_headers(jit PUBLIC <neml2/jit/types.h>)
 endif()
 
 # libneml2_tensor
@@ -80,11 +80,11 @@ target_link_libraries(tensor PUBLIC jit)
 
 if(NEML2_PCH)
   target_precompile_headers(tensor PUBLIC
-    ${NEML2_SOURCE_DIR}/include/neml2/tensors/TensorBase.h
-    ${NEML2_SOURCE_DIR}/include/neml2/tensors/TensorBaseImpl.h
-    ${NEML2_SOURCE_DIR}/include/neml2/tensors/PrimitiveTensor.h
-    ${NEML2_SOURCE_DIR}/include/neml2/tensors/assertions.h
-    ${NEML2_SOURCE_DIR}/include/neml2/tensors/shape_utils.h
+    <neml2/tensors/TensorBase.h>
+    <neml2/tensors/TensorBaseImpl.h>
+    <neml2/tensors/PrimitiveTensor.h>
+    <neml2/tensors/assertions.h>
+    <neml2/tensors/shape_utils.h>
   )
 endif()
 
@@ -94,10 +94,10 @@ target_link_libraries(base PUBLIC tensor hit)
 
 if(NEML2_PCH)
   target_precompile_headers(base PUBLIC
-    ${NEML2_SOURCE_DIR}/include/neml2/base/Registry.h
-    ${NEML2_SOURCE_DIR}/include/neml2/base/Factory.h
-    ${NEML2_SOURCE_DIR}/include/neml2/base/Option.h
-    ${NEML2_SOURCE_DIR}/include/neml2/base/TensorName.h
+    <neml2/base/Registry.h>
+    <neml2/base/Factory.h>
+    <neml2/base/Option.h>
+    <neml2/base/TensorName.h>
   )
 endif()
 
@@ -118,7 +118,7 @@ target_link_options(model INTERFACE ${CMAKE_CXX_LINK_WHAT_YOU_USE_FLAG})
 
 if(NEML2_PCH)
   target_precompile_headers(model PUBLIC
-    ${NEML2_SOURCE_DIR}/include/neml2/models/Model.h
+    <neml2/models/Model.h>
   )
 endif()
 


### PR DESCRIPTION
PCH should populate the INTERFACE_PRECOMPILE_HEADERS using relative path

The roots for find_dependency should use IMPORT_PREFIX