### PR TITLE
Use a better contrib install logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ contrib/Catch2*
 contrib/Doxygen*
 contrib/doxygen-awesome-css*
 contrib/hit*
-contrib/json*
+contrib/nlohmann_json*
 contrib/timpi*
 contrib/torch*
 contrib/wasp*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ if(NOT torch_FOUND)
             set(torch_ROOT ${NEML2_CONTRIB_PREFIX}/torch-src)
             find_package(torch MODULE REQUIRED OPTIONAL_COMPONENTS cuda python)
       else()
-            message(FATAL_ERROR "Torch not found and no download URL provided.")
+            message(FATAL_ERROR "Torch not found.")
       endif()
 endif()
 
@@ -350,9 +350,7 @@ endif()
 # argparse
 # ----------------------------------------------------------------------------
 if(NEML2_RUNNER)
-      if(NOT DEFINED argparse_INSTALL_PREFIX)
-            find_package(argparse CONFIG HINTS ${NEML2_CONTRIB_PREFIX}/argparse)
-      endif()
+      find_package(argparse CONFIG HINTS ${NEML2_CONTRIB_PREFIX}/argparse)
 
       if(NOT argparse_FOUND)
             download_from_git(argparse https://github.com/p-ranav/argparse.git ${NEML2_CONTRIB_PREFIX} ${argparse_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,8 +156,10 @@ endif()
 # For a standard NEML2 installation, we add the absolute link path to the torch
 # libraries as rpath.
 #
-# For a wheel installation, we additionally prepend the rpaths ../torch/lib and
-# ../../torch/lib assuming the wheel is installed in a standard location.
+# For a wheel installation, we prepend the rpaths
+#   ../torch/lib
+#   ../../torch/lib
+# assuming the wheel is installed in a standard site-packages location alongside torch.
 
 # find_package(neml2 CONFIG) will rely on the Findtorch.cmake module
 install(FILES
@@ -179,10 +181,15 @@ if(NOT wasp_FOUND)
       find_package(wasp MODULE REQUIRED COMPONENTS core hit)
 endif()
 
-# wasp will be packaged as part of the NEML2 installation.
-install_glob(${wasp_core_LIBRARY} lib libneml2)
-install_glob(${wasp_hit_LIBRARY} lib libneml2)
-install(DIRECTORY ${wasp_core_INCLUDE_DIR}/waspcore ${wasp_hit_INCLUDE_DIR}/wasphit TYPE INCLUDE COMPONENT libneml2)
+# check if wasp is downloaded
+path_has_prefix(${wasp_ROOT} ${NEML2_CONTRIB_PREFIX} wasp_CONTRIB)
+
+# wasp will be packaged as part of the NEML2 installation if it was downloaded by us (or if it is being built as a wheel).
+if(wasp_CONTRIB OR NEML2_WHEEL)
+      install_glob(${wasp_core_LIBRARY} lib libneml2)
+      install_glob(${wasp_hit_LIBRARY} lib libneml2)
+      install(DIRECTORY ${wasp_core_INCLUDE_DIR}/waspcore ${wasp_hit_INCLUDE_DIR}/wasphit TYPE INCLUDE COMPONENT libneml2)
+endif()
 install(FILES ${NEML2_SOURCE_DIR}/cmake/Modules/Findwasp.cmake DESTINATION share/cmake/neml2/Modules COMPONENT libneml2)
 
 # ----------------------------------------------------------------------------
@@ -204,9 +211,14 @@ if(NOT hit_FOUND)
       find_package(hit MODULE REQUIRED)
 endif()
 
-# hit will be packaged as part of the NEML2 installation.
-install(FILES ${hit_LIBRARY} TYPE LIB COMPONENT libneml2)
-install(DIRECTORY ${hit_INCLUDE_DIR}/hit TYPE INCLUDE COMPONENT libneml2)
+# check if hit is downloaded
+path_has_prefix(${hit_ROOT} ${NEML2_CONTRIB_PREFIX} hit_CONTRIB)
+
+# hit will be packaged as part of the NEML2 installation if it was downloaded by us (or if it is being built as a wheel).
+if(hit_CONTRIB OR NEML2_WHEEL)
+      install(FILES ${hit_LIBRARY} TYPE LIB COMPONENT libneml2)
+      install(DIRECTORY ${hit_INCLUDE_DIR}/hit TYPE INCLUDE COMPONENT libneml2)
+endif()
 install(FILES ${NEML2_SOURCE_DIR}/cmake/Modules/Findhit.cmake DESTINATION share/cmake/neml2/Modules COMPONENT libneml2)
 
 # ----------------------------------------------------------------------------
@@ -225,9 +237,14 @@ if(NEML2_WORK_DISPATCHER)
             find_package(timpi MODULE REQUIRED)
       endif()
 
-      # timpi will be packaged as part of the NEML2 installation.
-      install_glob(${timpi_LIBRARY} lib libneml2)
-      install(DIRECTORY ${timpi_INCLUDE_DIR}/timpi TYPE INCLUDE COMPONENT libneml2)
+      # check if timpi is downloaded
+      path_has_prefix(${timpi_ROOT} ${NEML2_CONTRIB_PREFIX} timpi_CONTRIB)
+
+      # timpi will be packaged as part of the NEML2 installation if it was downloaded by us (or if it is being built as a wheel).
+      if(timpi_CONTRIB OR NEML2_WHEEL)
+            install_glob(${timpi_LIBRARY} lib libneml2)
+            install(DIRECTORY ${timpi_INCLUDE_DIR}/timpi TYPE INCLUDE COMPONENT libneml2)
+      endif()
       install(FILES ${NEML2_SOURCE_DIR}/cmake/Modules/Findtimpi.cmake DESTINATION share/cmake/neml2/Modules COMPONENT libneml2)
 endif()
 
@@ -238,15 +255,20 @@ if(NEML2_JSON)
       find_package(nlohmann_json CONFIG HINTS ${NEML2_CONTRIB_PREFIX}/json)
 
       if(NOT nlohmann_json_FOUND)
-            download_from_git(json https://github.com/nlohmann/json.git ${NEML2_CONTRIB_PREFIX} ${nlohmann_json_VERSION})
-            set(nlohmann_json_INSTALL_PREFIX ${NEML2_CONTRIB_PREFIX}/json CACHE PATH "nlohmann json install prefix")
-            custom_install(json contrib/install_nlohmann_json.sh ${NEML2_CONTRIB_PREFIX}/json-src ${NEML2_CONTRIB_PREFIX}/json-build ${nlohmann_json_INSTALL_PREFIX})
+            download_from_git(nlohmann_json https://github.com/nlohmann/json.git ${NEML2_CONTRIB_PREFIX} ${nlohmann_json_VERSION})
+            set(nlohmann_json_INSTALL_PREFIX ${NEML2_CONTRIB_PREFIX}/nlohmann_json CACHE PATH "nlohmann json install prefix")
+            custom_install(nlohmann_json contrib/install_nlohmann_json.sh ${NEML2_CONTRIB_PREFIX}/nlohmann_json-src ${NEML2_CONTRIB_PREFIX}/nlohmann_json-build ${nlohmann_json_INSTALL_PREFIX})
             find_package(nlohmann_json CONFIG REQUIRED PATHS ${nlohmann_json_INSTALL_PREFIX} NO_DEFAULT_PATH)
       endif()
-
-      # nlohmann json will be packaged as part of the NEML2 installation.
       file(REAL_PATH "../../../" nlohmann_json_DIR BASE_DIRECTORY ${nlohmann_json_DIR})
-      install(DIRECTORY ${nlohmann_json_DIR}/include/nlohmann TYPE INCLUDE COMPONENT libneml2)
+
+      # check if nlohmann json is downloaded
+      path_has_prefix(${nlohmann_json_DIR} ${NEML2_CONTRIB_PREFIX} nlohmann_json_CONTRIB)
+
+      # nlohmann json will be packaged as part of the NEML2 installation if it was downloaded by us (or if it is being built as a wheel).
+      if(nlohmann_json_CONTRIB OR NEML2_WHEEL)
+            install(DIRECTORY ${nlohmann_json_DIR}/include/nlohmann TYPE INCLUDE COMPONENT libneml2)
+      endif()
       install(DIRECTORY ${nlohmann_json_DIR}/share/ DESTINATION share COMPONENT libneml2)
 endif()
 
@@ -270,8 +292,13 @@ if(NEML2_TESTS OR NEML2_RUNNER)
                   find_package(gperftools MODULE REQUIRED COMPONENTS profiler)
             endif()
 
-            # gperftools will be packaged as part of the NEML2 installation.
-            install_glob(${gperftools_profiler_LIBRARY} lib libneml2)
+            # check if gperftools is downloaded
+            path_has_prefix(${gperftools_ROOT} ${NEML2_CONTRIB_PREFIX} gperftools_CONTRIB)
+
+            # gperftools will be packaged as part of the NEML2 installation if it was downloaded by us (or if it is being built as a wheel).
+            if(gperftools_CONTRIB OR NEML2_WHEEL)
+                  install_glob(${gperftools_profiler_LIBRARY} lib libneml2)
+            endif()
             install(FILES ${NEML2_SOURCE_DIR}/cmake/Modules/Findgperftools.cmake DESTINATION share/cmake/neml2/Modules COMPONENT libneml2)
       endif()
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,7 +5,7 @@
       "name": "default",
       "hidden": true,
       "binaryDir": "${sourceDir}/build/${presetName}",
-      "installDir": "${sourceDir}/install/${presetName}",
+      "installDir": "${sourceDir}/installed/${presetName}",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "OFF",

--- a/cmake/Modules/DepUtils.cmake
+++ b/cmake/Modules/DepUtils.cmake
@@ -59,3 +59,23 @@ function(install_glob path install_dir component)
 
   install(FILES ${files} DESTINATION "${install_dir}" COMPONENT ${component})
 endfunction()
+
+# Check if a path has a specific prefix
+# Usage:
+#   path_has_prefix(<path> <prefix> <result_var>)
+#   Sets <result_var> to TRUE if <path> is under <prefix>, else FALSE.
+function(path_has_prefix path prefix result_var)
+  # Resolve to absolute real paths (follows symlinks, normalizes)
+  get_filename_component(abs_path "${path}" REALPATH BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+  get_filename_component(abs_prefix "${prefix}" REALPATH BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  # Add trailing slash to prefix for strict matching
+  set(abs_prefix_slash "${abs_prefix}/")
+
+  # Check either exact match or "prefix/" match
+  if(abs_path STREQUAL abs_prefix OR abs_path MATCHES "^${abs_prefix_slash}")
+    set(${result_var} TRUE PARENT_SCOPE)
+  else()
+    set(${result_var} FALSE PARENT_SCOPE)
+  endif()
+endfunction()

--- a/cmake/neml2Config.cmake.in
+++ b/cmake/neml2Config.cmake.in
@@ -23,17 +23,23 @@ else()
 endif()
 
 # wasp
-set(wasp_ROOT ${_IMPORT_PREFIX})
+if(@wasp_CONTRIB@)
+  set(wasp_ROOT ${_IMPORT_PREFIX})
+endif()
 find_dependency(wasp MODULE REQUIRED COMPONENTS core hit)
 
 # hit
-set(hit_ROOT ${_IMPORT_PREFIX})
+if(@hit_CONTRIB@)
+  set(hit_ROOT ${_IMPORT_PREFIX})
+endif()
 find_dependency(hit MODULE REQUIRED)
 
 # timpi
 if(@timpi_FOUND@)
   set(timpi_BUILD_TYPE @timpi_BUILD_TYPE@)
-  set(timpi_ROOT ${_IMPORT_PREFIX})
+  if(@timpi_CONTRIB@)
+    set(timpi_ROOT ${_IMPORT_PREFIX})
+  endif()
   find_dependency(timpi MODULE REQUIRED)
 endif()
 
@@ -44,6 +50,8 @@ endif()
 
 # gperftools
 if(@gperftools_FOUND@)
-  set(gperftools_ROOT ${_IMPORT_PREFIX})
+  if(@gperftools_CONTRIB@)
+    set(gperftools_ROOT ${_IMPORT_PREFIX})
+  endif
   find_dependency(gperftools MODULE REQUIRED COMPONENTS profiler)
 endif()

--- a/cmake/neml2Config.cmake.in
+++ b/cmake/neml2Config.cmake.in
@@ -52,6 +52,6 @@ endif()
 if(@gperftools_FOUND@)
   if(@gperftools_CONTRIB@)
     set(gperftools_ROOT ${_IMPORT_PREFIX})
-  endif
+  endif()
   find_dependency(gperftools MODULE REQUIRED COMPONENTS profiler)
 endif()


### PR DESCRIPTION
If a dependency was downloaded by us, we will install the dependency as part of the neml2 installation.