### PR TITLE
ModelDriver fix

### DIFF
--- a/src/neml2/drivers/ModelDriver.cxx
+++ b/src/neml2/drivers/ModelDriver.cxx
@@ -84,6 +84,7 @@ void
 ModelDriver::setup()
 {
   Driver::setup();
+  _model->to(_device);
 
 #ifdef NEML2_HAS_DISPATCHER
   if (_scheduler)


### PR DESCRIPTION
Fix a bug where the model isn't sent to the target device when no scheduler is set