### PR TITLE
Additional crystallography helpers

### DIFF
--- a/include/neml2/misc/types.h
+++ b/include/neml2/misc/types.h
@@ -92,5 +92,6 @@ std::ostream & operator<<(std::ostream & os, FType f);
 constexpr auto eps = std::numeric_limits<double>::epsilon();
 constexpr double sqrt2 = 1.4142135623730951;
 constexpr double invsqrt2 = 0.7071067811865475;
+constexpr double pi = M_PI;
 ///@}
 } // namespace neml2

--- a/include/neml2/tensors/Rot.h
+++ b/include/neml2/tensors/Rot.h
@@ -112,6 +112,9 @@ public:
 
   /// Volume element at locations
   Scalar dV() const;
+
+  /// Convert back to Euler angles
+  Vec to_euler_angles(const std::string & angle_convention, const std::string & angle_type) const;
 };
 
 /// Composition of rotations r3 = r1 * r2 (r2 first, then r1)
@@ -119,5 +122,10 @@ public:
 //  as the standard matrix product R1 * R2 where R1 and R2 are the
 //  matrix representations of r1 and r2
 Rot operator*(const Rot & r1, const Rot & r2);
+
+/// Convert between Euler angle types
+//  Input/output in radians
+//  to_convention one of "kocks", "bunge", "roe"
+Vec convert_euler_angles_from_kocks(const Vec & angles, const std::string & to_convention);
 
 } // namespace neml2

--- a/include/neml2/tensors/crystallography.h
+++ b/include/neml2/tensors/crystallography.h
@@ -40,7 +40,7 @@ R2 symmetry(const std::string & orbifold, const TensorOptions & options = defaul
 Vec unique_bidirectional(const R2 & ops, const Vec & inp);
 
 /// Calculate the misorientation of two batches of rotations
-Scalar misorientation(const Rot & r1, const Rot & r2, std::string orbifold = "1");
+Scalar misorientation(const Rot & r1, const Rot & r2, const std::string & orbifold = "1");
 
 /// Move a collection of orientations to a fundemental zone defined by the crystal symmetry
 // The coice of the reference orientation is arbitrary.  This matches the results from
@@ -50,8 +50,8 @@ Scalar misorientation(const Rot & r1, const Rot & r2, std::string orbifold = "1"
 // This function doesn't tolerate input intermediate dimensions because it needs advanced indexing
 //
 Rot move_to_fundamental_zone(const Rot & r,
-                             std::string orbifold,
-                             Rot ref = Rot(at::tensor({0.0, 0.0, 0.005}), 0));
+                             const std::string & orbifold,
+                             const Rot & ref = Rot::fill(0, 0, 0.005));
 
 namespace symmetry_operators
 {

--- a/include/neml2/tensors/crystallography.h
+++ b/include/neml2/tensors/crystallography.h
@@ -25,12 +25,11 @@
 #pragma once
 
 #include "neml2/tensors/R2.h"
+#include "neml2/tensors/Rot.h"
 
 namespace neml2
 {
-class R2;
 class Scalar;
-class Rot;
 
 namespace crystallography
 {
@@ -42,6 +41,17 @@ Vec unique_bidirectional(const R2 & ops, const Vec & inp);
 
 /// Calculate the misorientation of two batches of rotations
 Scalar misorientation(const Rot & r1, const Rot & r2, std::string orbifold = "1");
+
+/// Move a collection of orientations to a fundemental zone defined by the crystal symmetry
+// The coice of the reference orientation is arbitrary.  This matches the results from
+// Messner, Mark C., and Tianchen Hu. "Fully implicit crystal plasticity models representing
+// orientations with modified Rodrigues parameters." Mechanics of Materials (2025): 105388.
+//
+// This function doesn't tolerate input intermediate dimensions because it needs advanced indexing
+//
+Rot move_to_fundamental_zone(const Rot & r,
+                             std::string orbifold,
+                             Rot ref = Rot(at::tensor({0.0, 0.0, 0.005}), 0));
 
 namespace symmetry_operators
 {

--- a/include/neml2/tensors/functions/atan2.h
+++ b/include/neml2/tensors/functions/atan2.h
@@ -1,0 +1,34 @@
+// Copyright 2024, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "neml2/tensors/tensors_fwd.h"
+
+namespace neml2
+{
+#define DECLARE_ATAN2(T) T atan2(const T & a, const T & b)
+FOR_ALL_TENSORBASE(DECLARE_ATAN2);
+#undef DECLARE_ATAN2
+} // namespace neml2

--- a/include/neml2/tensors/functions/max.h
+++ b/include/neml2/tensors/functions/max.h
@@ -24,41 +24,16 @@
 
 #pragma once
 
-#include "neml2/tensors/R2.h"
+#include "neml2/misc/types.h"
+#include "neml2/tensors/tensors_fwd.h"
 
 namespace neml2
 {
-class R2;
-class Scalar;
-class Rot;
+#define DECLARE_BATCH_MAX(T)                                                                       \
+  T dynamic_max(const T & a, Size d = 0);                                                          \
+  T intmd_max(const T & a, Size d = 0)
+FOR_ALL_TENSORBASE(DECLARE_BATCH_MAX);
+#undef DECLARE_BATCH_MAX
 
-namespace crystallography
-{
-/// Helper function to return the symmetry operators given the Orbifold notation
-R2 symmetry(const std::string & orbifold, const TensorOptions & options = default_tensor_options());
-
-/// Helper to return all symmetrically-equivalent directions from a cartesian vector
-Vec unique_bidirectional(const R2 & ops, const Vec & inp);
-
-/// Calculate the misorientation of two batches of rotations
-Scalar misorientation(const Rot & r1, const Rot & r2, std::string orbifold = "1");
-
-namespace symmetry_operators
-{
-constexpr double a = 0.7071067811865476;
-constexpr double b = 0.8660254037844386;
-constexpr double h = 0.5;
-constexpr double o = 1.0;
-constexpr double z = 0.0;
-
-/// @brief tetragonal symmetry operators
-Quaternion tetragonal(const TensorOptions & options = default_tensor_options());
-
-/// @brief hexagonal symmetry operators
-Quaternion hexagonal(const TensorOptions & options = default_tensor_options());
-
-/// @brief cubic symmetry operators
-Quaternion cubic(const TensorOptions & options = default_tensor_options());
-} // namespace symmetry_operators
-} // namespace crystallography
+Tensor base_max(const Tensor & a, Size d = 0);
 } // namespace neml2

--- a/include/neml2/tensors/functions/min.h
+++ b/include/neml2/tensors/functions/min.h
@@ -24,41 +24,16 @@
 
 #pragma once
 
-#include "neml2/tensors/R2.h"
+#include "neml2/misc/types.h"
+#include "neml2/tensors/tensors_fwd.h"
 
 namespace neml2
 {
-class R2;
-class Scalar;
-class Rot;
+#define DECLARE_BATCH_MIN(T)                                                                       \
+  T dynamic_min(const T & a, Size d = 0);                                                          \
+  T intmd_min(const T & a, Size d = 0)
+FOR_ALL_TENSORBASE(DECLARE_BATCH_MIN);
+#undef DECLARE_BATCH_MIN
 
-namespace crystallography
-{
-/// Helper function to return the symmetry operators given the Orbifold notation
-R2 symmetry(const std::string & orbifold, const TensorOptions & options = default_tensor_options());
-
-/// Helper to return all symmetrically-equivalent directions from a cartesian vector
-Vec unique_bidirectional(const R2 & ops, const Vec & inp);
-
-/// Calculate the misorientation of two batches of rotations
-Scalar misorientation(const Rot & r1, const Rot & r2, std::string orbifold = "1");
-
-namespace symmetry_operators
-{
-constexpr double a = 0.7071067811865476;
-constexpr double b = 0.8660254037844386;
-constexpr double h = 0.5;
-constexpr double o = 1.0;
-constexpr double z = 0.0;
-
-/// @brief tetragonal symmetry operators
-Quaternion tetragonal(const TensorOptions & options = default_tensor_options());
-
-/// @brief hexagonal symmetry operators
-Quaternion hexagonal(const TensorOptions & options = default_tensor_options());
-
-/// @brief cubic symmetry operators
-Quaternion cubic(const TensorOptions & options = default_tensor_options());
-} // namespace symmetry_operators
-} // namespace crystallography
+Tensor base_min(const Tensor & a, Size d = 0);
 } // namespace neml2

--- a/python/neml2/crystallography.cxx
+++ b/python/neml2/crystallography.cxx
@@ -38,6 +38,34 @@ PYBIND11_MODULE(crystallography, m)
 
   py::module_::import("neml2.tensors");
 
+  m.def("misorientation",
+        &crystallography::misorientation,
+        py::arg("r1"),
+        py::arg("r2"),
+        py::arg("orbifold") = "1",
+        R"(
+Calculate the misorientation of two batches of rotations
+:param r1:          First batch of rotations
+:param r2:          Second batch of rotations
+:param orbifold:    String giving the orbifold notation for the symmetry group
+:return:            Batch of misorientation angles in radians
+  )");
+
+  m.def("move_to_fundamental_zone",
+        &crystallography::move_to_fundamental_zone,
+        py::arg("r"),
+        py::arg("orbifold"),
+        py::arg_v("ref",
+                  Rot(at::tensor({0.0, 0.0, 0.005}), 0),
+                  "Rot(torch.tensor([0.0, 0.0, 0.005]), 0)"),
+        R"(
+Move a collection of orientations to a fundemental zone defined by the crystal symmetry
+:param r:           Batch of rotations to move to the fundamental zone
+:param orbifold:    String giving the orbifold notation for the symmetry group
+:param ref:         Reference orientation to define the fundamental zone
+:return:            Batch of rotations moved to the fundamental zone
+)");
+
   m.def(
       "symmetry",
       [](const std::string & orbifold, NEML2_TENSOR_OPTIONS_VARGS)

--- a/python/neml2/crystallography.cxx
+++ b/python/neml2/crystallography.cxx
@@ -55,9 +55,7 @@ Calculate the misorientation of two batches of rotations
         &crystallography::move_to_fundamental_zone,
         py::arg("r"),
         py::arg("orbifold"),
-        py::arg_v("ref",
-                  Rot(at::tensor({0.0, 0.0, 0.005}), 0),
-                  "Rot(torch.tensor([0.0, 0.0, 0.005]), 0)"),
+        py::arg_v("ref", Rot::fill(0.0, 0.0, 0.005), "Rot(torch.tensor([0.0, 0.0, 0.005]), 0)"),
         R"(
 Move a collection of orientations to a fundemental zone defined by the crystal symmetry
 :param r:           Batch of rotations to move to the fundamental zone

--- a/python/neml2/csrc/tensors/Rot.cxx
+++ b/python/neml2/csrc/tensors/Rot.cxx
@@ -54,7 +54,8 @@ def(py::module_ & m, py::class_<Rot> & c)
       .def("drotate", &Rot::drotate)
       .def("shadow", &Rot::shadow)
       .def("dist", &Rot::dist)
-      .def("dV", &Rot::dV);
+      .def("dV", &Rot::dV)
+      .def("to_euler_angles", &Rot::to_euler_angles);
 
   c.def(py::self * py::self);
 }

--- a/src/neml2/tensors/Rot.cxx
+++ b/src/neml2/tensors/Rot.cxx
@@ -141,11 +141,12 @@ Rot::fill_matrix(const R2 & M)
 {
   // Get the angle
   auto trace = M(0, 0) + M(1, 1) + M(2, 2);
-  auto theta = neml2::acos((trace - 1.0) / 2.0);
+  auto theta = neml2::acos(neml2::clip((trace - 1.0) / 2.0, -1.0, 1.0));
 
   // Get the standard Rod. parameters
   auto scale = neml2::tan(theta / 2.0) / (2.0 * neml2::sin(theta));
   scale.index_put_({theta == 0}, 0.0);
+
   auto rx = (M(2, 1) - M(1, 2)) * scale;
   auto ry = (M(0, 2) - M(2, 0)) * scale;
   auto rz = (M(1, 0) - M(0, 1)) * scale;

--- a/src/neml2/tensors/Rot.cxx
+++ b/src/neml2/tensors/Rot.cxx
@@ -33,6 +33,9 @@
 #include "neml2/tensors/WR2.h"
 #include "neml2/tensors/Quaternion.h"
 #include "neml2/misc/assertions.h"
+#include "neml2/misc/types.h"
+#include "neml2/tensors/functions/abs.h"
+#include "neml2/tensors/functions/atan2.h"
 #include "neml2/tensors/functions/sqrt.h"
 #include "neml2/tensors/functions/pow.h"
 #include "neml2/tensors/functions/sin.h"
@@ -52,6 +55,7 @@
 #include "neml2/tensors/functions/norm.h"
 #include "neml2/tensors/functions/outer.h"
 #include "neml2/tensors/functions/inv.h"
+#include "neml2/tensors/functions/where.h"
 
 namespace neml2
 {
@@ -89,22 +93,22 @@ Rot::fill_euler_angles(const Vec & v,
                        const std::string & angle_convention,
                        const std::string & angle_type)
 {
-  auto m = v;
+  auto m = v.clone();
 
   if (angle_type == "degrees")
-    m = neml2::deg2rad(v);
+    m = neml2::deg2rad(m);
   else
     neml_assert(angle_type == "radians", "Rot angle_type must be either 'degrees' or 'radians'");
 
   if (angle_convention == "bunge")
   {
-    m.base_index_put_({0}, neml2::fmod(m.base_index({0}) - M_PI / 2.0, 2.0 * M_PI));
-    m.base_index_put_({1}, neml2::fmod(m.base_index({1}), M_PI));
-    m.base_index_put_({2}, neml2::fmod(M_PI / 2.0 - m.base_index({2}), 2.0 * M_PI));
+    m.base_index_put_({0}, neml2::fmod(m.base_index({0}) - pi / 2.0, 2.0 * pi));
+    m.base_index_put_({1}, neml2::fmod(m.base_index({1}), pi));
+    m.base_index_put_({2}, neml2::fmod(pi / 2.0 - m.base_index({2}), 2.0 * pi));
   }
   else if (angle_convention == "roe")
   {
-    m.base_index_put_({2}, M_PI - m.base_index({2}));
+    m.base_index_put_({2}, pi - m.base_index({2}));
   }
   else
     neml_assert(angle_convention == "kocks", "Unknown Rot angle_convention " + angle_convention);
@@ -293,6 +297,34 @@ Rot::dV() const
   return 8.0 / M_PI * neml2::pow(1.0 + norm_sq(*this), -3.0);
 }
 
+Vec
+Rot::to_euler_angles(const std::string & angle_convention, const std::string & angle_type) const
+{
+  auto M = this->euler_rodrigues();
+  auto tol = machine_precision(scalar_type()) * 2;
+
+  auto s1 = neml2::atan2(M.base_index({0, 1}), M.base_index({0, 0})) / 2.0 - pi / 2.0;
+  auto option_1 = Vec(base_stack({s1, Scalar::zeros_like(s1), -s1}));
+
+  auto t2 = neml2::acos(M.base_index({2, 2}));
+  auto s = neml2::sin(t2);
+  auto t3 = pi / 2.0 - neml2::atan2(M.base_index({0, 2}) / s, M.base_index({1, 2}) / s);
+  auto t1 = pi / 2.0 - neml2::atan2(M.base_index({2, 0}) / s, M.base_index({2, 1}) / s);
+  auto option_2 = Vec(base_stack({t1, t2, t3}));
+
+  auto crit = neml2::Tensor(neml2::abs(neml2::abs(M.base_index({2, 2})) - 1.0) < tol);
+
+  auto kocks = neml2::where(crit.base_expand_as(option_1), option_1, option_2);
+
+  auto correct = convert_euler_angles_from_kocks(kocks, angle_convention);
+
+  if (angle_type == "degrees")
+    correct = correct * (180.0 / pi);
+  else
+    neml_assert(angle_type == "radians", "Rot angle_type must be either 'degrees' or 'radians'");
+  return correct;
+}
+
 Rot
 operator*(const Rot & r1, const Rot & r2)
 {
@@ -301,6 +333,40 @@ operator*(const Rot & r1, const Rot & r2)
 
   return Rot((1 - rr2) * Vec(r1) + (1.0 - rr1) * Vec(r2) - 2.0 * neml2::cross(Vec(r2), r1)) /
          (1.0 + rr1 * rr2 - 2 * neml2::vdot(r1, r2));
+}
+
+Vec
+convert_euler_angles_from_kocks(const Vec & angles, const std::string & to_convention)
+{
+  Vec result;
+
+  if (to_convention == "kocks")
+  {
+    result = angles;
+  }
+  else if (to_convention == "bunge")
+  {
+    auto a = angles.base_index({0});
+    auto b = angles.base_index({1});
+    auto c = angles.base_index({2});
+
+    result = Vec(base_stack({neml2::fmod(a + pi / 2.0, 2 * pi),
+                             neml2::fmod(b, pi),
+                             neml2::fmod(pi / 2.0 - c, 2 * pi)}));
+  }
+  else if (to_convention == "roe")
+  {
+    auto a = angles.base_index({0});
+    auto b = angles.base_index({1});
+    auto c = angles.base_index({2});
+
+    result = Vec(base_stack({a, b, M_PI - c}));
+  }
+  else
+  {
+    neml_assert(false, "Unknown euler angle convention " + to_convention);
+  }
+  return result;
 }
 
 } // namemspace neml2

--- a/src/neml2/tensors/crystallography.cxx
+++ b/src/neml2/tensors/crystallography.cxx
@@ -162,7 +162,7 @@ unique_bidirectional(const R2 & ops, const Vec & inp)
 }
 
 Scalar
-misorientation(const Rot & r1, const Rot & r2, std::string orbifold)
+misorientation(const Rot & r1, const Rot & r2, const std::string & orbifold)
 {
   neml_assert_broadcastable_dbg(r1, r2);
   const auto [r1a, r2a, i] = utils::align_intmd_dim(r1, r2);
@@ -177,11 +177,11 @@ misorientation(const Rot & r1, const Rot & r2, std::string orbifold)
 }
 
 Rot
-move_to_fundamental_zone(const Rot & r, std::string orbifold, Rot ref)
+move_to_fundamental_zone(const Rot & r, const std::string & orbifold, const Rot & ref)
 {
   neml_assert_dbg(r.intmd_dim() == 0, "Input must not have intermediate dimensions");
 
-  auto orig_dynamic_sizes = r.dynamic_sizes();
+  const auto & orig_dynamic_sizes = r.dynamic_sizes();
   auto flattened_r = r.batch_flatten();
 
   auto ops = symmetry(orbifold, r.options());

--- a/src/neml2/tensors/crystallography.cxx
+++ b/src/neml2/tensors/crystallography.cxx
@@ -30,8 +30,15 @@
 #include "neml2/tensors/functions/stack.h"
 #include "neml2/misc/assertions.h"
 
+#include "neml2/tensors/R2.h"
+#include "neml2/tensors/functions/clamp.h"
+#include "neml2/tensors/functions/acos.h"
+#include "neml2/tensors/functions/tr.h"
+#include "neml2/tensors/functions/min.h"
+
 namespace neml2::crystallography
 {
+
 namespace symmetry_operators
 {
 Quaternion
@@ -151,6 +158,21 @@ unique_bidirectional(const R2 & ops, const Vec & inp)
   }
   // Get the batch of all possible answers
   return unique_vecs;
+}
+
+Scalar
+misorientation(const Rot & r1, const Rot & r2, std::string orbifold)
+{
+  neml_assert_broadcastable_dbg(r1, r2);
+  const auto [r1a, r2a, i] = utils::align_intmd_dim(r1, r2);
+
+  R2 r1_mat = r1a.intmd_unsqueeze(-1).euler_rodrigues();
+  R2 r2_mat = r2a.intmd_unsqueeze(-1).euler_rodrigues();
+  R2 S_mat = symmetry(orbifold, r1.options());
+
+  R2 prod = r1_mat.transpose() * S_mat * r2_mat;
+
+  return intmd_min(acos(clamp((tr(prod) - 1.0) / 2.0, -1.0, 1.0)), -1);
 }
 
 } // namespace neml2

--- a/src/neml2/tensors/functions/atan2.cxx
+++ b/src/neml2/tensors/functions/atan2.cxx
@@ -1,0 +1,39 @@
+// Copyright 2024, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "neml2/tensors/functions/atan.h"
+#include "neml2/tensors/tensors.h"
+
+namespace neml2
+{
+#define DEFINE_ARCTAN2(T)                                                                          \
+  T atan2(const T & a, const T & b)                                                                \
+  {                                                                                                \
+    neml_assert_dynamic_broadcastable_dbg(a, b);                                                   \
+    const auto [aa, bb, i] = utils::align_intmd_dim(a, b);                                         \
+    return T(at::atan2(aa, bb), utils::broadcast_dynamic_dim(a, b), i);                            \
+  }                                                                                                \
+  static_assert(true)
+FOR_ALL_TENSORBASE(DEFINE_ARCTAN2);
+} // namespace neml2

--- a/src/neml2/tensors/functions/max.cxx
+++ b/src/neml2/tensors/functions/max.cxx
@@ -1,0 +1,53 @@
+// Copyright 2024, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "neml2/tensors/functions/max.h"
+#include "neml2/tensors/tensors.h"
+#include "neml2/tensors/shape_utils.h"
+
+namespace neml2
+{
+#define DEFINE_MAX(T)                                                                              \
+  T dynamic_max(const T & a, Size d)                                                               \
+  {                                                                                                \
+    d = utils::normalize_dim(d, 0, a.dynamic_dim());                                               \
+    auto sizes = a.dynamic_sizes();                                                                \
+    sizes.erase(sizes.begin() + d);                                                                \
+    return T(std::get<0>(at::max(a, d)), sizes, a.intmd_dim());                                    \
+  }                                                                                                \
+  T intmd_max(const T & a, Size d)                                                                 \
+  {                                                                                                \
+    d = utils::normalize_dim(d, a.dynamic_dim(), a.batch_dim());                                   \
+    return T(std::get<0>(at::max(a, d)), a.dynamic_sizes(), a.intmd_dim() - 1);                    \
+  }                                                                                                \
+  static_assert(true)
+FOR_ALL_TENSORBASE(DEFINE_MAX);
+
+Tensor
+base_max(const Tensor & a, Size d)
+{
+  d = utils::normalize_dim(d, a.batch_dim(), a.dim());
+  return Tensor(std::get<0>(at::max(a, d)), a.dynamic_sizes(), a.intmd_dim());
+}
+} // namespace neml2

--- a/src/neml2/tensors/functions/min.cxx
+++ b/src/neml2/tensors/functions/min.cxx
@@ -1,0 +1,53 @@
+// Copyright 2024, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "neml2/tensors/functions/min.h"
+#include "neml2/tensors/tensors.h"
+#include "neml2/tensors/shape_utils.h"
+
+namespace neml2
+{
+#define DEFINE_MIN(T)                                                                              \
+  T dynamic_min(const T & a, Size d)                                                               \
+  {                                                                                                \
+    d = utils::normalize_dim(d, 0, a.dynamic_dim());                                               \
+    auto sizes = a.dynamic_sizes();                                                                \
+    sizes.erase(sizes.begin() + d);                                                                \
+    return T(std::get<0>(at::min(a, d)), sizes, a.intmd_dim());                                    \
+  }                                                                                                \
+  T intmd_min(const T & a, Size d)                                                                 \
+  {                                                                                                \
+    d = utils::normalize_dim(d, a.dynamic_dim(), a.batch_dim());                                   \
+    return T(std::get<0>(at::min(a, d)), a.dynamic_sizes(), a.intmd_dim() - 1);                    \
+  }                                                                                                \
+  static_assert(true)
+FOR_ALL_TENSORBASE(DEFINE_MIN);
+
+Tensor
+base_min(const Tensor & a, Size d)
+{
+  d = utils::normalize_dim(d, a.batch_dim(), a.dim());
+  return Tensor(std::get<0>(at::min(a, d)), a.dynamic_sizes(), a.intmd_dim());
+}
+} // namespace neml2

--- a/tests/unit/tensors/functions/test_atan2.cxx
+++ b/tests/unit/tensors/functions/test_atan2.cxx
@@ -1,0 +1,52 @@
+// Copyright 2024, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "neml2/tensors/tensors.h"
+#include "neml2/tensors/functions/atan2.h"
+
+#include "unit/tensors/generators.h"
+#include "utils.h"
+
+using namespace neml2;
+
+#define TYPE_IDENTITY(T) T
+
+TEMPLATE_TEST_CASE("atan2", "[tensors/functions]", FOR_ALL_TENSORBASE_COMMA(TYPE_IDENTITY))
+{
+  at::manual_seed(42);
+  auto cfg = test::generate_tensor_config(test::fp_dtypes());
+  auto shape = test::generate_tensor_shape<TestType>();
+  DYNAMIC_SECTION(cfg.desc() << " " << shape.desc())
+  {
+    auto a = test::generate_random_tensor<TestType>(cfg, shape);
+    auto b = neml2::atan2(a, 2 * a);
+    auto b0 = at::atan2(a, 2 * a);
+    REQUIRE(test::match_tensor_shape(b, shape));
+    REQUIRE_THAT(b, test::allclose(b0));
+  }
+}

--- a/tests/unit/tensors/functions/test_max.cxx
+++ b/tests/unit/tensors/functions/test_max.cxx
@@ -1,0 +1,92 @@
+// Copyright 2024, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "neml2/tensors/tensors.h"
+#include "neml2/tensors/functions/max.h"
+
+#include "unit/tensors/generators.h"
+#include "utils.h"
+
+using namespace neml2;
+
+#define TYPE_IDENTITY(T) T
+
+TEMPLATE_TEST_CASE("dynamic_max", "[tensors/functions]", FOR_ALL_TENSORBASE_COMMA(TYPE_IDENTITY))
+{
+  at::manual_seed(42);
+  auto cfg = test::generate_tensor_config(test::fp_dtypes());
+  auto shape = test::generate_tensor_shape<TestType>();
+  DYNAMIC_SECTION(cfg.desc() << " s1: " << shape.desc())
+  {
+    auto a = test::generate_random_tensor<TestType>(cfg, shape);
+
+    if (a.dynamic_dim() == 0)
+      return;
+
+    auto b1 = neml2::dynamic_max(a, /*dim=*/0);
+    auto b2 = std::get<0>(at::max(a, 0));
+
+    REQUIRE_THAT(b1, test::allclose(b2));
+  }
+}
+
+TEMPLATE_TEST_CASE("intmd_max", "[tensors/functions]", FOR_ALL_TENSORBASE_COMMA(TYPE_IDENTITY))
+{
+  at::manual_seed(42);
+  auto cfg = test::generate_tensor_config(test::fp_dtypes());
+  auto shape = test::generate_tensor_shape<TestType>();
+  DYNAMIC_SECTION(cfg.desc() << " s1: " << shape.desc())
+  {
+    auto a = test::generate_random_tensor<TestType>(cfg, shape);
+
+    if (a.intmd_dim() == 0)
+      return;
+
+    auto b1 = neml2::intmd_max(a, /*dim=*/0);
+    auto b2 = std::get<0>(at::max(a, a.dynamic_dim()));
+
+    REQUIRE_THAT(b1, test::allclose(b2));
+  }
+}
+
+TEST_CASE("base_max", "[tensors/functions]")
+{
+  at::manual_seed(42);
+  auto cfg = test::generate_tensor_config(test::fp_dtypes());
+  auto shape = test::generate_tensor_shape<Scalar>();
+  DYNAMIC_SECTION(cfg.desc() << " s1: " << shape.desc())
+  {
+    auto a = test::generate_random_tensor<Scalar>(cfg, shape);
+    if (a.base_dim() == 0)
+      return;
+
+    auto b1 = neml2::base_max(a, /*dim=*/0);
+    auto b2 = std::get<0>(at::max(a, a.intmd_dim()));
+    REQUIRE_THAT(b1, test::allclose(b2));
+  }
+}

--- a/tests/unit/tensors/functions/test_min.cxx
+++ b/tests/unit/tensors/functions/test_min.cxx
@@ -1,0 +1,92 @@
+// Copyright 2024, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "neml2/tensors/tensors.h"
+#include "neml2/tensors/functions/min.h"
+
+#include "unit/tensors/generators.h"
+#include "utils.h"
+
+using namespace neml2;
+
+#define TYPE_IDENTITY(T) T
+
+TEMPLATE_TEST_CASE("dynamic_min", "[tensors/functions]", FOR_ALL_TENSORBASE_COMMA(TYPE_IDENTITY))
+{
+  at::manual_seed(42);
+  auto cfg = test::generate_tensor_config(test::fp_dtypes());
+  auto shape = test::generate_tensor_shape<TestType>();
+  DYNAMIC_SECTION(cfg.desc() << " s1: " << shape.desc())
+  {
+    auto a = test::generate_random_tensor<TestType>(cfg, shape);
+
+    if (a.dynamic_dim() == 0)
+      return;
+
+    auto b1 = neml2::dynamic_min(a, /*dim=*/0);
+    auto b2 = std::get<0>(at::min(a, 0));
+
+    REQUIRE_THAT(b1, test::allclose(b2));
+  }
+}
+
+TEMPLATE_TEST_CASE("intmd_min", "[tensors/functions]", FOR_ALL_TENSORBASE_COMMA(TYPE_IDENTITY))
+{
+  at::manual_seed(42);
+  auto cfg = test::generate_tensor_config(test::fp_dtypes());
+  auto shape = test::generate_tensor_shape<TestType>();
+  DYNAMIC_SECTION(cfg.desc() << " s1: " << shape.desc())
+  {
+    auto a = test::generate_random_tensor<TestType>(cfg, shape);
+
+    if (a.intmd_dim() == 0)
+      return;
+
+    auto b1 = neml2::intmd_min(a, /*dim=*/0);
+    auto b2 = std::get<0>(at::min(a, a.dynamic_dim()));
+
+    REQUIRE_THAT(b1, test::allclose(b2));
+  }
+}
+
+TEST_CASE("base_min", "[tensors/functions]")
+{
+  at::manual_seed(42);
+  auto cfg = test::generate_tensor_config(test::fp_dtypes());
+  auto shape = test::generate_tensor_shape<Scalar>();
+  DYNAMIC_SECTION(cfg.desc() << " s1: " << shape.desc())
+  {
+    auto a = test::generate_random_tensor<Scalar>(cfg, shape);
+    if (a.base_dim() == 0)
+      return;
+
+    auto b1 = neml2::base_min(a, /*dim=*/0);
+    auto b2 = std::get<0>(at::min(a, a.intmd_dim()));
+    REQUIRE_THAT(b1, test::allclose(b2));
+  }
+}

--- a/tests/unit/tensors/test_Rot.cxx
+++ b/tests/unit/tensors/test_Rot.cxx
@@ -127,4 +127,37 @@ TEST_CASE("Rot", "[tensors]")
     auto c = Rot::fill(1.48720771, -2.26086024, 1.02025338);
     REQUIRE_THAT(a * b, test::allclose(c));
   }
+
+  SECTION("euler angle conversions")
+  {
+    auto kocks_radians = Vec::fill(0.1, 0.5, 1.0);
+    auto r_kocks_radians = Rot::fill_euler_angles(kocks_radians, "kocks", "radians");
+    auto a_kocks_radians = r_kocks_radians.to_euler_angles("kocks", "radians");
+    REQUIRE_THAT(a_kocks_radians, test::allclose(kocks_radians));
+
+    auto kocks_degrees = Vec::fill(10.0, 30.0, 60.0);
+    auto r_kocks_degrees = Rot::fill_euler_angles(kocks_degrees, "kocks", "degrees");
+    auto a_kocks_degrees = r_kocks_degrees.to_euler_angles("kocks", "degrees");
+    REQUIRE_THAT(a_kocks_degrees, test::allclose(kocks_degrees));
+
+    auto bunge_radians = Vec::fill(0.2, 0.6, 1.2);
+    auto r_bunge_radians = Rot::fill_euler_angles(bunge_radians, "bunge", "radians");
+    auto a_bunge_radians = r_bunge_radians.to_euler_angles("bunge", "radians");
+    REQUIRE_THAT(a_bunge_radians, test::allclose(bunge_radians));
+
+    auto bunge_degrees = Vec::fill(20.0, 40.0, 70.0);
+    auto r_bunge_degrees = Rot::fill_euler_angles(bunge_degrees, "bunge", "degrees");
+    auto a_bunge_degrees = r_bunge_degrees.to_euler_angles("bunge", "degrees");
+    REQUIRE_THAT(a_bunge_degrees, test::allclose(bunge_degrees));
+
+    auto roe_radians = Vec::fill(0.3, 0.7, 1.4);
+    auto r_roe_radians = Rot::fill_euler_angles(roe_radians, "roe", "radians");
+    auto a_roe_radians = r_roe_radians.to_euler_angles("roe", "radians");
+    REQUIRE_THAT(a_roe_radians, test::allclose(roe_radians));
+
+    auto roe_degrees = Vec::fill(30.0, 50.0, 80.0);
+    auto r_roe_degrees = Rot::fill_euler_angles(roe_degrees, "roe", "degrees");
+    auto a_roe_degrees = r_roe_degrees.to_euler_angles("roe", "degrees");
+    REQUIRE_THAT(a_roe_degrees, test::allclose(roe_degrees));
+  }
 }

--- a/tests/unit/tensors/test_misorientation_calculations.cxx
+++ b/tests/unit/tensors/test_misorientation_calculations.cxx
@@ -1,0 +1,129 @@
+// Copyright 2024, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "neml2/tensors/tensors.h"
+#include "neml2/tensors/crystallography.h"
+
+#include "neml2/tensors/functions/det.h"
+
+#include "unit/tensors/generators.h"
+#include "utils.h"
+
+using namespace neml2;
+
+TEST_CASE("Misorientation calculations", "[tensors]")
+{
+  at::manual_seed(42);
+  const auto & DTO = default_tensor_options();
+
+  SECTION("misorientation")
+  {
+    SECTION("shapes")
+    {
+      SECTION("simple dynamic")
+      {
+        auto r1 = Rot::rand({10}, {}, DTO);
+        auto r2 = Rot::rand({10}, {}, DTO);
+        auto miso = crystallography::misorientation(r1, r2, "432");
+        REQUIRE(miso.sizes() == at::IntArrayRef({10}));
+      }
+      SECTION("broadcast dynamic")
+      {
+        auto r1 = Rot::rand({10, 1}, {}, DTO);
+        auto r2 = Rot::rand({15}, {}, DTO);
+        auto miso = crystallography::misorientation(r1, r2, "432");
+        REQUIRE(miso.sizes() == at::IntArrayRef({10, 15}));
+      }
+      SECTION("existing intermediate")
+      {
+        auto r1 = Rot::rand({10, 1}, {2}, DTO);
+        auto r2 = Rot::rand({15}, {2}, DTO);
+        auto miso = crystallography::misorientation(r1, r2, "432");
+        REQUIRE(miso.sizes() == at::IntArrayRef({10, 15, 2}));
+      }
+    }
+    SECTION("correctness")
+    {
+      SECTION("same")
+      {
+        auto r1 = Rot::rand({10}, {}, DTO);
+        auto miso = crystallography::misorientation(r1, r1, "432");
+        REQUIRE_THAT(miso, test::allclose(Scalar::zeros_like(miso), 1e-6, 1e-6));
+      }
+      SECTION("max 432")
+      {
+        auto r1 = Rot::fill_euler_angles(Vec::fill(0, 0, 0, DTO), "bunge", "degrees");
+        auto r2 = Rot::fill_euler_angles(Vec::fill(45, 45, 0, DTO), "bunge", "degrees");
+        auto miso = crystallography::misorientation(r1, r2, "432");
+        REQUIRE_THAT(miso, test::allclose(Scalar::full_like(miso, 1.09605), 1e-3, 1e-6));
+      }
+      SECTION("one axis")
+      {
+        auto r1 = Rot::fill_euler_angles(Vec::fill(0, 0, 0, DTO), "bunge", "degrees");
+        auto r2 = Rot::fill_euler_angles(Vec::fill(10, 0, 0, DTO), "bunge", "degrees");
+        auto miso = crystallography::misorientation(r1, r2, "432");
+        REQUIRE_THAT(miso, test::allclose(Scalar::full_like(miso, 0.174532925), 1e-6, 1e-6));
+      }
+      SECTION("symmetry")
+      {
+        auto r1 = Rot::rand({10}, {}, DTO);
+        auto r2 = Rot::rand({10}, {}, DTO);
+        auto a = crystallography::misorientation(r1, r2, "432");
+        auto b = crystallography::misorientation(r2, r1, "432");
+        REQUIRE_THAT(a, test::allclose(b));
+      }
+      SECTION("invariance")
+      {
+        auto r1 = Rot::rand({}, {}, DTO);
+        auto r2 = Rot::rand({}, {}, DTO);
+        for (auto orbifold : {"1", "2", "222", "4", "42", "3", "6", "32", "622", "23", "432"})
+        {
+          auto a = crystallography::misorientation(r1, r2, orbifold);
+          auto ops = crystallography::symmetry(orbifold, DTO);
+          for (Size i = 0; i < ops.intmd_size(0); i++)
+          {
+            auto Ri = ops.intmd_index({i});
+            for (Size j = 0; j < ops.intmd_size(0); j++)
+            {
+              auto Rj = ops.intmd_index({j});
+              auto r1p = Rot::fill_matrix(Ri * r1.euler_rodrigues());
+              auto r2p = Rot::fill_matrix(Rj * r2.euler_rodrigues());
+
+              auto b = crystallography::misorientation(r1p, r2p, orbifold);
+              REQUIRE_THAT(a, test::allclose(b, 1e-6, 1e-6));
+              auto c = crystallography::misorientation(r1, r2p, orbifold);
+              REQUIRE_THAT(a, test::allclose(c, 1e-6, 1e-6));
+              auto d = crystallography::misorientation(r1p, r2, orbifold);
+              REQUIRE_THAT(a, test::allclose(d, 1e-6, 1e-6));
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds some new helpers for crystallography:
1. Misorientation calculations
2. Moves MRPs to the fundamental zone for some symmetry
3. Spit back Euler angles given a `Rot`.