### PR TITLE
Fix python binding memory leaks

### DIFF
--- a/python/neml2/csrc/tensors/BaseView.cxx
+++ b/python/neml2/csrc/tensors/BaseView.cxx
@@ -33,8 +33,7 @@ void
 def_BaseView(py::module_ & m, const std::string & name)
 {
   auto c = py::class_<BaseView<T>>(m, name.c_str());
-  c.def(py::init<T *>())
-      .def("dim", &BaseView<T>::dim)
+  c.def("dim", &BaseView<T>::dim)
       .def_property_readonly("shape",
                              [](const BaseView<T> & self)
                              {
@@ -72,8 +71,9 @@ def_BaseView(py::module_ & m, const std::string & name)
 }
 
 template <class T>
-BaseView<T>::BaseView(T * data)
-  : _data(data)
+BaseView<T>::BaseView(py::object data)
+  : _owner(std::move(data)),
+    _data(_owner.cast<T *>())
 {
 }
 

--- a/python/neml2/csrc/tensors/BaseView.h
+++ b/python/neml2/csrc/tensors/BaseView.h
@@ -42,7 +42,7 @@ template <class T>
 class BaseView
 {
 public:
-  BaseView(T * data);
+  BaseView(pybind11::object data);
 
   // These methods mirror TensorBase (the intmd_xxx ones)
   neml2::Size dim() const;
@@ -62,6 +62,7 @@ public:
   neml2::Tensor flatten() const;
 
 private:
+  pybind11::object _owner;
   T * _data;
 };
 

--- a/python/neml2/csrc/tensors/BatchView.cxx
+++ b/python/neml2/csrc/tensors/BatchView.cxx
@@ -33,8 +33,7 @@ void
 def_BatchView(py::module_ & m, const std::string & name)
 {
   auto c = py::class_<BatchView<T>>(m, name.c_str());
-  c.def(py::init<T *>())
-      .def("dim", &BatchView<T>::dim)
+  c.def("dim", &BatchView<T>::dim)
       .def_property_readonly("shape",
                              [](const BatchView<T> & self)
                              {
@@ -71,8 +70,9 @@ def_BatchView(py::module_ & m, const std::string & name)
 }
 
 template <class T>
-BatchView<T>::BatchView(T * data)
-  : _data(data)
+BatchView<T>::BatchView(py::object data)
+  : _owner(std::move(data)),
+    _data(_owner.cast<T *>())
 {
 }
 

--- a/python/neml2/csrc/tensors/BatchView.h
+++ b/python/neml2/csrc/tensors/BatchView.h
@@ -42,7 +42,7 @@ template <class T>
 class BatchView
 {
 public:
-  BatchView(T * data);
+  BatchView(pybind11::object data);
 
   // These methods mirror TensorBase (the batch_xxx ones)
   neml2::Size dim() const;
@@ -61,6 +61,7 @@ public:
   T flatten() const;
 
 private:
+  pybind11::object _owner;
   T * _data;
 };
 

--- a/python/neml2/csrc/tensors/DynamicView.cxx
+++ b/python/neml2/csrc/tensors/DynamicView.cxx
@@ -33,8 +33,7 @@ void
 def_DynamicView(py::module_ & m, const std::string & name)
 {
   auto c = py::class_<DynamicView<T>>(m, name.c_str());
-  c.def(py::init<T *>())
-      .def("dim", &DynamicView<T>::dim)
+  c.def("dim", &DynamicView<T>::dim)
       .def_property_readonly("shape",
                              [](const DynamicView<T> & self)
                              {
@@ -72,8 +71,9 @@ def_DynamicView(py::module_ & m, const std::string & name)
 }
 
 template <class T>
-DynamicView<T>::DynamicView(T * data)
-  : _data(data)
+DynamicView<T>::DynamicView(py::object data)
+  : _owner(std::move(data)),
+    _data(_owner.cast<T *>())
 {
 }
 

--- a/python/neml2/csrc/tensors/DynamicView.h
+++ b/python/neml2/csrc/tensors/DynamicView.h
@@ -42,7 +42,7 @@ template <class T>
 class DynamicView
 {
 public:
-  DynamicView(T * data);
+  DynamicView(pybind11::object data);
 
   // These methods mirror TensorBase (the dynamic_xxx ones)
   neml2::Size dim() const;
@@ -62,6 +62,7 @@ public:
   T flatten() const;
 
 private:
+  pybind11::object _owner;
   T * _data;
 };
 

--- a/python/neml2/csrc/tensors/IntmdView.cxx
+++ b/python/neml2/csrc/tensors/IntmdView.cxx
@@ -33,8 +33,7 @@ void
 def_IntmdView(py::module_ & m, const std::string & name)
 {
   auto c = py::class_<IntmdView<T>>(m, name.c_str());
-  c.def(py::init<T *>())
-      .def("dim", &IntmdView<T>::dim)
+  c.def("dim", &IntmdView<T>::dim)
       .def_property_readonly("shape",
                              [](const IntmdView<T> & self)
                              {
@@ -72,8 +71,9 @@ def_IntmdView(py::module_ & m, const std::string & name)
 }
 
 template <class T>
-IntmdView<T>::IntmdView(T * data)
-  : _data(data)
+IntmdView<T>::IntmdView(py::object data)
+  : _owner(std::move(data)),
+    _data(_owner.cast<T *>())
 {
 }
 

--- a/python/neml2/csrc/tensors/IntmdView.h
+++ b/python/neml2/csrc/tensors/IntmdView.h
@@ -42,7 +42,7 @@ template <class T>
 class IntmdView
 {
 public:
-  IntmdView(T * data);
+  IntmdView(pybind11::object data);
 
   // These methods mirror TensorBase (the intmd_xxx ones)
   neml2::Size dim() const;
@@ -62,6 +62,7 @@ public:
   T flatten() const;
 
 private:
+  pybind11::object _owner;
   T * _data;
 };
 

--- a/python/neml2/csrc/tensors/StaticView.cxx
+++ b/python/neml2/csrc/tensors/StaticView.cxx
@@ -33,8 +33,7 @@ void
 def_StaticView(py::module_ & m, const std::string & name)
 {
   auto c = py::class_<StaticView<T>>(m, name.c_str());
-  c.def(py::init<T *>())
-      .def("dim", &StaticView<T>::dim)
+  c.def("dim", &StaticView<T>::dim)
       .def_property_readonly("shape",
                              [](const StaticView<T> & self)
                              {
@@ -52,8 +51,9 @@ def_StaticView(py::module_ & m, const std::string & name)
 }
 
 template <class T>
-StaticView<T>::StaticView(T * data)
-  : _data(data)
+StaticView<T>::StaticView(py::object data)
+  : _owner(std::move(data)),
+    _data(_owner.cast<T *>())
 {
 }
 

--- a/python/neml2/csrc/tensors/StaticView.h
+++ b/python/neml2/csrc/tensors/StaticView.h
@@ -42,7 +42,7 @@ template <class T>
 class StaticView
 {
 public:
-  StaticView(T * data);
+  StaticView(pybind11::object data);
 
   // These methods mirror TensorBase (the dynamic_xxx ones)
   neml2::Size dim() const;
@@ -54,6 +54,7 @@ public:
   neml2::Tensor flatten() const;
 
 private:
+  pybind11::object _owner;
   T * _data;
 };
 

--- a/python/neml2/csrc/tensors/TensorBase.cxx
+++ b/python/neml2/csrc/tensors/TensorBase.cxx
@@ -68,26 +68,36 @@ def_TensorBase(py::module_ & m, const std::string & type)
            })
       .def("torch", [](const T & self) { return torch::Tensor(self); })
       .def("tensor", [](const T & self) { return neml2::Tensor(self); })
-      .def_property_readonly(
-          "dynamic",
-          [](T * self) { return std::make_unique<DynamicView<T>>(self); },
-          py::keep_alive<0, 1>())
-      .def_property_readonly(
-          "intmd",
-          [](T * self) { return std::make_unique<IntmdView<T>>(self); },
-          py::keep_alive<0, 1>())
-      .def_property_readonly(
-          "base",
-          [](T * self) { return std::make_unique<BaseView<T>>(self); },
-          py::keep_alive<0, 1>())
-      .def_property_readonly(
-          "batch",
-          [](T * self) { return std::make_unique<BatchView<T>>(self); },
-          py::keep_alive<0, 1>())
-      .def_property_readonly(
-          "static",
-          [](T * self) { return std::make_unique<StaticView<T>>(self); },
-          py::keep_alive<0, 1>())
+      .def_property_readonly("dynamic",
+                             [](T * self)
+                             {
+                               py::capsule free_when_done(&self, [](void * f) {});
+                               return DynamicView<T>(self);
+                             })
+      .def_property_readonly("intmd",
+                             [](T * self)
+                             {
+                               py::capsule free_when_done(&self, [](void * f) {});
+                               return IntmdView<T>(self);
+                             })
+      .def_property_readonly("base",
+                             [](T * self)
+                             {
+                               py::capsule free_when_done(&self, [](void * f) {});
+                               return BaseView<T>(self);
+                             })
+      .def_property_readonly("batch",
+                             [](T * self)
+                             {
+                               py::capsule free_when_done(&self, [](void * f) {});
+                               return BatchView<T>(self);
+                             })
+      .def_property_readonly("static",
+                             [](T * self)
+                             {
+                               py::capsule free_when_done(&self, [](void * f) {});
+                               return StaticView<T>(self);
+                             })
       .def("contiguous", &T::contiguous)
       .def("clone", &T::clone)
       .def("detach", &T::detach)

--- a/python/neml2/csrc/tensors/TensorBase.cxx
+++ b/python/neml2/csrc/tensors/TensorBase.cxx
@@ -67,40 +67,12 @@ def_TensorBase(py::module_ & m, const std::string & type)
       .def("torch", [](const T & self) { return torch::Tensor(self); })
       .def("tensor", [](const T & self) { return neml2::Tensor(self); })
       .def_property_readonly("dynamic",
-                             [](py::object self)
-                             {
-                               auto view = py::cast(DynamicView<T>(self.cast<T *>()));
-                               py::detail::keep_alive_impl(view, self);
-                               return view;
-                             })
-      .def_property_readonly("intmd",
-                             [](py::object self)
-                             {
-                               auto view = py::cast(IntmdView<T>(self.cast<T *>()));
-                               py::detail::keep_alive_impl(view, self);
-                               return view;
-                             })
-      .def_property_readonly("base",
-                             [](py::object self)
-                             {
-                               auto view = py::cast(BaseView<T>(self.cast<T *>()));
-                               py::detail::keep_alive_impl(view, self);
-                               return view;
-                             })
-      .def_property_readonly("batch",
-                             [](py::object self)
-                             {
-                               auto view = py::cast(BatchView<T>(self.cast<T *>()));
-                               py::detail::keep_alive_impl(view, self);
-                               return view;
-                             })
+                             [](py::object self) { return DynamicView<T>(std::move(self)); })
+      .def_property_readonly("intmd", [](py::object self) { return IntmdView<T>(std::move(self)); })
+      .def_property_readonly("base", [](py::object self) { return BaseView<T>(std::move(self)); })
+      .def_property_readonly("batch", [](py::object self) { return BatchView<T>(std::move(self)); })
       .def_property_readonly("static",
-                             [](py::object self)
-                             {
-                               auto view = py::cast(StaticView<T>(self.cast<T *>()));
-                               py::detail::keep_alive_impl(view, self);
-                               return view;
-                             })
+                             [](py::object self) { return StaticView<T>(std::move(self)); })
       .def("contiguous", &T::contiguous)
       .def("clone", &T::clone)
       .def("detach", &T::detach)

--- a/python/neml2/csrc/tensors/TensorBase.cxx
+++ b/python/neml2/csrc/tensors/TensorBase.cxx
@@ -69,34 +69,39 @@ def_TensorBase(py::module_ & m, const std::string & type)
       .def("torch", [](const T & self) { return torch::Tensor(self); })
       .def("tensor", [](const T & self) { return neml2::Tensor(self); })
       .def_property_readonly("dynamic",
-                             [](T * self)
+                             [](py::object self)
                              {
-                               py::capsule free_when_done(&self, [](void * f) {});
-                               return DynamicView<T>(self);
+                               auto view = py::cast(DynamicView<T>(self.cast<T *>()));
+                               py::detail::keep_alive_impl(view, self);
+                               return view;
                              })
       .def_property_readonly("intmd",
-                             [](T * self)
+                             [](py::object self)
                              {
-                               py::capsule free_when_done(&self, [](void * f) {});
-                               return IntmdView<T>(self);
+                               auto view = py::cast(IntmdView<T>(self.cast<T *>()));
+                               py::detail::keep_alive_impl(view, self);
+                               return view;
                              })
       .def_property_readonly("base",
-                             [](T * self)
+                             [](py::object self)
                              {
-                               py::capsule free_when_done(&self, [](void * f) {});
-                               return BaseView<T>(self);
+                               auto view = py::cast(BaseView<T>(self.cast<T *>()));
+                               py::detail::keep_alive_impl(view, self);
+                               return view;
                              })
       .def_property_readonly("batch",
-                             [](T * self)
+                             [](py::object self)
                              {
-                               py::capsule free_when_done(&self, [](void * f) {});
-                               return BatchView<T>(self);
+                               auto view = py::cast(BatchView<T>(self.cast<T *>()));
+                               py::detail::keep_alive_impl(view, self);
+                               return view;
                              })
       .def_property_readonly("static",
-                             [](T * self)
+                             [](py::object self)
                              {
-                               py::capsule free_when_done(&self, [](void * f) {});
-                               return StaticView<T>(self);
+                               auto view = py::cast(StaticView<T>(self.cast<T *>()));
+                               py::detail::keep_alive_impl(view, self);
+                               return view;
                              })
       .def("contiguous", &T::contiguous)
       .def("clone", &T::clone)

--- a/python/neml2/csrc/tensors/TensorBase.cxx
+++ b/python/neml2/csrc/tensors/TensorBase.cxx
@@ -24,8 +24,6 @@
 
 #include "neml2/tensors/tensors.h"
 
-#include <memory>
-
 #include "python/neml2/csrc/tensors/TensorBase.h"
 #include "python/neml2/csrc/tensors/DynamicView.h"
 #include "python/neml2/csrc/tensors/IntmdView.h"

--- a/python/neml2/csrc/tensors/TensorBase.cxx
+++ b/python/neml2/csrc/tensors/TensorBase.cxx
@@ -24,6 +24,8 @@
 
 #include "neml2/tensors/tensors.h"
 
+#include <memory>
+
 #include "python/neml2/csrc/tensors/TensorBase.h"
 #include "python/neml2/csrc/tensors/DynamicView.h"
 #include "python/neml2/csrc/tensors/IntmdView.h"
@@ -66,11 +68,26 @@ def_TensorBase(py::module_ & m, const std::string & type)
            })
       .def("torch", [](const T & self) { return torch::Tensor(self); })
       .def("tensor", [](const T & self) { return neml2::Tensor(self); })
-      .def_property_readonly("dynamic", [](T * self) { return new DynamicView<T>(self); })
-      .def_property_readonly("intmd", [](T * self) { return new IntmdView<T>(self); })
-      .def_property_readonly("base", [](T * self) { return new BaseView<T>(self); })
-      .def_property_readonly("batch", [](T * self) { return new BatchView<T>(self); })
-      .def_property_readonly("static", [](T * self) { return new StaticView<T>(self); })
+      .def_property_readonly(
+          "dynamic",
+          [](T * self) { return std::make_unique<DynamicView<T>>(self); },
+          py::keep_alive<0, 1>())
+      .def_property_readonly(
+          "intmd",
+          [](T * self) { return std::make_unique<IntmdView<T>>(self); },
+          py::keep_alive<0, 1>())
+      .def_property_readonly(
+          "base",
+          [](T * self) { return std::make_unique<BaseView<T>>(self); },
+          py::keep_alive<0, 1>())
+      .def_property_readonly(
+          "batch",
+          [](T * self) { return std::make_unique<BatchView<T>>(self); },
+          py::keep_alive<0, 1>())
+      .def_property_readonly(
+          "static",
+          [](T * self) { return std::make_unique<StaticView<T>>(self); },
+          py::keep_alive<0, 1>())
       .def("contiguous", &T::contiguous)
       .def("clone", &T::clone)
       .def("detach", &T::detach)

--- a/python/neml2/csrc/tensors/types.h
+++ b/python/neml2/csrc/tensors/types.h
@@ -109,7 +109,7 @@ public:
     pybind11::int_ start(src.start().expect_int());
     pybind11::int_ stop(src.stop().expect_int());
     pybind11::int_ step(src.step().expect_int());
-    return pybind11::slice(start, stop, step).release();
+    return pybind11::slice(start, stop, step);
   }
 };
 
@@ -186,7 +186,7 @@ public:
       pybind11::int_ start(src.slice().start().expect_int());
       pybind11::int_ stop(src.slice().stop().expect_int());
       pybind11::int_ step(src.slice().step().expect_int());
-      return pybind11::slice(start, stop, step).release();
+      return pybind11::slice(start, stop, step);
     }
     if (src.is_boolean())
       return src.boolean() ? Py_True : Py_False;

--- a/python/neml2/csrc/tensors/types.h
+++ b/python/neml2/csrc/tensors/types.h
@@ -106,10 +106,10 @@ public:
   static handle
   cast(const at::indexing::Slice & src, return_value_policy /* policy */, handle /* parent */)
   {
-    auto start = THPUtils_packInt64(src.start().expect_int());
-    auto stop = THPUtils_packInt64(src.stop().expect_int());
-    auto step = THPUtils_packInt64(src.step().expect_int());
-    return PySlice_New(start, stop, step);
+    pybind11::int_ start(src.start().expect_int());
+    pybind11::int_ stop(src.stop().expect_int());
+    pybind11::int_ step(src.step().expect_int());
+    return pybind11::slice(start, stop, step).release();
   }
 };
 
@@ -183,10 +183,10 @@ public:
       return THPUtils_packInt64(src.integer().expect_int());
     if (src.is_slice())
     {
-      auto start = THPUtils_packInt64(src.slice().start().expect_int());
-      auto stop = THPUtils_packInt64(src.slice().stop().expect_int());
-      auto step = THPUtils_packInt64(src.slice().step().expect_int());
-      return PySlice_New(start, stop, step);
+      pybind11::int_ start(src.slice().start().expect_int());
+      pybind11::int_ stop(src.slice().stop().expect_int());
+      pybind11::int_ step(src.slice().step().expect_int());
+      return pybind11::slice(start, stop, step).release();
     }
     if (src.is_boolean())
       return src.boolean() ? Py_True : Py_False;


### PR DESCRIPTION
There are two leak sites:
1. In python/neml2/tensors/TensorBase.cxx, I was returning heap pointers hoping python would take ownership and delete them. But apparently that's not happening. I am switching to unique_ptr + keep_alive to make sure the views outlive the original tensor.
2. In python/neml2/tensors/types.h, the type casters make PySlice_New without stealing the ownership from unpacked integers. Switching to pybind11::slice to avoid leaks.

Thanks @Jes-s-L for reporting the bug!