### PR TITLE
Filter derivatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ NEML2 is provided as open source software under a MIT [license](https://raw.gith
 
 Building should be as easy as cloning the repository, configuring with CMake, compiling with `make`, and installing with `make install`. Refer to the [installation guide](https://applied-material-modeling.github.io/neml2/install.html) for more detailed instructions and finer control over various dependencies as well as other build customization.
 
+Once NEML2 is built/installed, refer to the [getting started](https://applied-material-modeling.github.io/neml2/tutorials-getting-started.html) guide for commonly used APIs.
+
 ### Features and design philosophy
 
 #### Vectorization

--- a/doc/config/DoxygenLayout.xml
+++ b/doc/config/DoxygenLayout.xml
@@ -82,6 +82,7 @@
     </tab>
     <tab type="usergroup" title="Migration Guides">
       <tab type="user" url="@ref migration-200-210" title="Migrating from v2.0.0 to v2.1.0"/>
+      <tab type="user" url="@ref migration-211-212" title="Migrating from v2.1.1 to v2.1.2"/>
     </tab>
     <tab type="topics" title="Aditional Documentation"/>
     <tab type="usergroup" title="C++ API Reference">

--- a/doc/config/DoxygenLayoutPython.xml
+++ b/doc/config/DoxygenLayoutPython.xml
@@ -82,6 +82,7 @@
     </tab>
     <tab type="usergroup" title="Migration Guides">
       <tab type="user" url="../migration-200-210.html" title="Migrating from v2.0.0 to v2.1.0"/>
+      <tab type="user" url="../migration-211-212.html" title="Migrating from v2.1.1 to v2.1.2"/>
     </tab>
     <tab type="topics" title="Aditional Documentation"/>
     <tab type="usergroup" title="C++ API Reference">

--- a/doc/content/tutorials/getting_started.md
+++ b/doc/content/tutorials/getting_started.md
@@ -8,7 +8,69 @@ Once the NEML2 library is built following the [installation guide](@ref install)
 
 ## Downstream C++ project
 
-NEML2 core capabilities are implemented as a _library_, not a _program_. As a library, it will be used by another C++ program to parse and evaluate a material model defined in an [input file](@ref tutorials-models-input-file). Boilerplate for the C++ program can be found in this [set of tutorials](#tutorials-models), and external project integration is documented in the [installation guide](@ref external-project-integration).
+NEML2 core capabilities are implemented as a _library_, not a _program_. As a library, it will be used by another C++ program to parse and evaluate a material model defined in an [input file](@ref tutorials-models-input-file). Boilerplate for the C++ program can be found in the [quick start guide](#getting-started-quick-start) below as well as in this [set of tutorials](#tutorials-models), and external project integration is documented in the [installation guide](@ref external-project-integration).
+
+## Python script
+
+The other option to evaluate NEML2 material models is to use the NEML2 Python package. As mentioned in the [installation guide](@ref install), NEML2 also provides a Python package which provides bindings for the primitive tensors and parsers for deserializing and running material models. The following [quick start guide](#getting-started-quick-start) as well as this [set of tutorials](#tutorials-models) describe the usage of the package.
+
+## Quick start {#getting-started-quick-start}
+
+The following is a quick summary of the most common model API usage patterns. Each topic is covered in full detail in the [model tutorials](#tutorials-models).
+
+### Loading a model
+
+Given an [input file](@ref tutorials-models-input-file), a model is loaded with a single call:
+
+<div class="tabbed">
+
+- <b class="tab-title">C++</b>
+  @list:cpp:running_your_first_model/ex1.cxx
+
+- <b class="tab-title">Python</b>
+  @list:python:running_your_first_model/ex2.py
+
+</div>
+
+`load_model` parses the file and returns the named model ready for evaluation. The [running your first model tutorial](#tutorials-models-running-your-first-model) walks through a complete example.
+
+### Calling forward operators
+
+All NEML2 models expose three forward operators that accept a map of input variable values:
+
+| Operator           | Returns                                           |
+| ------------------ | ------------------------------------------------- |
+| `value`            | output variable values \f$ y = f(x) \f$           |
+| `dvalue`           | first derivatives \f$ \partial y / \partial x \f$ |
+| `value_and_dvalue` | both simultaneously                               |
+
+<div class="tabbed">
+
+- <b class="tab-title">C++</b>
+  @list:cpp:running_your_first_model/ex3.cxx
+
+- <b class="tab-title">Python</b>
+  @list:python:running_your_first_model/ex4.py
+
+</div>
+
+The return value of neml2::Model::value is a dictionary keyed by output variable name. neml2::Model::dvalue returns a nested dictionary keyed by `(output, input)` variable names.
+
+### Modifying parameter values
+
+Model parameters can be updated at runtime — useful for optimization or training loops. Parameters are accessed by name and assigned new tensor values:
+
+<div class="tabbed">
+
+- <b class="tab-title">C++</b>
+  @list:cpp:model_parameters/ex5.cxx
+
+- <b class="tab-title">Python</b>
+  @list:python:model_parameters/ex6.py
+
+</div>
+
+The [model parameters tutorial](#tutorials-models-model-parameters) covers parameters and buffers in detail, including how parameters can themselves be defined by other models.
 
 ## Utility binaries
 
@@ -33,7 +95,3 @@ For the Python package, matching CLI wrappers are registered in `pyproject.toml`
 - `neml2-time`
 
 These commands dispatch to the shipped binaries bundled inside the Python package. See each tool's help message (for example, `neml2-run --help`) for further details.
-
-## Python script
-
-The other option to evaluate NEML2 material models is to use the NEML2 Python package. As mentioned in the [installation guide](@ref install), NEML2 also provides a Python package which provides bindings for the primitive tensors and parsers for deserializing and running material models. This [set of tutorials](#tutorials-models) describes the usage of the package.

--- a/include/neml2/models/Model.h
+++ b/include/neml2/models/Model.h
@@ -192,11 +192,6 @@ public:
   void
   set_output_derivative_filter(const std::vector<std::pair<VariableName, VariableName>> & derivs);
 
-  /// Same as set_output_derivative_filter but applies only during nonlinear system assembly.
-  /// Only invalidates the nl_sys JIT graph cache; the regular graph cache is untouched.
-  void set_output_derivative_filter_nl_sys(
-      const std::vector<std::pair<VariableName, VariableName>> & derivs);
-
   /// Declaration of nonlinear parameters may require manipulation of input
   friend class ParameterStore;
 
@@ -206,7 +201,15 @@ public:
   /// ModelNonlinearSystem needs access to some setup methods
   friend class ModelNonlinearSystem;
 
+  /// ImplicitUpdate sets the nl_sys derivative filter on its sub-model at construction time
+  friend class ImplicitUpdate;
+
 protected:
+  /// Same as set_output_derivative_filter but applies only during nonlinear system assembly.
+  /// Only invalidates the nl_sys JIT graph cache; the regular graph cache is untouched.
+  void set_output_derivative_filter_nl_sys(
+      const std::vector<std::pair<VariableName, VariableName>> & derivs);
+
   virtual void link_input_variables();
   virtual void link_input_variables(Model * submodel);
   virtual void link_output_variables();

--- a/include/neml2/models/Model.h
+++ b/include/neml2/models/Model.h
@@ -187,6 +187,16 @@ public:
   /// Convenient shortcut to construct and return the model value and its derivative
   virtual std::tuple<ValueMap, DerivMap> value_and_dvalue(const ValueMap & in);
 
+  /// Set the (output, input) pairs whose derivatives should be computed and returned by dvalue and
+  /// value_and_dvalue. Pass an empty vector to clear the filter and compute all derivatives.
+  void
+  set_output_derivative_filter(const std::vector<std::pair<VariableName, VariableName>> & derivs);
+
+  /// Same as set_output_derivative_filter but applies only during nonlinear system assembly.
+  /// Only invalidates the nl_sys JIT graph cache; the regular graph cache is untouched.
+  void set_output_derivative_filter_nl_sys(
+      const std::vector<std::pair<VariableName, VariableName>> & derivs);
+
   /// Declaration of nonlinear parameters may require manipulation of input
   friend class ParameterStore;
 

--- a/include/neml2/models/VariableStore.h
+++ b/include/neml2/models/VariableStore.h
@@ -98,6 +98,30 @@ public:
   const std::optional<SecDerivSparsity> & second_derivative_sparsity() const;
   ///@}
 
+  /// Set the (output, input) pairs whose derivatives should be computed and returned.
+  /// Pass an empty vector to clear the filter and compute all derivatives.
+  void
+  set_output_derivative_filter(const std::vector<std::pair<VariableName, VariableName>> & derivs);
+
+  /// The currently active output derivative filter, or nullopt if all derivatives are requested.
+  const std::optional<std::vector<std::pair<VariableName, VariableName>>> &
+  requested_output_derivatives() const
+  {
+    return _requested_derivs;
+  }
+
+  /// Same as set_output_derivative_filter but applies only during nonlinear system assembly.
+  /// Pass an empty vector to clear the filter. Independent from the regular filter.
+  void set_output_derivative_filter_nl_sys(
+      const std::vector<std::pair<VariableName, VariableName>> & derivs);
+
+  /// The currently active nl_sys output derivative filter.
+  const std::optional<std::vector<std::pair<VariableName, VariableName>>> &
+  requested_output_derivatives_nl_sys() const
+  {
+    return _requested_derivs_nl_sys;
+  }
+
   ///@{
   /// Assign input variable values
   void assign_input(const ValueMap &, bool allow_nonexistent = false);
@@ -232,5 +256,13 @@ private:
 
   /// Second derivative sparsity for the nonlinear system
   std::optional<SecDerivSparsity> _secderiv_sparsity_nl_sys = std::nullopt;
+
+  /// User-requested subset of (output, input) derivative pairs; nullopt means compute all.
+  std::optional<std::vector<std::pair<VariableName, VariableName>>> _requested_derivs =
+      std::nullopt;
+
+  /// Same as _requested_derivs but applies only during nonlinear system assembly.
+  std::optional<std::vector<std::pair<VariableName, VariableName>>> _requested_derivs_nl_sys =
+      std::nullopt;
 };
 } // namespace neml2

--- a/include/neml2/models/VariableStore.h
+++ b/include/neml2/models/VariableStore.h
@@ -110,18 +110,6 @@ public:
     return _requested_derivs;
   }
 
-  /// Same as set_output_derivative_filter but applies only during nonlinear system assembly.
-  /// Pass an empty vector to clear the filter. Independent from the regular filter.
-  void set_output_derivative_filter_nl_sys(
-      const std::vector<std::pair<VariableName, VariableName>> & derivs);
-
-  /// The currently active nl_sys output derivative filter.
-  const std::optional<std::vector<std::pair<VariableName, VariableName>>> &
-  requested_output_derivatives_nl_sys() const
-  {
-    return _requested_derivs_nl_sys;
-  }
-
   ///@{
   /// Assign input variable values
   void assign_input(const ValueMap &, bool allow_nonexistent = false);
@@ -146,6 +134,11 @@ public:
   ///@}
 
 protected:
+  /// Same as set_output_derivative_filter but applies only during nonlinear system assembly.
+  /// Pass an empty vector to clear the filter. Independent from the regular filter.
+  void set_output_derivative_filter_nl_sys(
+      const std::vector<std::pair<VariableName, VariableName>> & derivs);
+
   /**
    * @brief Send padding variables to options
    *

--- a/python/src/csrc/core/Model.cxx
+++ b/python/src/csrc/core/Model.cxx
@@ -144,5 +144,12 @@ def(py::module_ & m, py::class_<Model, std::shared_ptr<Model>> & c)
              auto [values, derivs] =
                  self.value_and_dvalue(unpack_value_map(pyinputs, false, base_shape_lookup));
              return std::make_pair(pack_value_map(values), pack_deriv_map(derivs));
-           });
+           })
+      .def(
+          "set_output_derivative_filter",
+          [](Model & self, const std::vector<std::pair<std::string, std::string>> & derivs)
+          { self.set_output_derivative_filter(derivs); },
+          py::arg("derivs"),
+          "Filter which (output, input) derivative pairs are computed and returned by dvalue and "
+          "value_and_dvalue. Pass an empty list to clear the filter and compute all derivatives.");
 }

--- a/src/neml2/models/ImplicitUpdate.cxx
+++ b/src/neml2/models/ImplicitUpdate.cxx
@@ -93,6 +93,18 @@ ImplicitUpdate::ImplicitUpdate(const OptionSet & options)
     const auto & u = model->input_variable(ulayout.var(i));
     clone_output_variable(u);
   }
+
+  // During the iterative nonlinear solve, the sub-model's nl_sys JIT graph only needs residual
+  // derivatives w.r.t. unknowns (for the Jacobian A = dr/du). Derivatives w.r.t. given variables
+  // (dr/dg) are never used during the solve — only once post-convergence for the IFT step, which
+  // runs outside the nl_sys assembly context. Pre-setting this filter here ensures the nl_sys JIT
+  // graph is built correctly from the very first assembly and is never invalidated again.
+  std::vector<std::pair<VariableName, VariableName>> nl_sys_pairs;
+  nl_sys_pairs.reserve(blayout.nvar() * ulayout.nvar());
+  for (std::size_t i = 0; i < blayout.nvar(); i++)
+    for (std::size_t j = 0; j < ulayout.nvar(); j++)
+      nl_sys_pairs.emplace_back(blayout.var(i), ulayout.var(j));
+  model->set_output_derivative_filter_nl_sys(nl_sys_pairs);
 }
 
 void

--- a/src/neml2/models/Model.cxx
+++ b/src/neml2/models/Model.cxx
@@ -453,6 +453,31 @@ Model::value_and_dvalue(const ValueMap & in)
   return {collect_output(), collect_output_derivatives()};
 }
 
+void
+Model::set_output_derivative_filter(
+    const std::vector<std::pair<VariableName, VariableName>> & derivs)
+{
+  // Stores the filter and resets _deriv_sparsity (not nl_sys — those are independent).
+  VariableStore::set_output_derivative_filter(derivs);
+
+  // Invalidate only the regular traced graphs for dout=true indices (2, 3, 6, 7).
+  // The nl_sys graphs are independent and are not affected by this filter.
+  for (const std::size_t idx : {2ul, 3ul, 6ul, 7ul})
+    _traced_functions[idx].clear();
+}
+
+void
+Model::set_output_derivative_filter_nl_sys(
+    const std::vector<std::pair<VariableName, VariableName>> & derivs)
+{
+  // Stores the nl_sys filter and resets _deriv_sparsity_nl_sys.
+  VariableStore::set_output_derivative_filter_nl_sys(derivs);
+
+  // Invalidate only the nl_sys traced graphs for dout=true indices (2, 3, 6, 7).
+  for (const std::size_t idx : {2ul, 3ul, 6ul, 7ul})
+    _traced_functions_nl_sys[idx].clear();
+}
+
 std::shared_ptr<Model>
 Model::registered_model(const std::string & name) const
 {

--- a/src/neml2/models/VariableStore.cxx
+++ b/src/neml2/models/VariableStore.cxx
@@ -224,15 +224,47 @@ VariableStore::zero_undefined_input()
 }
 
 void
+VariableStore::set_output_derivative_filter(
+    const std::vector<std::pair<VariableName, VariableName>> & derivs)
+{
+  _requested_derivs = derivs.empty() ? std::nullopt : std::make_optional(derivs);
+  _deriv_sparsity = std::nullopt;
+  // _deriv_sparsity_nl_sys is independent — use set_output_derivative_filter_nl_sys to change it
+}
+
+void
+VariableStore::set_output_derivative_filter_nl_sys(
+    const std::vector<std::pair<VariableName, VariableName>> & derivs)
+{
+  _requested_derivs_nl_sys = derivs.empty() ? std::nullopt : std::make_optional(derivs);
+  _deriv_sparsity_nl_sys = std::nullopt;
+}
+
+void
 VariableStore::cache_derivative_sparsity()
 {
+  const bool nl_sys = currently_assembling_nonlinear_system();
+  const auto & filter = nl_sys ? _requested_derivs_nl_sys : _requested_derivs;
+
   std::vector<std::pair<VariableBase *, const VariableBase *>> sparsity;
   for (auto && [yname, yvar] : output_variables())
     for (const auto & [dy_dx, xvar] : yvar->derivatives())
-      if (dy_dx.defined())
-        sparsity.emplace_back(yvar.get(), xvar);
+    {
+      if (!dy_dx.defined())
+        continue;
+      if (filter.has_value())
+      {
+        auto it = std::find_if(filter->begin(),
+                               filter->end(),
+                               [&](const auto & req)
+                               { return req.first == yname && req.second == xvar->name(); });
+        if (it == filter->end())
+          continue;
+      }
+      sparsity.emplace_back(yvar.get(), xvar);
+    }
 
-  if (currently_assembling_nonlinear_system())
+  if (nl_sys)
     _deriv_sparsity_nl_sys = std::move(sparsity);
   else
     _deriv_sparsity = std::move(sparsity);
@@ -413,8 +445,20 @@ VariableStore::collect_output_derivatives() const
   DerivMap derivs;
   for (auto && [name, var] : output_variables())
     for (const auto & [deriv, xvar] : var->derivatives())
-      if (deriv.defined())
-        derivs[name][xvar->name()] = deriv.tensor();
+    {
+      if (!deriv.defined())
+        continue;
+      if (_requested_derivs.has_value())
+      {
+        auto it = std::find_if(_requested_derivs->begin(),
+                               _requested_derivs->end(),
+                               [&](const auto & req)
+                               { return req.first == name && req.second == xvar->name(); });
+        if (it == _requested_derivs->end())
+          continue;
+      }
+      derivs[name][xvar->name()] = deriv.tensor();
+    }
   return derivs;
 }
 

--- a/src/neml2/models/VariableStore.cxx
+++ b/src/neml2/models/VariableStore.cxx
@@ -254,10 +254,12 @@ VariableStore::cache_derivative_sparsity()
         continue;
       if (filter.has_value())
       {
-        auto it = std::find_if(filter->begin(),
-                               filter->end(),
-                               [&](const auto & req)
-                               { return req.first == yname && req.second == xvar->name(); });
+        const auto & yn = yname;
+        const auto & xn = xvar->name();
+        auto it =
+            std::find_if(filter->begin(),
+                         filter->end(),
+                         [&](const auto & req) { return req.first == yn && req.second == xn; });
         if (it == filter->end())
           continue;
       }
@@ -448,13 +450,17 @@ VariableStore::collect_output_derivatives() const
     {
       if (!deriv.defined())
         continue;
-      if (_requested_derivs.has_value())
+      const auto & filter =
+          currently_assembling_nonlinear_system() ? _requested_derivs_nl_sys : _requested_derivs;
+      if (filter.has_value())
       {
-        auto it = std::find_if(_requested_derivs->begin(),
-                               _requested_derivs->end(),
-                               [&](const auto & req)
-                               { return req.first == name && req.second == xvar->name(); });
-        if (it == _requested_derivs->end())
+        const auto & yn = name;
+        const auto & xn = xvar->name();
+        auto it =
+            std::find_if(filter->begin(),
+                         filter->end(),
+                         [&](const auto & req) { return req.first == yn && req.second == xn; });
+        if (it == filter->end())
           continue;
       }
       derivs[name][xvar->name()] = deriv.tensor();

--- a/tests/unit/models/test_Model.cxx
+++ b/tests/unit/models/test_Model.cxx
@@ -35,6 +35,72 @@ using namespace neml2;
 
 TEST_CASE("Model", "[models]")
 {
+  SECTION("set_output_derivative_filter")
+  {
+    auto model = load_model("models/common/ScalarLinearCombination.i", "model");
+
+    set_default_dtype(kFloat64);
+    ValueMap in;
+    in["A"] = Scalar::full(3.0);
+    in["B"] = Scalar::full(2.0);
+
+    SECTION("no filter returns all derivatives")
+    {
+      auto derivs = model->dvalue(in);
+      REQUIRE(derivs.count("C") == 1);
+      REQUIRE(derivs.at("C").count("A") == 1);
+      REQUIRE(derivs.at("C").count("B") == 1);
+    }
+
+    SECTION("filter restricts to requested pair")
+    {
+      model->set_output_derivative_filter({{"C", "A"}});
+      auto derivs = model->dvalue(in);
+      REQUIRE(derivs.count("C") == 1);
+      REQUIRE(derivs.at("C").count("A") == 1);
+      REQUIRE(derivs.at("C").count("B") == 0);
+    }
+
+    SECTION("clearing filter restores all derivatives")
+    {
+      model->set_output_derivative_filter({{"C", "A"}});
+      model->set_output_derivative_filter({});
+      auto derivs = model->dvalue(in);
+      REQUIRE(derivs.count("C") == 1);
+      REQUIRE(derivs.at("C").count("A") == 1);
+      REQUIRE(derivs.at("C").count("B") == 1);
+    }
+
+    SECTION("filter applies to value_and_dvalue")
+    {
+      model->set_output_derivative_filter({{"C", "B"}});
+      auto [vals, derivs] = model->value_and_dvalue(in);
+      REQUIRE(vals.count("C") == 1);
+      REQUIRE(derivs.count("C") == 1);
+      REQUIRE(derivs.at("C").count("A") == 0);
+      REQUIRE(derivs.at("C").count("B") == 1);
+    }
+
+    SECTION("changing filter after evaluation uses the new filter")
+    {
+      // First evaluation with filter on A — traces the JIT graph
+      model->set_output_derivative_filter({{"C", "A"}});
+      {
+        auto derivs = model->dvalue(in);
+        REQUIRE(derivs.at("C").count("A") == 1);
+        REQUIRE(derivs.at("C").count("B") == 0);
+      }
+
+      // Change filter to B — must invalidate the old traced graph and re-trace
+      model->set_output_derivative_filter({{"C", "B"}});
+      {
+        auto derivs = model->dvalue(in);
+        REQUIRE(derivs.at("C").count("A") == 0);
+        REQUIRE(derivs.at("C").count("B") == 1);
+      }
+    }
+  }
+
   SECTION("variable type")
   {
     auto model = load_model("models/common/ComposedModel3.i", "model");


### PR DESCRIPTION
This pull request introduces a new feature that allows users to filter which (output, input) derivative pairs are computed and returned by the NEML2 model API, both in C++ and Python.

**Derivative Filtering Feature:**

* Added methods `set_output_derivative_filter` and `set_output_derivative_filter_nl_sys` to the `Model` and `VariableStore` classes to allow users to specify which output-input derivative pairs should be computed, with support for clearing the filter to revert to all derivatives. This includes independent filters for standard and nonlinear system assembly contexts. [[1]](diffhunk://#diff-8bd8051c017cabb279dff93530bc01f10aa107b8039634244b6eae42988459b5R190-R199) [[2]](diffhunk://#diff-4994b876a1f1ed383e74212b2c725ca51da4992b2da4c0c3f18b38731e761558R101-R124) [[3]](diffhunk://#diff-4994b876a1f1ed383e74212b2c725ca51da4992b2da4c0c3f18b38731e761558R259-R266) [[4]](diffhunk://#diff-490b5886788908b6e2513110485d6bba89a166ec990cfe7b3e905cc0297a6c49R456-R480) [[5]](diffhunk://#diff-b8385d6ce9ca151d89f0f9af4bffee57f8483c6f8f74647a0a123245ccfe70d7R226-R267)
* Updated the internal logic for derivative sparsity and output collection to respect the active filter, ensuring only the requested derivatives are computed and returned.
* Exposed the new filtering API to Python bindings, allowing Python users to set the derivative filter from Python code.
* Updated `ImplicitUpdate` to pre-set the appropriate derivative filter for nonlinear system solves, optimizing JIT graph construction and cache usage.
* Added comprehensive unit tests for the new filtering functionality, covering various scenarios including filter changes and clearing.

**Documentation and Tutorials:**

* Expanded the "Getting Started" and tutorial documentation to better describe API usage patterns, including the new filtering feature and both C++ and Python workflows. [[1]](diffhunk://#diff-e150ef91bb2802d671ff6fb6b5599dedb4830c99d28ed415dccdedf9b24b35e6L11-R73) [[2]](diffhunk://#diff-e150ef91bb2802d671ff6fb6b5599dedb4830c99d28ed415dccdedf9b24b35e6L36-L39)
* Added a direct link to the "getting started" guide in the main `README.md` for improved discoverability.

**Migration Guides:**

* Updated Doxygen and Python documentation layouts to include a migration guide for the new version (v2.1.2). [[1]](diffhunk://#diff-b9a09f20be8cfb8da35d0e5802edd530745485a761922f05cbf0e3feae88f6daR85) [[2]](diffhunk://#diff-f264a7a4da3d96b1096b117a7d350aa6bf008d387f858ac2fc53484b428c45a8R85)