### PR TITLE
Move type demangling to C++; add neml2-syntax --server mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ endif()
 # ----------------------------------------------------------------------------
 # nmhit (neml2-hit)
 # ----------------------------------------------------------------------------
-find_package(nmhit CONFIG HINTS ${NEML2_CONTRIB_PREFIX}/nmhit)
+find_package(nmhit 0.1.2 CONFIG HINTS ${NEML2_CONTRIB_PREFIX}/nmhit)
 
 if(NOT nmhit_FOUND)
       # nmhit is a git submodule, so we can just check it out and build it if it's not found.
@@ -184,7 +184,7 @@ if(NOT nmhit_FOUND)
       endif()
       set(nmhit_INSTALL_PREFIX ${NEML2_CONTRIB_PREFIX}/nmhit CACHE PATH "nmhit install prefix")
       custom_install(nmhit contrib/install_nmhit.sh ${NEML2_SOURCE_DIR}/contrib/nmhit-src ${NEML2_CONTRIB_PREFIX}/nmhit-build ${nmhit_INSTALL_PREFIX})
-      find_package(nmhit CONFIG REQUIRED PATHS ${nmhit_INSTALL_PREFIX} NO_DEFAULT_PATH)
+      find_package(nmhit 0.1.2 CONFIG REQUIRED PATHS ${nmhit_INSTALL_PREFIX} NO_DEFAULT_PATH)
 endif()
 
 # extract library path and include dir from the imported target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # dependencies: cmake.version_min
 cmake_minimum_required(VERSION 3.26.1)
 # dependencies: neml2.version
-project(NEML2 VERSION 2.1.3 LANGUAGES C CXX)
+project(NEML2 VERSION 2.1.4 LANGUAGES C CXX)
 
 # ----------------------------------------------------------------------------
 # Policy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ if(NOT nmhit_FOUND)
       endif()
       set(nmhit_INSTALL_PREFIX ${NEML2_CONTRIB_PREFIX}/nmhit CACHE PATH "nmhit install prefix")
       custom_install(nmhit contrib/install_nmhit.sh ${NEML2_SOURCE_DIR}/contrib/nmhit-src ${NEML2_CONTRIB_PREFIX}/nmhit-build ${nmhit_INSTALL_PREFIX})
+      # dependencies: nmhit.version_min
       find_package(nmhit 0.1.2 CONFIG REQUIRED PATHS ${nmhit_INSTALL_PREFIX} NO_DEFAULT_PATH)
 endif()
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -35,8 +35,9 @@ pyzag:
     - pyproject.toml
 
 nmhit:
-  version: "0.1.2"
+  version_min: "0.1.2"
   files:
+    - CMakeLists.txt
     - pyproject.toml
 
 # ---- Formatters / pre-commit hooks ----

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -118,7 +118,7 @@ doxygen:
 
 # ---- Project version ----
 neml2:
-  version: "2.1.3"
+  version: "2.1.4"
   files:
     - CMakeLists.txt
     - pyproject.toml

--- a/doc/content/installation/integration.md
+++ b/doc/content/installation/integration.md
@@ -63,7 +63,7 @@ FetchContent_Declare(
   neml2
   GIT_REPOSITORY https://github.com/applied-material-modeling/neml2.git
   <!-- dependencies: neml2.version -->
-  GIT_TAG v2.1.3
+  GIT_TAG v2.1.4
 )
 FetchContent_MakeAvailable(neml2)
 add_executable(foo main.cxx)

--- a/doc/scripts/syntax_to_md.py
+++ b/doc/scripts/syntax_to_md.py
@@ -26,55 +26,12 @@
 
 import yaml
 import sys
-import re
 from pathlib import Path
 from loguru import logger
 import unicodedata as ud
 from typing import Union
 
 
-def remove_namespace(type):
-    type = type.replace("std::", "")
-    type = type.replace("torch::", "")
-    type = type.replace("c10::", "")
-    type = type.replace("at::", "")
-    type = type.replace("neml2::", "")
-    type = type.replace("utils::", "")
-    type = type.replace("jit::", "")
-    return type
-
-
-def normalize_string_types(type):
-    return re.sub(
-        r"(?:\b[\w:]+::)?basic_string<\s*char\s*,\s*(?:[\w:]+::)?char_traits<char>\s*,\s*(?:[\w:]+::)?allocator<char>\s*>\s*",
-        "std::string",
-        type,
-    )
-
-
-def normalize_vector_types(type):
-    return re.sub(
-        r"(?:\b[\w:]+::)?vector<\s*([^,>]+)\s*,\s*(?:[\w:]+::)?allocator<[^>]+>\s*>\s*",
-        r"vector<\1>",
-        type,
-    )
-
-
-def demangle(type):
-    type = re.sub(r"SmallVector<[^>]*>", "tensor shape", type)
-    type = normalize_string_types(type)
-    type = normalize_vector_types(type)
-    type = re.sub(r",\s*(?:[\w:]+::)?allocator<[^>]+>\s*", "", type)
-    type = remove_namespace(type)
-    type = re.sub("TensorName<(.+)>", r"\1 🔗", type)
-    type = re.sub("vector<(.+)>", r"list of \1", type)
-    # Call all integral/floating point types "number", as this syntax documentation faces the general audience potentially without computer science background
-    type = type.replace("int", "number")
-    type = type.replace("long", "number")
-    type = type.replace("double", "number")
-    type = type.replace("unsigned", "non-negative")
-
-    return type
 
 
 def postprocess(value, type):
@@ -237,7 +194,7 @@ def syntax_to_md(syntax_file: Path, outdir: Path, logfile: Path) -> int:
                         if info["suppressed"]:
                             continue
 
-                        param_type = demangle(info["type"])
+                        param_type = info["type"]
                         param_value = postprocess(info["value"], param_type)
                         stream.write("<details>\n")
                         if not info["doc"]:

--- a/include/neml2/base/OptionSet.h
+++ b/include/neml2/base/OptionSet.h
@@ -42,6 +42,9 @@ struct TensorName;
 
 bool options_compatible(const OptionSet & opts, const OptionSet & additional_opts);
 
+/// Convert a raw C++ type string into a human-readable form suitable for end users.
+std::string user_readable_type(const std::string & type);
+
 // Streaming operators
 std::ostream & operator<<(std::ostream & os, const OptionSet & p);
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   # dependencies: pyzag.version
   "pyzag==1.1.1",
   # dependencies: nmhit.version
-  "nmhit==0.1.2",
+  "nmhit>=0.1.2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ NEML2_CSV = "ON"
 [project]
 name = "neml2"
 # dependencies: neml2.version
-version = "2.1.3"
+version = "2.1.4"
 authors = [
   { name = "Mark Messner", email = "messner@anl.gov" },
   { name = "Gary Hu", email = "thu@anl.gov" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "torch",
   # dependencies: pyzag.version
   "pyzag==1.1.1",
-  # dependencies: nmhit.version
+  # dependencies: nmhit.version_min
   "nmhit>=0.1.2",
 ]
 
@@ -97,7 +97,7 @@ skip = "*win* *manylinux_i686 *manylinux_aarch64 *manylinux_ppc64le *manylinux_s
 
 environment = { CMAKE_GENERATOR = "Ninja" }
 build-verbosity = 1
-build-frontend = {name = "build", args = ["--no-isolation"]}
+build-frontend = { name = "build", args = ["--no-isolation"] }
 
 before-all = ""
 # dependencies: pybind11_stubgen.version_min

--- a/src/neml2/base/OptionSet.cxx
+++ b/src/neml2/base/OptionSet.cxx
@@ -35,10 +35,10 @@ namespace
 std::string
 _remove_namespaces(std::string type)
 {
-  for (const std::string & ns :
-       {"std::__cxx11::", "std::", "torch::", "c10::", "at::", "neml2::", "utils::", "jit::"})
+  for (const std::string & ns : std::vector<std::string>{
+           "std::__cxx11::", "std::", "torch::", "c10::", "at::", "neml2::", "utils::", "jit::"})
   {
-    std::size_t pos;
+    std::size_t pos = 0;
     while ((pos = type.find(ns)) != std::string::npos)
       type.erase(pos, ns.size());
   }
@@ -46,7 +46,7 @@ _remove_namespaces(std::string type)
 }
 
 std::string
-_normalize_string(std::string type)
+_normalize_string(const std::string & type)
 {
   static const std::regex re(
       R"((?:\w+::)*basic_string\s*<\s*char\s*,\s*(?:\w+::)*char_traits\s*<\s*char\s*>\s*,\s*(?:\w+::)*allocator\s*<\s*char\s*>\s*>)");
@@ -54,7 +54,7 @@ _normalize_string(std::string type)
 }
 
 std::string
-_normalize_vector(std::string type)
+_normalize_vector(const std::string & type)
 {
   static const std::regex re(
       R"((?:\w+::)*vector\s*<\s*([^,>]+)\s*,\s*(?:\w+::)*allocator\s*<[^>]+>\s*>)");
@@ -62,14 +62,14 @@ _normalize_vector(std::string type)
 }
 
 std::string
-_normalize_small_vector(std::string type)
+_normalize_small_vector(const std::string & type)
 {
   static const std::regex re(R"((?:\w+::)*SmallVector\s*<[^>]*>)");
   return std::regex_replace(type, re, "tensor shape");
 }
 
 std::string
-_normalize_tensor_name(std::string type)
+_normalize_tensor_name(const std::string & type)
 {
   static const std::regex re(R"((?:\w+::)*TensorName\s*<\s*([^>]+)\s*>)");
   return std::regex_replace(type, re, "$1");
@@ -123,6 +123,7 @@ user_readable_type(const std::string & type)
   }
   return t;
 }
+
 bool
 options_compatible(const OptionSet & opts, const OptionSet & additional_opts)
 {

--- a/src/neml2/base/OptionSet.cxx
+++ b/src/neml2/base/OptionSet.cxx
@@ -23,12 +23,106 @@
 // THE SOFTWARE.
 
 #include <iostream>
+#include <regex>
 
 #include "neml2/base/OptionSet.h"
 #include "neml2/misc/assertions.h"
 
 namespace neml2
 {
+namespace
+{
+std::string
+_remove_namespaces(std::string type)
+{
+  for (const std::string & ns :
+       {"std::__cxx11::", "std::", "torch::", "c10::", "at::", "neml2::", "utils::", "jit::"})
+  {
+    std::size_t pos;
+    while ((pos = type.find(ns)) != std::string::npos)
+      type.erase(pos, ns.size());
+  }
+  return type;
+}
+
+std::string
+_normalize_string(std::string type)
+{
+  static const std::regex re(
+      R"((?:\w+::)*basic_string\s*<\s*char\s*,\s*(?:\w+::)*char_traits\s*<\s*char\s*>\s*,\s*(?:\w+::)*allocator\s*<\s*char\s*>\s*>)");
+  return std::regex_replace(type, re, "string");
+}
+
+std::string
+_normalize_vector(std::string type)
+{
+  static const std::regex re(
+      R"((?:\w+::)*vector\s*<\s*([^,>]+)\s*,\s*(?:\w+::)*allocator\s*<[^>]+>\s*>)");
+  return std::regex_replace(type, re, "vector<$1>");
+}
+
+std::string
+_normalize_small_vector(std::string type)
+{
+  static const std::regex re(R"((?:\w+::)*SmallVector\s*<[^>]*>)");
+  return std::regex_replace(type, re, "tensor shape");
+}
+
+std::string
+_normalize_tensor_name(std::string type)
+{
+  static const std::regex re(R"((?:\w+::)*TensorName\s*<\s*([^>]+)\s*>)");
+  return std::regex_replace(type, re, "$1");
+}
+
+std::string
+_vector_to_list(std::string type)
+{
+  // Apply iteratively to handle nested vectors: vector<vector<T>> → list of list of T.
+  static const std::regex re(R"(vector\s*<\s*([^<>]+)\s*>)");
+  std::string prev;
+  do
+  {
+    prev = type;
+    type = std::regex_replace(type, re, "list of $1");
+  } while (type != prev);
+  return type;
+}
+
+std::string
+_normalize_numeric_types(std::string type)
+{
+  static const std::regex int_re(R"(\bint\b)");
+  static const std::regex long_re(R"(\blong\b)");
+  static const std::regex double_re(R"(\bdouble\b)");
+  static const std::regex unsigned_re(R"(\bunsigned\b)");
+  type = std::regex_replace(type, unsigned_re, "non-negative");
+  type = std::regex_replace(type, int_re, "number");
+  type = std::regex_replace(type, long_re, "number");
+  type = std::regex_replace(type, double_re, "number");
+  return type;
+}
+} // namespace
+
+std::string
+user_readable_type(const std::string & type)
+{
+  std::string t = type;
+  for (int i = 0; i < 8; ++i)
+  {
+    std::string prev = t;
+    t = _normalize_small_vector(t);
+    t = _normalize_string(t);
+    t = _normalize_tensor_name(t);
+    t = _remove_namespaces(t);
+    t = _normalize_vector(t);
+    t = _vector_to_list(t);
+    t = _normalize_numeric_types(t);
+    if (t == prev)
+      break;
+  }
+  return t;
+}
 bool
 options_compatible(const OptionSet & opts, const OptionSet & additional_opts)
 {
@@ -199,7 +293,7 @@ OptionSet::to_str() const
   while (it != _values.end())
   {
     os << "  " << it->first << ":\n";
-    os << "    type: " << it->second->type() << '\n';
+    os << "    type: " << user_readable_type(it->second->type()) << '\n';
     os << "    ftype: " << it->second->ftype() << '\n';
     if (it->second->doc().empty())
       os << "    doc:\n";

--- a/src/tools/neml2-syntax.cxx
+++ b/src/tools/neml2-syntax.cxx
@@ -29,6 +29,11 @@
 
 #include <argparse/argparse.hpp>
 
+#ifdef NEML2_JSON
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+#endif
+
 int
 main(int argc, char * argv[])
 {
@@ -50,6 +55,9 @@ main(int argc, char * argv[])
       .default_value(std::string(""));
   program.add_argument("--summary")
       .help("emit only the type, section, and doc string for each object (omit per-option detail)")
+      .flag();
+  program.add_argument("--server")
+      .help("run as a long-lived JSON server on stdin/stdout (requires NEML2_JSON)")
       .flag();
 
   // Force link dynamic libraries
@@ -76,6 +84,140 @@ main(int argc, char * argv[])
   const auto section_filter = program.get<std::string>("--section");
   const auto type_filter = program.get<std::string>("--type");
   const bool summary = program.get<bool>("--summary");
+  const bool server_mode = program.get<bool>("--server");
+
+  if (server_mode && (program.is_used("--yaml") || program.is_used("--section") ||
+                      program.is_used("--type") || summary))
+  {
+    std::cerr << "error: --server is incompatible with --yaml, --section, --type, and --summary\n";
+    return 1;
+  }
+
+#ifdef NEML2_JSON
+  if (server_mode)
+  {
+    // Collect all OptionSets once; build pointer list after vector is fully populated
+    std::vector<neml2::OptionSet> all_opts_storage;
+    all_opts_storage.push_back(neml2::Settings::expected_options());
+    for (const auto & [type, info] : neml2::Registry::info())
+      all_opts_storage.push_back(info.expected_options);
+    std::vector<const neml2::OptionSet *> all_opts;
+    for (const auto & opts : all_opts_storage)
+      all_opts.push_back(&opts);
+
+    auto ftype_str = [](neml2::FType f) -> std::string
+    {
+      if (f == neml2::FType::INPUT)
+        return "INPUT";
+      if (f == neml2::FType::OUTPUT)
+        return "OUTPUT";
+      if (f == neml2::FType::PARAMETER)
+        return "PARAMETER";
+      if (f == neml2::FType::BUFFER)
+        return "BUFFER";
+      return "NONE";
+    };
+
+    auto opts_to_json = [&](const neml2::OptionSet & opts) -> json
+    {
+      json j;
+      j["type"] = opts.type();
+      j["section"] = opts.section();
+      j["doc"] = opts.doc();
+      json options = json::array();
+      for (const auto & [name, opt] : opts)
+      {
+        if (opt->suppressed())
+          continue;
+        json o;
+        o["name"] = name;
+        o["doc"] = opt->doc();
+        o["ftype"] = ftype_str(opt->ftype());
+        o["required"] = opt->required();
+        o["type"] = neml2::user_readable_type(opt->type());
+        options.push_back(std::move(o));
+      }
+      j["options"] = std::move(options);
+      return j;
+    };
+
+    std::string line;
+    while (std::getline(std::cin, line))
+    {
+      if (line.empty())
+        continue;
+      json req;
+      try
+      {
+        req = json::parse(line);
+      }
+      catch (...)
+      {
+        std::cout << json{{"id", nullptr}, {"error", "parse error"}}.dump() << "\n";
+        std::cout.flush();
+        continue;
+      }
+
+      const auto id = req.value("id", json{});
+      const std::string method = req.value("method", "");
+      json result;
+
+      if (method == "list_sections")
+      {
+        std::set<std::string> sections;
+        for (const auto * opts : all_opts)
+          if (!opts->section().empty())
+            sections.insert(opts->section());
+        result = json::array();
+        for (const auto & s : sections)
+          result.push_back(s);
+      }
+      else if (method == "list_types")
+      {
+        const std::string section = req.value("section", "");
+        result = json::array();
+        for (const auto * opts : all_opts)
+        {
+          if (!section.empty() && opts->section() != section)
+            continue;
+          if (opts->type().empty())
+            continue;
+          result.push_back(
+              {{"type", opts->type()}, {"section", opts->section()}, {"doc", opts->doc()}});
+        }
+      }
+      else if (method == "get_options")
+      {
+        const std::string type = req.value("type", "");
+        result = nullptr;
+        for (const auto * opts : all_opts)
+        {
+          if (opts->type() == type)
+          {
+            result = opts_to_json(*opts);
+            break;
+          }
+        }
+      }
+      else
+      {
+        std::cout << json{{"id", id}, {"error", "unknown method"}}.dump() << "\n";
+        std::cout.flush();
+        continue;
+      }
+
+      std::cout << json{{"id", id}, {"result", std::move(result)}}.dump() << "\n";
+      std::cout.flush();
+    }
+    return 0;
+  }
+#else
+  if (server_mode)
+  {
+    std::cerr << "neml2-syntax --server requires NEML2_JSON=ON\n";
+    return 1;
+  }
+#endif
 
   auto emit = [&](const neml2::OptionSet & opts)
   {


### PR DESCRIPTION
## Summary

- Ports the type-demangling logic (namespace stripping, vector/string normalization, numeric-type aliasing) from `syntax_to_md.py` into a new `user_readable_type()` free function in `OptionSet.cxx`/`.h`, so the YAML output from `neml2-syntax` already carries human-readable types natively and any consumer (Python docs script, `--server` mode, future tooling) can reuse the same result without reimplementing it.
- Removes the now-redundant Python `demangle()` helpers from `doc/scripts/syntax_to_md.py`; `param_type` is now taken directly from the pre-demangled YAML.
- Adds `--server` mode to `neml2-syntax` (requires `NEML2_JSON=ON`) that runs as a long-lived newline-delimited JSON-RPC server on stdin/stdout, exposing `list_sections`, `list_types`, and `get_options` methods for editor/IDE integrations.
- Relaxes the nmhit dependency from an exact pin (`==0.1.2` / no-version `find_package`) to a minimum-version bound (`>=0.1.2` in pyproject.toml, `find_package(nmhit 0.1.2 ...)` in CMakeLists.txt).

## Test plan

- [ ] Build with `cmake --preset dev && cmake --build --preset dev` — confirm `neml2-syntax` compiles cleanly.
- [ ] Run `neml2-syntax --section Models --summary` and verify type strings are human-readable (e.g. `list of string` instead of `std::vector<std::basic_string<...>>`).
- [ ] Run `neml2-syntax --server`, send `{"id":1,"method":"list_sections"}` on stdin, confirm JSON response on stdout.
- [ ] Run `doc/scripts/syntax_to_md.py` and verify the generated Markdown output is unchanged.
- [ ] Confirm `pip install ".[dev]"` resolves with `nmhit>=0.1.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)