### PR TITLE
Add --json output mode to neml2-inspect; bump version to 2.1.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # dependencies: cmake.version_min
 cmake_minimum_required(VERSION 3.26.1)
 # dependencies: neml2.version
-project(NEML2 VERSION 2.1.4 LANGUAGES C CXX)
+project(NEML2 VERSION 2.1.5 LANGUAGES C CXX)
 
 # ----------------------------------------------------------------------------
 # Policy

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -118,7 +118,7 @@ doxygen:
 
 # ---- Project version ----
 neml2:
-  version: "2.1.4"
+  version: "2.1.5"
   files:
     - CMakeLists.txt
     - pyproject.toml

--- a/doc/content/installation/integration.md
+++ b/doc/content/installation/integration.md
@@ -63,7 +63,7 @@ FetchContent_Declare(
   neml2
   GIT_REPOSITORY https://github.com/applied-material-modeling/neml2.git
   <!-- dependencies: neml2.version -->
-  GIT_TAG v2.1.4
+  GIT_TAG v2.1.5
 )
 FetchContent_MakeAvailable(neml2)
 add_executable(foo main.cxx)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ NEML2_CSV = "ON"
 [project]
 name = "neml2"
 # dependencies: neml2.version
-version = "2.1.4"
+version = "2.1.5"
 authors = [
   { name = "Mark Messner", email = "messner@anl.gov" },
   { name = "Gary Hu", email = "thu@anl.gov" },

--- a/src/tools/neml2-inspect.cxx
+++ b/src/tools/neml2-inspect.cxx
@@ -24,9 +24,75 @@
 
 #include "neml2/neml2.h"
 #include "neml2/models/Model.h"
+#include "neml2/models/ParameterStore.h"
+#include "neml2/models/BufferStore.h"
+#include "neml2/misc/string_utils.h"
 
 #include <argparse/argparse.hpp>
 #include "utils.h"
+
+#ifdef NEML2_JSON
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+#endif
+
+namespace
+{
+std::shared_ptr<neml2::Model>
+load_model(const argparse::ArgumentParser & program)
+{
+  const auto input = program.get<std::string>("input");
+  const auto additional_cliargs = get_additional_cliargs(program);
+  auto factory = neml2::load_input(input, additional_cliargs);
+  const auto modelname = program.get<std::string>("model");
+  return factory->get_model(modelname);
+}
+} // namespace
+
+#ifdef NEML2_JSON
+namespace
+{
+using neml2::utils::stringify;
+
+json
+model_to_json(const neml2::Model & model)
+{
+  json j;
+  j["name"] = model.name();
+  j["host"] = model.host()->name();
+
+  json inputs = json::array();
+  for (auto && [name, var] : model.input_variables())
+    inputs.push_back({{"name", name}, {"type", stringify(var->type())}});
+  j["inputs"] = std::move(inputs);
+
+  json outputs = json::array();
+  for (auto && [name, var] : model.output_variables())
+    outputs.push_back({{"name", name}, {"type", stringify(var->type())}});
+  j["outputs"] = std::move(outputs);
+
+  const auto * pstore = model.host<neml2::ParameterStore>();
+  json parameters = json::array();
+  for (auto && [name, param] : pstore->named_parameters())
+    parameters.push_back({{"name", name},
+                          {"type", stringify(param->type())},
+                          {"dtype", stringify(neml2::Tensor(*param).scalar_type())},
+                          {"device", stringify(neml2::Tensor(*param).device())}});
+  j["parameters"] = std::move(parameters);
+
+  const auto * bstore = model.host<neml2::BufferStore>();
+  json buffers = json::array();
+  for (auto && [name, buffer] : bstore->named_buffers())
+    buffers.push_back({{"name", name},
+                       {"type", stringify(buffer->type())},
+                       {"dtype", stringify(neml2::Tensor(*buffer).scalar_type())},
+                       {"device", stringify(neml2::Tensor(*buffer).device())}});
+  j["buffers"] = std::move(buffers);
+
+  return j;
+}
+} // namespace
+#endif
 
 int
 main(int argc, char * argv[])
@@ -38,26 +104,60 @@ main(int argc, char * argv[])
   program.add_description("Summarize the structure of a model.");
   program.add_argument("input").help("path to the input file");
   program.add_argument("model").help("name of the model in the input file to inspect");
+  program.add_argument("--json")
+      .help("emit a structured JSON description on stdout instead of the human-readable format "
+            "(requires NEML2_JSON). Errors are returned as {\"retcode\": <nonzero>, \"error\": "
+            "\"...\"}; the process exit code mirrors retcode.")
+      .flag();
   program.add_argument("additional_args")
       .remaining()
       .help("additional command-line arguments to pass to the input file parser");
 
   try
   {
-    // Parse cliargs
     program.parse_args(argc, argv);
-
-    const auto input = program.get<std::string>("input");
-    const auto additional_cliargs = get_additional_cliargs(program);
-    auto factory = neml2::load_input(input, additional_cliargs);
-    const auto modelname = program.get<std::string>("model");
-    auto model = factory->get_model(modelname);
-    std::cout << *model << std::endl;
   }
   catch (const std::exception & err)
   {
     std::cerr << err.what() << std::endl;
-    std::exit(1);
+    return 1;
+  }
+
+  const bool json_mode = program.get<bool>("--json");
+
+#ifndef NEML2_JSON
+  if (json_mode)
+  {
+    std::cerr << "neml2-inspect --json requires NEML2_JSON=ON\n";
+    return 2;
+  }
+#endif
+
+  try
+  {
+    auto model = load_model(program);
+#ifdef NEML2_JSON
+    if (json_mode)
+    {
+      auto out = model_to_json(*model);
+      out["retcode"] = 0;
+      std::cout << out.dump() << std::endl;
+      return 0;
+    }
+#endif
+    std::cout << *model << std::endl;
+  }
+  catch (const std::exception & err)
+  {
+#ifdef NEML2_JSON
+    if (json_mode)
+    {
+      std::cout << json{{"retcode", 1}, {"error", err.what()}}.dump() << std::endl;
+      return 1;
+    }
+#endif
+    std::cerr << err.what() << std::endl;
+    return 1;
   }
 
   return 0;


### PR DESCRIPTION
## Summary

Adds a `--json` output mode to `neml2-inspect` and bumps the project version to 2.1.5.

## `neml2-inspect --json`

When `--json` is passed, the tool emits a single-line JSON object on stdout describing the requested model:

- `name`, `host`
- `inputs` / `outputs` — each `{name, type}`
- `parameters` / `buffers` — each `{name, type, dtype, device}`
- `retcode: 0` on success

Errors are returned in-band as `{"retcode": <nonzero>, "error": "..."}` on stdout (and the process exit code mirrors `retcode`) so a caller can parse a single stream without juggling stdout vs. stderr. Argument-parsing errors and the "JSON support is off" diagnostic still go to stderr with a nonzero exit, since at that point there is no `--json` contract to honor.

The flag is gated by `NEML2_JSON`: without it, the tool exits 2 with a stderr diagnostic. The human-readable path is unchanged.

This mirrors the pattern from `neml2-syntax --server` (#352) and is intended for tooling/IDE integrations that want structured model metadata.

## Version bump

Routine `2.1.4` → `2.1.5`. Updated via the four `# dependencies: neml2.version` sites tracked in `dependencies.yaml`:

- `CMakeLists.txt`
- `pyproject.toml`
- `doc/content/installation/integration.md`
- `dependencies.yaml` itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)
