### PR TITLE
Fix submodel naming and hitschema

### DIFF
--- a/.claude/skills/add-model/SKILL.md
+++ b/.claude/skills/add-model/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: add-model
-description: Scaffold a new NEML2 `Model` subclass under `neml2/models/<domain>/`. NEML2 models are pure Python classes deriving from `neml2.model.Model` (an `nn.Module`), declared via a `HitSchema`, decorated with `@register_native("TypeName")`, and tested with a `.i` driver under `tests/models/<domain>/`. Trigger on any "add a Foo model", "scaffold a new yield function", "create an SR2-to-SR2 mapping", etc.
+description: Scaffold a new NEML2 `Model` subclass under `neml2/models/<domain>/`. NEML2 models are pure Python classes deriving from `neml2.model.Model` (an `nn.Module`), declared via a `HitSchema`, decorated with `@register_neml2_object("TypeName")`, and tested with a `.i` driver under `tests/models/<domain>/`. Trigger on any "add a Foo model", "scaffold a new yield function", "create an SR2-to-SR2 mapping", etc.
 ---
 
 # add-model
 
 A NEML2 model is a Python class with three load-bearing pieces:
 
-1. `@register_native("TypeName")` decorator (from `neml2.factory`).
+1. `@register_neml2_object("TypeName")` decorator (from `neml2.factory`).
 2. `hit = HitSchema(input(...), output(...), parameter(...))` block from
    `neml2.schema`.
 3. `forward(self, *typed_inputs, v=None, v2=None, vh=None)` body in
@@ -25,14 +25,14 @@ A NEML2 model is a Python class with three load-bearing pieces:
 
 ```python
 # neml2/models/solid_mechanics/plasticity/MyHardening.py
-from neml2.factory import register_native
+from neml2.factory import register_neml2_object
 from neml2.model import Model
 from neml2.schema import HitSchema, input, output, parameter
 from neml2.chain_rule import ChainRuleDict
 from neml2.types import Scalar
 
 
-@register_native("MyHardening")
+@register_neml2_object("MyHardening")
 class MyHardening(Model):
     r"""h = K * ep — single-line statement of the forward."""
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ The Python package layout under `neml2/`:
 
 ### Factory / Registry pattern
 
-Every concrete native object (model, driver, tensor, solver, ...) self-registers via the `@register_native("TypeName")` decorator from `neml2.factory`. HIT input files then instantiate them by type name. `Model` subclasses declare their input/output/parameter surface via a class-level `hit = HitSchema(...)` and a `from_hit` constructor; the `@register_native` decorator + `HitSchema` together feed both the live factory and the auto-generated `neml2-syntax` catalog.
+Every concrete native object (model, driver, tensor, solver, ...) self-registers via the `@register_neml2_object("TypeName")` decorator from `neml2.factory`. HIT input files then instantiate them by type name. `Model` subclasses declare their input/output/parameter surface via a class-level `hit = HitSchema(...)` and a `from_hit` constructor; the `@register_neml2_object` decorator + `HitSchema` together feed both the live factory and the auto-generated `neml2-syntax` catalog.
 
 When adding a new submodule under `neml2/models/<domain>/`, append the import to the parent `__init__.py` so `import neml2` triggers registration — there is no lazy-loading machinery and unimported modules' types are invisible to the factory.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # dependencies: cmake.version_min
 cmake_minimum_required(VERSION 3.26.1)
 # dependencies: neml2.version
-project(NEML2 VERSION 3.0.1 LANGUAGES C CXX)
+project(NEML2 VERSION 3.0.2 LANGUAGES C CXX)
 
 # ----------------------------------------------------------------------------
 # Policy

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -96,7 +96,7 @@ python:
 
 # ---- Project version ----
 neml2:
-  version: "3.0.1"
+  version: "3.0.2"
   files:
     - CMakeLists.txt
     - pyproject.toml

--- a/doc/content/cli_utilities.md
+++ b/doc/content/cli_utilities.md
@@ -20,7 +20,7 @@ All four tools accept a cumulative `--load PATH` flag for importing
 user-defined extensions (custom `Model` / `Driver` / `Solver` /
 `[Tensors]` / `[Data]` classes) before the tool's own work begins.
 `PATH` is either a path to a `.py` file or a package directory, or a
-dotted module name on `sys.path`. The matching `@register_native`
+dotted module name on `sys.path`. The matching `@register_neml2_object`
 decorators fire on import and the new types become resolvable from the
 input file and visible to `neml2-syntax`. Repeat `--load` for several
 extensions — they import in the order given, so later modules may

--- a/doc/content/cli_utilities.md
+++ b/doc/content/cli_utilities.md
@@ -16,6 +16,28 @@ needed), each forwards trailing positional tokens as HIT overrides
 under [`neml2/cli/`](https://github.com/applied-material-modeling/neml2/tree/main/neml2/cli)
 and is also importable as a regular Python function.
 
+All four tools accept a cumulative `--load PATH` flag for importing
+user-defined extensions (custom `Model` / `Driver` / `Solver` /
+`[Tensors]` / `[Data]` classes) before the tool's own work begins.
+`PATH` is either a path to a `.py` file or a package directory, or a
+dotted module name on `sys.path`. The matching `@register_native`
+decorators fire on import and the new types become resolvable from the
+input file and visible to `neml2-syntax`. Repeat `--load` for several
+extensions — they import in the order given, so later modules may
+depend on names registered by earlier ones.
+
+```bash
+# A custom model defined in ./my_models.py is now driveable by neml2-run
+# (and inspectable by neml2-inspect / neml2-compile, listed by neml2-syntax).
+neml2-run --load ./my_models.py input.i my_driver
+
+# Multiple extensions in priority order — later may depend on earlier:
+neml2-syntax --load ./shared.py --load ./project_models.py --summary --json -
+```
+
+See [](tutorials-extension-input-files) for the author's side of the
+contract.
+
 Most of the worked examples below reuse a single input file — a linear
 isotropic elastic model named `elasticity`, wrapped in a five-step
 `TransientDriver` named `driver`:

--- a/doc/content/migration/212_300.md
+++ b/doc/content/migration/212_300.md
@@ -63,7 +63,7 @@ authoring surface is documented end-to-end in [](tutorials-extension)
 - Schema declaration uses the helpers in `neml2.schema` (`input`,
   `output`, `parameter`, …) rather than the C++
   `options.add_input` / `add_parameter` family.
-- Registration uses the `@register_native("TypeName")` decorator
+- Registration uses the `@register_neml2_object("TypeName")` decorator
   rather than the `register_NEML2_object` C++ macro.
 - `forward(self, *typed_inputs, v=None, v2=None, vh=None)` replaces
   the C++ `set_value` virtual; the optional `v` / `v2` / `vh` kwargs

--- a/doc/content/tutorials/extension/connection_to_input_files/main.md
+++ b/doc/content/tutorials/extension/connection_to_input_files/main.md
@@ -47,7 +47,7 @@ runtime object creation:
 
 There are three pieces a model author touches:
 
-`@register_native("TypeName")`
+`@register_neml2_object("TypeName")`
 : Decorator on the class. Adds the class to the native registry
   under the given HIT type name. Lives in {mod}`neml2.factory`.
 
@@ -85,7 +85,7 @@ tutorial is about.
 
 Two things to notice:
 
-1. **`@register_native("ProjectileAcceleration")`** is what makes
+1. **`@register_neml2_object("ProjectileAcceleration")`** is what makes
    `type = ProjectileAcceleration` resolvable from an input file.
    The string passed to the decorator is the HIT type name — it does
    not have to match the Python class name (it usually does, by
@@ -132,7 +132,7 @@ Each line in the `[accel]` block lines up with one schema field:
 ## Loading and inspecting
 
 Before `neml2.load_model` can recognise the type name, the module
-that defines it must have been imported (so the `@register_native`
+that defines it must have been imported (so the `@register_neml2_object`
 decorator has run). In a Python script this is just an `import`; in
 this notebook page the source file is sitting next to `input.i`, so
 we put its directory on `sys.path` and import it.
@@ -140,7 +140,7 @@ we put its directory on `sys.path` and import it.
 ```{code-cell} ipython3
 import sys
 sys.path.insert(0, ".")
-import projectile  # the @register_native runs at import time
+import projectile  # the @register_neml2_object runs at import time
 
 import neml2
 model = neml2.load_model("input.i", "accel")
@@ -189,7 +189,7 @@ from neml2.factory import _registry
 
 If a `KeyError` mentioning *"not registered in NativeRegistry"* fires
 at `load_model` time, the cause is almost always that the module
-holding `@register_native` was never imported — fix the import (or
+holding `@register_neml2_object` was never imported — fix the import (or
 re-order imports) so the decorator runs before the load call.
 
 ## Loading the extension from the CLI

--- a/doc/content/tutorials/extension/connection_to_input_files/main.md
+++ b/doc/content/tutorials/extension/connection_to_input_files/main.md
@@ -192,6 +192,27 @@ at `load_model` time, the cause is almost always that the module
 holding `@register_native` was never imported — fix the import (or
 re-order imports) so the decorator runs before the load call.
 
+## Loading the extension from the CLI
+
+Every `neml2-*` console script accepts a cumulative `--load PATH`
+flag for exactly this situation: a custom model defined outside the
+`neml2` package can be driven from the shell without writing a
+wrapper script. `PATH` is either a filesystem path to a `.py` file
+(or a package directory) or a dotted module name on `sys.path`. The
+flag is processed before the input file is parsed, so the registered
+type is visible by the time `load_model` runs:
+
+```bash
+neml2-run --load ./projectile.py input.i driver
+neml2-inspect --load ./projectile.py input.i accel
+neml2-syntax --load ./projectile.py --type ProjectileAcceleration --json -
+neml2-compile --load ./projectile.py input.i --model accel
+```
+
+Repeat `--load` to pull in several extensions; they import in the
+order given, so a later module may depend on names registered by an
+earlier one. See [](cli-utilities) for the option in context.
+
 ## What's next
 
 - The schema fields glossed over here — typed inputs, list options,

--- a/doc/content/tutorials/extension/connection_to_input_files/projectile.py
+++ b/doc/content/tutorials/extension/connection_to_input_files/projectile.py
@@ -4,19 +4,19 @@
 #     a = g - mu * v
 # with `g` a Vec buffer (constant gravity) and `mu` a single Scalar
 # parameter. The point of this file is the *connection to HIT* — the
-# schema declaration and the `@register_native` decorator — not the
+# schema declaration and the `@register_neml2_object` decorator — not the
 # physics.
 
 from __future__ import annotations
 
 from neml2.chain_rule import ChainRuleDict
-from neml2.factory import register_native
+from neml2.factory import register_neml2_object
 from neml2.model import Model
 from neml2.schema import HitSchema, buffer, input, output, parameter
 from neml2.types import Scalar, Vec
 
 
-@register_native("ProjectileAcceleration")
+@register_neml2_object("ProjectileAcceleration")
 class ProjectileAcceleration(Model):
     """Projectile acceleration under gravity and linear drag: a = g - mu * v."""
 

--- a/doc/content/tutorials/extension/model_composition/projectile.py
+++ b/doc/content/tutorials/extension/model_composition/projectile.py
@@ -15,13 +15,13 @@ acceleration (output), ``g`` is the gravitational acceleration vector
 from __future__ import annotations
 
 from neml2.chain_rule import ChainRuleDict
-from neml2.factory import register_native
+from neml2.factory import register_neml2_object
 from neml2.model import Model
 from neml2.schema import HitSchema, buffer, input, output, parameter
 from neml2.types import Scalar, Vec
 
 
-@register_native("ProjectileAcceleration")
+@register_neml2_object("ProjectileAcceleration")
 class ProjectileAcceleration(Model):
     """Newton's second law for a projectile in a viscous medium:
     ``a = g - mu * v``.

--- a/doc/content/tutorials/extension/the_forward_operator/projectile.py
+++ b/doc/content/tutorials/extension/the_forward_operator/projectile.py
@@ -15,13 +15,13 @@ acceleration (output), ``g`` is the gravitational acceleration vector
 from __future__ import annotations
 
 from neml2.chain_rule import ChainRuleDict
-from neml2.factory import register_native
+from neml2.factory import register_neml2_object
 from neml2.model import Model
 from neml2.schema import HitSchema, buffer, input, output, parameter
 from neml2.types import Scalar, Vec
 
 
-@register_native("ProjectileAcceleration")
+@register_neml2_object("ProjectileAcceleration")
 class ProjectileAcceleration(Model):
     """Newton's second law for a projectile in a viscous medium:
     ``a = g - mu * v``.

--- a/neml2/README.md
+++ b/neml2/README.md
@@ -22,7 +22,7 @@ results.
   `DenseNewtonStep`, `DenseIFT`).
 - `solvers.py` — `DenseLU`, `SchurComplement` (block 2-group factorisation), `Newton`.
 - `factory.py` — HIT input parsing (`load_input`, `load_model`,
-  `register_native`, `_NativeInputFile.get_tensor`).
+  `register_neml2_object`, `_NativeInputFile.get_tensor`).
 - `data/` — registered `[Data]` objects: `CrystalGeometry` (base) and
   `CubicCrystal`.
 - `models/` — registered leaves, one file per C++ header; the composition

--- a/neml2/__init__.py
+++ b/neml2/__init__.py
@@ -71,7 +71,13 @@ from .equation_systems import (  # noqa: F401 (side-effect: registers NonlinearS
     DenseRHS,
     ModelNonlinearSystem,
 )
-from .factory import load_input, load_model, load_nonlinear_system, load_string, register_native
+from .factory import (
+    load_input,
+    load_model,
+    load_nonlinear_system,
+    load_string,
+    register_neml2_object,
+)
 from .model import Model
 from .models import (
     chemical_reactions as _chemical_reactions_module,  # noqa: F401 (registers chemical-reactions leaves)
@@ -176,7 +182,7 @@ __all__ = [
     "ChainRuleDict",
     "ChainRuleAction",
     "TangentAction",
-    "register_native",
+    "register_neml2_object",
     "load_input",
     "load_string",
     "load_model",

--- a/neml2/aoti/_shim.py
+++ b/neml2/aoti/_shim.py
@@ -54,7 +54,7 @@ import torch
 from torch import nn
 
 from .. import types as _types
-from ..factory import register_native
+from ..factory import register_neml2_object
 from ..schema import HitSchema, option
 from ..types import TensorWrapper
 from ._aoti import Model as _BoundModel
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
     from ..factory import _NativeInputFile
 
 
-@register_native("AOTIModel")
+@register_neml2_object("AOTIModel")
 class AOTIModel(nn.Module):
     """HIT-loadable wrapper around :class:`neml2.aoti.Model`.
 

--- a/neml2/aoti/_shim.py
+++ b/neml2/aoti/_shim.py
@@ -55,6 +55,7 @@ from torch import nn
 
 from .. import types as _types
 from ..factory import register_native
+from ..schema import HitSchema, option
 from ..types import TensorWrapper
 from ._aoti import Model as _BoundModel
 
@@ -81,6 +82,21 @@ class AOTIModel(nn.Module):
     ``input_spec`` -- the caller mutates them in place via
     ``self._inner.named_parameters()`` to drive runtime-flexible behavior.
     """
+
+    #: Inherits from ``nn.Module`` rather than :class:`neml2.model.Model` so
+    #: the bound ``torch::inductor::AOTIModelPackageLoader`` runtime drives
+    #: evaluation; the explicit class attribute keeps it in the [Models]
+    #: section of the syntax catalog despite not subclassing Model.
+    SECTION = "Models"
+
+    hit = HitSchema(
+        option(
+            "meta",
+            str,
+            "Path to the AOTI metadata JSON produced by ``neml2-compile``. Resolved "
+            "relative to the input file's directory when not absolute.",
+        ),
+    )
 
     @classmethod
     def from_hit(cls, node: nmhit.Node, factory: _NativeInputFile) -> AOTIModel:

--- a/neml2/cli/_extensions.py
+++ b/neml2/cli/_extensions.py
@@ -26,7 +26,7 @@
 
 Downstream users author custom ``Model`` / ``Driver`` / ``Solver`` / ``Data``
 / tensor classes outside the ``neml2`` package. Importing the module that
-defines them is what fires the ``@register_native`` decorators that make the
+defines them is what fires the ``@register_neml2_object`` decorators that make the
 types resolvable from a HIT input file.
 
 A user-friendly CLI workflow needs a way to do that without writing a wrapper
@@ -72,7 +72,7 @@ def add_load_argument(parser: argparse.ArgumentParser) -> None:
 
 
 def load_user_extensions(paths: list[str]) -> None:
-    """Import every entry in *paths* so its ``@register_native`` decorators fire.
+    """Import every entry in *paths* so its ``@register_neml2_object`` decorators fire.
 
     File paths take precedence over dotted-module resolution: if *path* names
     an existing file or directory on disk, it is imported by spec under a

--- a/neml2/cli/_extensions.py
+++ b/neml2/cli/_extensions.py
@@ -1,0 +1,163 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Shared ``--load`` plumbing for the ``neml2-*`` CLI utilities.
+
+Downstream users author custom ``Model`` / ``Driver`` / ``Solver`` / ``Data``
+/ tensor classes outside the ``neml2`` package. Importing the module that
+defines them is what fires the ``@register_native`` decorators that make the
+types resolvable from a HIT input file.
+
+A user-friendly CLI workflow needs a way to do that without writing a wrapper
+script. :func:`add_load_argument` adds a cumulative ``--load`` flag that
+accepts either:
+
+* a path to a ``.py`` file or a package directory, or
+* a dotted module name already importable from ``sys.path``.
+
+:func:`load_user_extensions` then imports each path before the CLI's normal
+load / run / inspect / compile workflow begins. The helper is invoked from
+every CLI entry point so the user-facing surface stays uniform.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def add_load_argument(parser: argparse.ArgumentParser) -> None:
+    """Add a cumulative ``--load PATH`` argument to *parser*.
+
+    Each ``--load`` entry is imported before the CLI's normal workflow runs,
+    so that the user-defined classes are registered in the native factory.
+    """
+    parser.add_argument(
+        "--load",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help=(
+            "Import a user extension before processing. PATH is either a "
+            "filesystem path to a .py file / package directory, or a dotted "
+            "module name already importable from sys.path. Repeatable; "
+            "modules are imported in the order given so later modules may "
+            "depend on names registered by earlier ones."
+        ),
+    )
+
+
+def load_user_extensions(paths: list[str]) -> None:
+    """Import every entry in *paths* so its ``@register_native`` decorators fire.
+
+    File paths take precedence over dotted-module resolution: if *path* names
+    an existing file or directory on disk, it is imported by spec under a
+    sanitized synthetic module name; otherwise it falls through to
+    :func:`importlib.import_module`.
+
+    Raises :class:`ImportError` (with the offending path in the message) on
+    the first failure — partial loads are not committed to the registry.
+    """
+    for path in paths:
+        _import_one(path)
+
+
+def _import_one(path: str) -> None:
+    fs_target = Path(path)
+    if fs_target.exists():
+        _import_by_path(fs_target)
+        return
+    try:
+        importlib.import_module(path)
+    except ImportError as exc:
+        raise ImportError(
+            f"--load {path!r}: not a filesystem path and not an importable dotted module "
+            f"({exc}). Pass either a .py file, a package directory, or a dotted module "
+            "name on sys.path."
+        ) from exc
+
+
+def _import_by_path(target: Path) -> None:
+    """Import a file or package directory by spec.
+
+    Directories must contain ``__init__.py``. The synthetic module name is
+    derived from the file/directory stem with non-identifier characters
+    replaced — the name is only meaningful inside :data:`sys.modules`, so the
+    sanitisation just keeps ``importlib`` happy.
+    """
+    resolved = target.resolve()
+    if resolved.is_dir():
+        init = resolved / "__init__.py"
+        if not init.is_file():
+            raise ImportError(
+                f"--load {target!s}: directory has no __init__.py — point at the "
+                "package's __init__.py directly or pass the parent dotted module name."
+            )
+        location = init
+        # Add the directory's *parent* to sys.path so submodule imports inside
+        # the package resolve against the user's expected layout.
+        parent = str(resolved.parent)
+        if parent not in sys.path:
+            sys.path.insert(0, parent)
+        module_name = _sanitise_module_name(resolved.name)
+    else:
+        location = resolved
+        # Single-file scripts often `import` sibling modules — put the script's
+        # directory on sys.path so those imports resolve the way the user
+        # expects when running the script directly.
+        parent = str(resolved.parent)
+        if parent not in sys.path:
+            sys.path.insert(0, parent)
+        module_name = _sanitise_module_name(resolved.stem)
+
+    spec = importlib.util.spec_from_file_location(module_name, location)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"--load {target!s}: importlib could not build a module spec.")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        # Roll back the sys.modules entry so a broken extension doesn't
+        # masquerade as successfully loaded on a retry.
+        sys.modules.pop(module_name, None)
+        raise
+
+
+def _sanitise_module_name(stem: str) -> str:
+    """Map an arbitrary file stem to a valid Python identifier.
+
+    The result lives only in ``sys.modules`` under a ``_neml2_ext_`` prefix
+    so it can never collide with the user's own module names.
+    """
+    safe = "".join(c if c.isidentifier() or c.isdigit() else "_" for c in stem)
+    if not safe or not safe[0].isidentifier():
+        safe = f"_{safe}"
+    return f"_neml2_ext_{safe}"
+
+
+__all__ = ["add_load_argument", "load_user_extensions"]

--- a/neml2/cli/aoti_compile.py
+++ b/neml2/cli/aoti_compile.py
@@ -50,6 +50,7 @@ import os
 import sys
 from pathlib import Path
 
+from ._extensions import add_load_argument, load_user_extensions
 from .aoti_export import export_model_for_aoti
 
 
@@ -100,6 +101,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "fully baked."
         ),
     )
+    add_load_argument(parser)
     return parser
 
 
@@ -196,6 +198,12 @@ def main(argv: list[str] | None = None) -> int:
     input_path: Path = args.input.resolve()
     if not input_path.exists():
         print(f"Error: input file not found: {input_path}", file=sys.stderr)
+        return 1
+
+    try:
+        load_user_extensions(args.load)
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         return 1
 
     output_dir: Path = (args.output_dir or Path.cwd() / "aoti" / args.model).resolve()

--- a/neml2/cli/inspect.py
+++ b/neml2/cli/inspect.py
@@ -39,6 +39,7 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 from ..factory import load_input
+from ._extensions import add_load_argument, load_user_extensions
 
 if TYPE_CHECKING:
     from ..model import Model
@@ -98,6 +99,7 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="emit a structured JSON description on stdout instead of the human-readable format",
     )
+    add_load_argument(parser)
     return parser
 
 
@@ -106,6 +108,7 @@ def main(argv: list[str] | None = None) -> int:
     # overrides without REMAINDER greedily capturing ``--json``.
     args, additional_args = _build_parser().parse_known_args(argv)
     try:
+        load_user_extensions(args.load)
         factory = load_input(args.input, additional_args=additional_args)
         model = factory.get_model(args.model)
     except Exception as exc:  # noqa: BLE001

--- a/neml2/cli/run.py
+++ b/neml2/cli/run.py
@@ -30,6 +30,7 @@ import argparse
 import sys
 
 from ..factory import load_input
+from ._extensions import add_load_argument, load_user_extensions
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -42,6 +43,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("input", help="path to the input file")
     parser.add_argument("driver", help="name of the driver in the input file")
+    add_load_argument(parser)
     return parser
 
 
@@ -51,6 +53,7 @@ def main(argv: list[str] | None = None) -> int:
     # subsequent flags too.
     args, additional_args = _build_parser().parse_known_args(argv)
     try:
+        load_user_extensions(args.load)
         factory = load_input(args.input, additional_args=additional_args)
         factory.get_driver(args.driver).run()
     except Exception as exc:  # noqa: BLE001

--- a/neml2/cli/syntax.py
+++ b/neml2/cli/syntax.py
@@ -36,6 +36,7 @@ from typing import Any, TextIO
 
 from ..factory import _registry
 from ..schema import _MISSING, BLOCK_NAME, HitField, HitSchema
+from ._extensions import add_load_argument, load_user_extensions
 
 
 @dataclass(frozen=True)
@@ -217,6 +218,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--server", action="store_true", help="run as a JSON server on stdin/stdout"
     )
+    add_load_argument(parser)
     return parser
 
 
@@ -276,6 +278,12 @@ def main(
         err_stream.write(
             "error: --server is incompatible with --json, --section, --type, and --summary\n"
         )
+        return 1
+
+    try:
+        load_user_extensions(args.load)
+    except ImportError as exc:
+        err_stream.write(f"error: {exc}\n")
         return 1
 
     records = collect_records()

--- a/neml2/cli/syntax.py
+++ b/neml2/cli/syntax.py
@@ -35,14 +35,7 @@ from pathlib import Path
 from typing import Any, TextIO
 
 from ..factory import _registry
-from ..model import Model
 from ..schema import _MISSING, BLOCK_NAME, HitField, HitSchema
-
-_SOLVER_TYPES = frozenset({"DenseLU", "SchurComplement", "Newton", "NewtonWithLineSearch"})
-_EQUATION_SYSTEM_TYPES = frozenset({"NonlinearSystem"})
-_DATA_TYPES = frozenset({"CubicCrystal"})
-_DRIVER_TYPES = frozenset({"TransientDriver", "TransientRegression", "Verification"})
-_TENSOR_TYPES = frozenset({"CSVScalar", "CSVSR2", "CSVVec", "CSVWR2"})
 
 
 @dataclass(frozen=True)
@@ -56,19 +49,20 @@ class SyntaxRecord:
 
 
 def _section_for(type_name: str, cls: type) -> str:
-    if type_name in _SOLVER_TYPES:
-        return "Solvers"
-    if type_name in _EQUATION_SYSTEM_TYPES:
-        return "EquationSystems"
-    if type_name in _DATA_TYPES:
-        return "Data"
-    if type_name in _DRIVER_TYPES:
-        return "Drivers"
-    if type_name in _TENSOR_TYPES:
-        return "Tensors"
-    if issubclass(cls, Model):
-        return "Models"
-    return ""
+    """Read the registered class's HIT section.
+
+    Each registered class declares its section through a ``SECTION`` class
+    attribute, usually inherited from its base (:class:`neml2.model.Model`,
+    :class:`neml2.driver.Driver`, :class:`neml2.equation_systems.LinearSystem`,
+    ...). Classes outside an inheritance chain (linear/nonlinear solvers,
+    standalone tensor/data classes) set their own.
+
+    Falls back to ``""`` when no section is declared — surfaced by
+    :func:`collect_records` validation.
+    """
+    del type_name
+    section = getattr(cls, "SECTION", "")
+    return section if isinstance(section, str) else ""
 
 
 def _source_path(cls: type) -> str:
@@ -90,10 +84,23 @@ def _ascii_doc(text: str, context: str) -> str:
 
 
 def collect_records() -> list[SyntaxRecord]:
-    """Collect Python-native syntax records from the native registry."""
+    """Collect Python-native syntax records from the native registry.
+
+    Every registered class must declare a HIT ``SECTION`` (usually inherited
+    from its base class — see :func:`_section_for`). A missing section means
+    the type would silently fall out of the syntax catalog, so this raises
+    rather than skipping.
+    """
     records: list[SyntaxRecord] = []
     for type_name, cls in sorted(_registry.items()):
         section = _section_for(type_name, cls)
+        if not section:
+            raise ValueError(
+                f"{cls.__module__}.{cls.__qualname__} (registered as {type_name!r}) has "
+                "no SECTION declared. Add ``SECTION = '<Section>'`` to the class or one "
+                "of its base classes so neml2-syntax knows which HIT section it belongs "
+                "to."
+            )
         doc = _ascii_doc(inspect.getdoc(cls) or "", f"{type_name} doc")
         hit = getattr(cls, "hit", None)
         records.append(

--- a/neml2/data/CubicCrystal.py
+++ b/neml2/data/CubicCrystal.py
@@ -36,7 +36,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from ..factory import register_native
+from ..factory import register_neml2_object
 from ..schema import HitSchema, parameter
 from ..types import (
     R2,
@@ -132,7 +132,7 @@ def cubic_symmetry_operators(
 # ---------------------------------------------------------------------------
 
 
-@register_native("CubicCrystal")
+@register_neml2_object("CubicCrystal")
 class CubicCrystal:
     """A specialization of the general CrystalGeometry class defining a cubic crystal system."""
 

--- a/neml2/data/CubicCrystal.py
+++ b/neml2/data/CubicCrystal.py
@@ -136,6 +136,8 @@ def cubic_symmetry_operators(
 class CubicCrystal:
     """A specialization of the general CrystalGeometry class defining a cubic crystal system."""
 
+    SECTION = "Data"
+
     # Construction-only options. ``from_hit`` owns the parsing (the lattice
     # parameter may be a literal float or a [Tensors] cross-reference, and the
     # symmetry operators are fixed to the cubic "432" group rather than read

--- a/neml2/data/__init__.py
+++ b/neml2/data/__init__.py
@@ -28,7 +28,7 @@
 Construction-time inputs shared by reference across consumers (mirrors the C++
 ``[Data]`` section). ``CrystalGeometry`` is the base slip-system geometry;
 ``CubicCrystal`` is the registered ``[Data]`` block that specializes it to the
-cubic crystal system. Importing this package fires the ``@register_native``
+cubic crystal system. Importing this package fires the ``@register_neml2_object``
 side effects.
 """
 

--- a/neml2/driver.py
+++ b/neml2/driver.py
@@ -29,7 +29,7 @@ an ``nn.Module``, and does not participate in chain-rule propagation. It is a
 top-level workflow object (e.g. step a model over a time history, dispatch a
 calibration job) constructed from a ``[Drivers]`` block.
 
-Concrete drivers register with ``@register_native("TypeName")`` and live under
+Concrete drivers register with ``@register_neml2_object("TypeName")`` and live under
 ``python/neml2/native/drivers/``. The factory routes ``[Drivers]`` blocks here
 via ``_NativeInputFile.get_driver()``.
 """

--- a/neml2/driver.py
+++ b/neml2/driver.py
@@ -37,6 +37,7 @@ via ``_NativeInputFile.get_driver()``.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import ClassVar
 
 
 class Driver(ABC):
@@ -45,6 +46,11 @@ class Driver(ABC):
     Subclasses implement ``from_hit(cls, node, factory)`` (the standard native
     factory contract) and ``run()``.
     """
+
+    #: HIT section a registered subclass belongs to — drives ``neml2-syntax``
+    #: classification without hard-coded type sets. Inherited; override on a
+    #: subclass only when the class deliberately lives in a different section.
+    SECTION: ClassVar[str] = "Drivers"
 
     @abstractmethod
     def run(self) -> bool:

--- a/neml2/drivers/TransientDriver.py
+++ b/neml2/drivers/TransientDriver.py
@@ -49,7 +49,7 @@ import nmhit
 import torch
 
 from ..driver import Driver
-from ..factory import register_native
+from ..factory import register_neml2_object
 from ..schema import HitField, HitSchema, dependency, option
 from ..types import R2, SR2, SSR4, WR2, MillerIndex, Rot, Scalar, TensorWrapper, Vec
 
@@ -156,7 +156,7 @@ def _typed_io_fields() -> tuple[HitField, ...]:
     return tuple(fields)
 
 
-@register_native("TransientDriver")
+@register_neml2_object("TransientDriver")
 class TransientDriver(Driver):
     """Drive a model over a prescribed time history.
 

--- a/neml2/drivers/TransientDriver.py
+++ b/neml2/drivers/TransientDriver.py
@@ -50,6 +50,7 @@ import torch
 
 from ..driver import Driver
 from ..factory import register_native
+from ..schema import HitField, HitSchema, dependency, option
 from ..types import R2, SR2, SSR4, WR2, MillerIndex, Rot, Scalar, TensorWrapper, Vec
 
 if TYPE_CHECKING:
@@ -118,12 +119,76 @@ def _read_typed_pairs(
     return out
 
 
+def _typed_io_fields() -> tuple[HitField, ...]:
+    """Build documentation fields for the ``force_<Type>_*`` / ``ic_<Type>_*``
+    name/value pairs that ``_read_typed_pairs`` ingests at parse time.
+
+    Each typed wrapper (Scalar, Vec, SR2, ...) maps to four optional list
+    options: ``force_<T>_names`` paired with ``force_<T>_values`` and the same
+    pair under ``ic_<T>_*`` for initial conditions. The schema doesn't drive
+    parsing here (the driver overrides ``from_hit``) — it exists so
+    ``neml2-syntax`` can render the full HIT surface.
+    """
+    fields: list[HitField] = []
+    for type_name in _TYPE_MAP:
+        for prefix, prefix_doc, article in (
+            ("force", "driving force", "a"),
+            ("ic", "initial condition", "an"),
+        ):
+            fields.append(
+                option(
+                    f"{prefix}_{type_name}_names",
+                    list,
+                    f"{type_name} variable names assigned {article} {prefix_doc} value.",
+                    default=[],
+                )
+            )
+            fields.append(
+                option(
+                    f"{prefix}_{type_name}_values",
+                    list,
+                    f"{type_name} {prefix_doc} tokens. Each is either an inline Scalar literal "
+                    f"(Scalar only) or a [Tensors] block name. Length must match "
+                    f"``{prefix}_{type_name}_names``.",
+                    default=[],
+                )
+            )
+    return tuple(fields)
+
+
 @register_native("TransientDriver")
 class TransientDriver(Driver):
     """Drive a model over a prescribed time history.
 
     Mirrors C++ ``TransientDriver``. See module docstring for differences.
     """
+
+    # Documentation-only schema; ``from_hit`` below owns the parsing because
+    # ``force_<Type>_*`` / ``ic_<Type>_*`` are a wide product of optional list
+    # options that the typed Model-style schema can't express directly.
+    hit = HitSchema(
+        dependency("model", "get_model", "The Model to drive over the time history."),
+        option(
+            "prescribed_time",
+            str,
+            "[Tensors] block name of a Scalar whose leading axis is the per-step time history.",
+        ),
+        option(
+            "time",
+            str,
+            "Name of the model input that receives the per-step time value.",
+            default="t",
+        ),
+        option(
+            "save_as",
+            str,
+            "Output file path. Accepted for compatibility with the C++ driver but ignored "
+            "by the native runtime; results are held in memory and retrieved via "
+            ":meth:`result`.",
+            default="",
+        ),
+        *_typed_io_fields(),
+    )
 
     def __init__(
         self,

--- a/neml2/drivers/TransientRegression.py
+++ b/neml2/drivers/TransientRegression.py
@@ -48,7 +48,7 @@ import nmhit
 import torch
 
 from ..driver import Driver
-from ..factory import register_native
+from ..factory import register_neml2_object
 from ..schema import HitSchema, dependency, option
 from .TransientDriver import TransientDriver
 
@@ -87,7 +87,7 @@ def _load_gold(path: Path) -> dict[str, torch.Tensor]:
     return dict(torch.jit.load(str(path)).state_dict())
 
 
-@register_native("TransientRegression")
+@register_neml2_object("TransientRegression")
 class TransientRegression(Driver):
     """Run a TransientDriver and diff its result against a gold ``.pt`` file."""
 

--- a/neml2/drivers/TransientRegression.py
+++ b/neml2/drivers/TransientRegression.py
@@ -49,6 +49,7 @@ import torch
 
 from ..driver import Driver
 from ..factory import register_native
+from ..schema import HitSchema, dependency, option
 from .TransientDriver import TransientDriver
 
 if TYPE_CHECKING:
@@ -89,6 +90,28 @@ def _load_gold(path: Path) -> dict[str, torch.Tensor]:
 @register_native("TransientRegression")
 class TransientRegression(Driver):
     """Run a TransientDriver and diff its result against a gold ``.pt`` file."""
+
+    hit = HitSchema(
+        dependency("driver", "get_driver", "The TransientDriver to run before diffing."),
+        option(
+            "reference",
+            str,
+            "Path to the gold ``.pt`` file. Resolved relative to the input file's directory "
+            "when not absolute.",
+        ),
+        option(
+            "rtol",
+            float,
+            "Relative tolerance for per-tensor comparison.",
+            default=1.0e-5,
+        ),
+        option(
+            "atol",
+            float,
+            "Absolute tolerance for per-tensor comparison.",
+            default=1.0e-8,
+        ),
+    )
 
     def __init__(
         self,

--- a/neml2/drivers/Verification.py
+++ b/neml2/drivers/Verification.py
@@ -58,6 +58,7 @@ import torch
 
 from ..driver import Driver
 from ..factory import register_native
+from ..schema import HitField, HitSchema, dependency, option
 from ..types import SR2, WR2, Scalar, Vec
 from .TransientDriver import TransientDriver
 
@@ -83,9 +84,64 @@ def _read_token_list(node: nmhit.Node, name: str) -> list[str]:
     return raw.split() if raw else []
 
 
+def _typed_ref_fields() -> tuple[HitField, ...]:
+    """Build the ``<Type>_names`` / ``<Type>_values`` option pairs the driver
+    consumes for every wrapper class in :data:`_SUPPORTED_TYPES`.
+
+    Documentation-only — :meth:`Verification.from_hit` parses them directly. The
+    schema exists so ``neml2-syntax`` can render the full HIT surface.
+    """
+    fields: list[HitField] = []
+    for type_name in _SUPPORTED_TYPES:
+        fields.append(
+            option(
+                f"{type_name}_names",
+                list,
+                f"Result-buffer variable names (e.g. ``output.stress``) whose per-step "
+                f"values are compared against ``{type_name}_values``.",
+                default=[],
+            )
+        )
+        fields.append(
+            option(
+                f"{type_name}_values",
+                list,
+                f"[Tensors] block names producing the reference {type_name} per result "
+                f"variable named in ``{type_name}_names``; same length and order.",
+                default=[],
+            )
+        )
+    return tuple(fields)
+
+
 @register_native("Verification")
 class Verification(Driver):
     """Run a TransientDriver and diff its result against per-variable references."""
+
+    hit = HitSchema(
+        dependency("driver", "get_driver", "The TransientDriver to run before diffing."),
+        option(
+            "rtol",
+            float,
+            "Relative tolerance for per-tensor comparison.",
+            default=1.0e-5,
+        ),
+        option(
+            "atol",
+            float,
+            "Absolute tolerance for per-tensor comparison.",
+            default=1.0e-8,
+        ),
+        option(
+            "time_steps",
+            list,
+            "Optional whitespace-separated list of step indices to compare. When absent, "
+            "every step is checked. A single step entry switches to snapshot comparison "
+            "(the reference is treated as the value at that step, not time-axis-sliced).",
+            default=[],
+        ),
+        *_typed_ref_fields(),
+    )
 
     def __init__(
         self,

--- a/neml2/drivers/Verification.py
+++ b/neml2/drivers/Verification.py
@@ -57,7 +57,7 @@ import nmhit
 import torch
 
 from ..driver import Driver
-from ..factory import register_native
+from ..factory import register_neml2_object
 from ..schema import HitField, HitSchema, dependency, option
 from ..types import SR2, WR2, Scalar, Vec
 from .TransientDriver import TransientDriver
@@ -114,7 +114,7 @@ def _typed_ref_fields() -> tuple[HitField, ...]:
     return tuple(fields)
 
 
-@register_native("Verification")
+@register_neml2_object("Verification")
 class Verification(Driver):
     """Run a TransientDriver and diff its result against per-variable references."""
 

--- a/neml2/drivers/__init__.py
+++ b/neml2/drivers/__init__.py
@@ -25,7 +25,7 @@
 """Native ``[Drivers]`` registrations.
 
 One file per registered driver type. Importing this package fires the
-``@register_native`` decorators so the factory can resolve ``[Drivers]`` blocks
+``@register_neml2_object`` decorators so the factory can resolve ``[Drivers]`` blocks
 from HIT input.
 """
 

--- a/neml2/equation_systems.py
+++ b/neml2/equation_systems.py
@@ -765,6 +765,11 @@ def norm_sq(v: AssembledVector) -> torch.Tensor:
 class LinearSystem:
     """Base class for systems with assembled operators."""
 
+    #: HIT section for ``neml2-syntax`` classification — inherited by every
+    #: registered subclass (``ModelNonlinearSystem`` lives under
+    #: ``[EquationSystems]`` in the input file).
+    SECTION = "EquationSystems"
+
     def __init__(self) -> None:
         self._ulayout = self.setup_ulayout()
         self._glayout = self.setup_glayout()

--- a/neml2/equation_systems.py
+++ b/neml2/equation_systems.py
@@ -35,7 +35,7 @@ import torch
 from torch import nn
 
 from .chain_rule import ChainRuleDict
-from .factory import register_native
+from .factory import register_neml2_object
 from .model import Model
 from .schema import HitSchema, dependency, option
 from .types import TensorWrapper
@@ -846,7 +846,7 @@ class NonlinearSystem(LinearSystem):
     """Nonlinear system with C++-matching Newton sign convention."""
 
 
-@register_native("NonlinearSystem")
+@register_neml2_object("NonlinearSystem")
 class ModelNonlinearSystem(NonlinearSystem):
     """A nonlinear system defined by a Model."""
 

--- a/neml2/factory.py
+++ b/neml2/factory.py
@@ -26,7 +26,7 @@
 
 Mirrors the C++ Factory / Registry pattern for Python-native models:
 
-- :func:`register_native` — decorator that registers a model class under its
+- :func:`register_neml2_object` — decorator that registers a model class under its
   C++ type name. ``Model`` subclasses usually inherit schema-backed
   ``from_hit(node, factory)``; non-model objects and special cases implement
   their own.
@@ -80,7 +80,7 @@ def _check_python_attr_name(name: str, *, kind: str, owner: str) -> None:
         )
 
 
-def register_native(type_name: str) -> Callable[[type[_T]], type[_T]]:
+def register_neml2_object(type_name: str) -> Callable[[type[_T]], type[_T]]:
     """Decorator: register a Model (or solver/system) class under *type_name*.
 
     The class must provide a ``from_hit(cls, node, factory)`` classmethod that
@@ -479,7 +479,7 @@ def load_nonlinear_system(path: str | Path, name: str) -> Any:
 
 
 __all__ = [
-    "register_native",
+    "register_neml2_object",
     "load_input",
     "load_string",
     "load_model",

--- a/neml2/factory.py
+++ b/neml2/factory.py
@@ -235,19 +235,21 @@ class _NativeInputFile:
     # ── [Tensors] support (mode 2 of declare_typed_parameter) ────────────────
 
     def get_tensor(self, name: str) -> Any:
-        """Evaluate a named ``[Tensors/<name>]`` Python expression and return the result.
+        """Build (or return cached) the ``[Tensors/<name>]`` value.
 
-        The block must declare ``type = Python`` and an ``expr`` parameter containing
-        a Python expression (or a multi-line code block that assigns to ``result``).
-        The expression is evaluated in a namespace pre-populated with ``torch``, all
-        ``neml2.types`` symbols (``Scalar``, ``SR2``, ``SSR4``, free functions),
-        ``math``, ``np`` (numpy, if importable), and ``tensor(name)`` for cross-references.
+        Dispatches on the block's ``type`` to a class in the native registry —
+        ``type = Python`` resolves to
+        :class:`~neml2.user_tensors.PythonTensor.PythonTensor` (inline Python
+        expression evaluated in the typed-tensor namespace),
+        ``type = CSV<T>`` to the corresponding CSV reader, and so on.
 
-        Returns the raw value produced by the expression — either a ``torch.Tensor``
-        or a ``TensorWrapper`` subclass.  The call site (``declare_typed_parameter`` mode 2)
-        is responsible for wrapping a raw ``torch.Tensor`` into the appropriate typed wrapper.
+        Returns the raw value produced by the registered class — either a
+        ``torch.Tensor`` or a ``TensorWrapper`` subclass. The call site
+        (``declare_typed_parameter`` mode 2) is responsible for wrapping a raw
+        ``torch.Tensor`` into the appropriate typed wrapper.
 
-        Raises ``KeyError`` if no ``[Tensors/<name>]`` block exists.
+        Raises ``KeyError`` if no ``[Tensors/<name>]`` block exists or its
+        ``type`` isn't registered.
         """
         key = ("Tensors", name)
         if key in self._cache:
@@ -258,32 +260,26 @@ class _NativeInputFile:
             raise KeyError(f"No [Tensors/{name}] found in {self._path}")
 
         type_str = node.param_str("type")
+        if type_str not in _registry:
+            raise ValueError(
+                f"[Tensors/{name}] has type={type_str!r}; expected a registered tensor "
+                "type. For an inline Python expression use:\n"
+                f"  [Tensors/{name}]\n"
+                "    type = Python\n"
+                "    expr = '...pytorch expression...'\n"
+                "  []"
+            )
 
+        # Cycle detection wraps the dispatch itself because registered tensor
+        # classes (notably ``Python``) may recursively call back into
+        # ``get_tensor`` through the eval namespace's ``__missing__`` hook.
         if name in self._evaluating:
             raise RecursionError(
                 f"[Tensors/{name}] cross-references itself (directly or indirectly)."
             )
         self._evaluating.add(name)
         try:
-            if type_str == "Python":
-                # Inline Python expression — evaluated in the typed-tensor namespace.
-                result = _eval_tensor_code(
-                    node.param_str("expr"), name, _build_tensor_eval_namespace(self)
-                )
-            elif type_str in _registry:
-                # Registered tensor type (e.g. CSVScalar, CSVSR2). The class
-                # builds its own typed wrapper from the HIT block.
-                cls = _registry[type_str]
-                result = cls.from_hit(node, self)
-            else:
-                raise ValueError(
-                    f"[Tensors/{name}] has type={type_str!r}; expected 'Python' or a "
-                    "registered tensor type. For an inline Python expression use:\n"
-                    f"  [Tensors/{name}]\n"
-                    "    type = Python\n"
-                    "    expr = '...pytorch expression...'\n"
-                    "  []"
-                )
+            result = _registry[type_str].from_hit(node, self)
         finally:
             self._evaluating.discard(name)
 

--- a/neml2/model.py
+++ b/neml2/model.py
@@ -59,7 +59,7 @@ from __future__ import annotations
 from abc import ABC
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
 import torch
 from torch import nn
@@ -93,7 +93,37 @@ __all__ = [
     "SecondOrderChainRuleAction",
     "Model",
     "NLParam",
+    "register_submodule",
 ]
+
+
+def register_submodule(
+    parent: nn.Module,
+    child: nn.Module,
+    fallback: str,
+    *,
+    used: set[str] | None = None,
+) -> str:
+    """Add *child* to *parent* under its HIT block name if available.
+
+    The factory stamps ``_hit_name`` on every object it constructs; preferring
+    that name over an opaque attribute slot keeps ``named_parameters()``
+    readable (``elasticity.E`` instead of ``_residual_model.E``). Falls back to
+    *fallback* when the HIT name is missing (direct Python construction), is
+    not a valid Python identifier, would collide with an existing attribute on
+    *parent*, or is already in *used* (when a parent registers several children
+    in one pass and must avoid collisions across siblings).
+
+    Returns the attribute name the child was registered under.
+    """
+    hit_name = getattr(child, "_hit_name", None)
+    attr = hit_name if hit_name and hit_name.isidentifier() else None
+    if attr is None or (used is not None and attr in used) or hasattr(parent, attr):
+        attr = fallback
+    if used is not None:
+        used.add(attr)
+    parent.add_module(attr, child)
+    return attr
 
 
 @dataclass(frozen=True)
@@ -136,6 +166,10 @@ class Model(nn.Module, ABC):
     single typed wrapper or a tuple thereof).  When called with ``v``, it
     additionally returns the sensitivity dict as the final element of the tuple.
     """
+
+    #: HIT section every registered subclass belongs to. Inherited; subclasses
+    #: that deliberately live elsewhere (none today) can override.
+    SECTION: ClassVar[str] = "Models"
 
     input_spec: dict[str, type[TensorWrapper]]
     output_spec: dict[str, type[TensorWrapper]]

--- a/neml2/models/chemical_reactions/AvramiErofeevNucleation.py
+++ b/neml2/models/chemical_reactions/AvramiErofeevNucleation.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import torch
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar, pow
@@ -44,7 +44,7 @@ def _log(s: Scalar) -> Scalar:
     return Scalar(torch.log(s.data), sub_batch_ndim=s.sub_batch_ndim)
 
 
-@register_native("AvramiErofeevNucleation")
+@register_neml2_object("AvramiErofeevNucleation")
 class AvramiErofeevNucleation(Model):
     r"""Avrami--Erofeev nucleation reaction mechanism.
 

--- a/neml2/models/chemical_reactions/ContractingGeometry.py
+++ b/neml2/models/chemical_reactions/ContractingGeometry.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import torch
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar, clamp, pow
 
 
-@register_native("ContractingGeometry")
+@register_neml2_object("ContractingGeometry")
 class ContractingGeometry(Model):
     r"""Contracting-geometry reaction mechanism.
 

--- a/neml2/models/chemical_reactions/CylindricalChannelGeometry.py
+++ b/neml2/models/chemical_reactions/CylindricalChannelGeometry.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import torch
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import Scalar, clamp, gt, sqrt, where
 
 
-@register_native("CylindricalChannelGeometry")
+@register_neml2_object("CylindricalChannelGeometry")
 class CylindricalChannelGeometry(Model):
     r"""Dimensionless inner/outer radii of a cylindrical reaction product.
 

--- a/neml2/models/chemical_reactions/DiffusionLimitedReaction.py
+++ b/neml2/models/chemical_reactions/DiffusionLimitedReaction.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output, parameter
 from ...types import Scalar
 
 
-@register_native("DiffusionLimitedReaction")
+@register_neml2_object("DiffusionLimitedReaction")
 class DiffusionLimitedReaction(Model):
     r"""Diffusion-limited reaction rate for a shrinking-core product phase.
 

--- a/neml2/models/chemical_reactions/EffectiveVolume.py
+++ b/neml2/models/chemical_reactions/EffectiveVolume.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter, parameters, var_inputs
 from ...types import Scalar
 
 
-@register_native("EffectiveVolume")
+@register_neml2_object("EffectiveVolume")
 class EffectiveVolume(Model):
     r"""Total volume of a control-mass composite during a reaction.
 

--- a/neml2/models/chemical_reactions/ReactionMechanism.py
+++ b/neml2/models/chemical_reactions/ReactionMechanism.py
@@ -34,7 +34,7 @@ that every reaction-mechanism leaf shares, leaving the actual forward map to
 subclasses.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical input/output names so concrete
 native reaction-mechanism leaves can mirror the C++ contract; ``forward``
 raises ``NotImplementedError`` so any accidental direct use surfaces

--- a/neml2/models/chemical_reactions/__init__.py
+++ b/neml2/models/chemical_reactions/__init__.py
@@ -26,7 +26,7 @@
 """Native chemical-reactions models.
 
 One file per C++ header under ``include/neml2/models/chemical_reactions/``;
-this package re-imports each file so ``@register_native`` side effects fire on
+this package re-imports each file so ``@register_neml2_object`` side effects fire on
 package import.
 """
 

--- a/neml2/models/common/ArrheniusParameter.py
+++ b/neml2/models/common/ArrheniusParameter.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict, SecondOrderChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import BLOCK_NAME, HitSchema, input, option, output, parameter
 from ...types import Scalar, exp
 
 
-@register_native("ArrheniusParameter")
+@register_neml2_object("ArrheniusParameter")
 class ArrheniusParameter(Model):
     r"""Define the variable as a function of temperature according to the
     Arrhenius law $p = p_0 \exp \left( -\frac{Q}{RT} \right)$, where

--- a/neml2/models/common/BackwardEulerTimeIntegration.py
+++ b/neml2/models/common/BackwardEulerTimeIntegration.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, derived_input, derived_output, input, option
 from ...types import (
@@ -111,7 +111,7 @@ def _backward_euler_schema(t: type[TensorWrapper]) -> HitSchema:
     )
 
 
-@register_native("ScalarBackwardEulerTimeIntegration")
+@register_neml2_object("ScalarBackwardEulerTimeIntegration")
 class ScalarBackwardEulerTimeIntegration(_BackwardEulerTimeIntegration):
     r"""Define the backward Euler time integration residual
     $r = s - s_n - (t - t_n) \dot{s}$, where $s$ is the variable being
@@ -123,7 +123,7 @@ class ScalarBackwardEulerTimeIntegration(_BackwardEulerTimeIntegration):
     hit = _backward_euler_schema(Scalar)
 
 
-@register_native("SR2BackwardEulerTimeIntegration")
+@register_neml2_object("SR2BackwardEulerTimeIntegration")
 class SR2BackwardEulerTimeIntegration(_BackwardEulerTimeIntegration):
     r"""Define the backward Euler time integration residual
     $r = s - s_n - (t - t_n) \dot{s}$, where $s$ is the variable being
@@ -135,7 +135,7 @@ class SR2BackwardEulerTimeIntegration(_BackwardEulerTimeIntegration):
     hit = _backward_euler_schema(SR2)
 
 
-@register_native("R2BackwardEulerTimeIntegration")
+@register_neml2_object("R2BackwardEulerTimeIntegration")
 class R2BackwardEulerTimeIntegration(_BackwardEulerTimeIntegration):
     r"""Define the backward Euler time integration residual
     $r = s - s_n - (t - t_n) \dot{s}$, where $s$ is the variable being
@@ -147,7 +147,7 @@ class R2BackwardEulerTimeIntegration(_BackwardEulerTimeIntegration):
     hit = _backward_euler_schema(R2)
 
 
-@register_native("VecBackwardEulerTimeIntegration")
+@register_neml2_object("VecBackwardEulerTimeIntegration")
 class VecBackwardEulerTimeIntegration(_BackwardEulerTimeIntegration):
     r"""Define the backward Euler time integration residual
     $r = s - s_n - (t - t_n) \dot{s}$, where $s$ is the variable being

--- a/neml2/models/common/BilinearInterpolation.py
+++ b/neml2/models/common/BilinearInterpolation.py
@@ -35,7 +35,7 @@ analytical chain-rule slopes from
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import BLOCK_NAME, HitSchema, input, output, parameter
 from ...types import (
@@ -58,7 +58,7 @@ def _make_bilinear(type_name: str, ordinate_cls: type[TensorWrapper]) -> type[Mo
     arguments are Scalars at the query point.
     """
 
-    @register_native(type_name)
+    @register_neml2_object(type_name)
     class _BilinearInterpolation(Model):
         # Match the C++ ``Interpolation<T>`` HIT surface: ``ordinate`` is a
         # typed parameter, the output defaults to the model's block name.

--- a/neml2/models/common/ComposedModel.py
+++ b/neml2/models/common/ComposedModel.py
@@ -58,7 +58,7 @@ from ...chain_rule import (
     SparsityFlag,
     combine_sparsity,
 )
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model, NLParam, register_submodule
 from ...resolver import DependencyResolver
 from ...schema import HitSchema, option
@@ -117,7 +117,7 @@ if TYPE_CHECKING:
     from ...factory import _NativeInputFile
 
 
-@register_native("ComposedModel")
+@register_neml2_object("ComposedModel")
 class ComposedModel(Model):
     """Compose multiple Models together to form a single Model. The execution order
     of the composed models is determined by an internal dependency resolver such

--- a/neml2/models/common/ComposedModel.py
+++ b/neml2/models/common/ComposedModel.py
@@ -59,7 +59,7 @@ from ...chain_rule import (
     combine_sparsity,
 )
 from ...factory import register_native
-from ...model import Model, NLParam
+from ...model import Model, NLParam, register_submodule
 from ...resolver import DependencyResolver
 from ...schema import HitSchema, option
 from ...types import TensorWrapper
@@ -162,18 +162,7 @@ class ComposedModel(Model):
         self._child_supports_second_order: list[bool] = []
         used_attrs: set[str] = set()
         for i, m in enumerate(order):
-            # Prefer the HIT block name (stashed on the model by the factory)
-            # so ``self.named_parameters()`` returns readable, user-meaningful
-            # names like ``elasticity.E`` rather than ``_child_11.E``. Fall
-            # back to ``_child_{i}`` if no HIT name is available (direct
-            # Python construction) or if the name would collide with an
-            # existing attribute or a previously-registered child.
-            hit_name = getattr(m, "_hit_name", None)
-            attr = hit_name if hit_name and hit_name.isidentifier() else None
-            if attr is None or attr in used_attrs or hasattr(self, attr):
-                attr = f"_child_{i}"
-            used_attrs.add(attr)
-            self.add_module(attr, m)
+            attr = register_submodule(self, m, fallback=f"_child_{i}", used=used_attrs)
             self._plan.append(
                 (attr, list(m.input_spec), list(m.input_spec.values()), list(m.output_spec))
             )

--- a/neml2/models/common/ConstantExtrapolationPredictor.py
+++ b/neml2/models/common/ConstantExtrapolationPredictor.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, option
 from ...types import (
@@ -44,7 +44,7 @@ def _read_list_str(node, name):  # noqa: ANN001, ANN202
     return list(node.param_list_str(name))
 
 
-@register_native("ConstantExtrapolationPredictor")
+@register_neml2_object("ConstantExtrapolationPredictor")
 class ConstantExtrapolationPredictor(Model):
     """Initial guess for an implicit update: each unknown takes its ``~1`` value.
 

--- a/neml2/models/common/ConstantParameter.py
+++ b/neml2/models/common/ConstantParameter.py
@@ -36,7 +36,7 @@ holds the forward/action logic; each registered variant only differs in the
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict, SecondOrderChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import BLOCK_NAME, HitSchema, output, parameter
 from ...types import (
@@ -120,7 +120,7 @@ class _ConstantParameter(Model):
         )
 
 
-@register_native("ScalarConstantParameter")
+@register_neml2_object("ScalarConstantParameter")
 class ScalarConstantParameter(_ConstantParameter):
     """Scalar-valued constant parameter. Mirrors ``ConstantParameter<Scalar>``."""
 
@@ -145,7 +145,7 @@ class ScalarConstantParameter(_ConstantParameter):
     )
 
 
-@register_native("VecConstantParameter")
+@register_neml2_object("VecConstantParameter")
 class VecConstantParameter(_ConstantParameter):
     """Vec-valued constant parameter. Mirrors ``ConstantParameter<Vec>``."""
 
@@ -170,7 +170,7 @@ class VecConstantParameter(_ConstantParameter):
     )
 
 
-@register_native("RotConstantParameter")
+@register_neml2_object("RotConstantParameter")
 class RotConstantParameter(_ConstantParameter):
     """Rot-valued constant parameter. Mirrors ``ConstantParameter<Rot>``."""
 
@@ -195,7 +195,7 @@ class RotConstantParameter(_ConstantParameter):
     )
 
 
-@register_native("WR2ConstantParameter")
+@register_neml2_object("WR2ConstantParameter")
 class WR2ConstantParameter(_ConstantParameter):
     """WR2-valued constant parameter. Mirrors ``ConstantParameter<WR2>``."""
 
@@ -220,7 +220,7 @@ class WR2ConstantParameter(_ConstantParameter):
     )
 
 
-@register_native("R2ConstantParameter")
+@register_neml2_object("R2ConstantParameter")
 class R2ConstantParameter(_ConstantParameter):
     """R2-valued constant parameter. Mirrors ``ConstantParameter<R2>``."""
 
@@ -245,7 +245,7 @@ class R2ConstantParameter(_ConstantParameter):
     )
 
 
-@register_native("SR2ConstantParameter")
+@register_neml2_object("SR2ConstantParameter")
 class SR2ConstantParameter(_ConstantParameter):
     """SR2-valued constant parameter. Mirrors ``ConstantParameter<SR2>``."""
 
@@ -270,7 +270,7 @@ class SR2ConstantParameter(_ConstantParameter):
     )
 
 
-@register_native("SSR4ConstantParameter")
+@register_neml2_object("SSR4ConstantParameter")
 class SSR4ConstantParameter(_ConstantParameter):
     """SSR4-valued constant parameter. Mirrors ``ConstantParameter<SSR4>``."""
 
@@ -295,7 +295,7 @@ class SSR4ConstantParameter(_ConstantParameter):
     )
 
 
-@register_native("MillerIndexConstantParameter")
+@register_neml2_object("MillerIndexConstantParameter")
 class MillerIndexConstantParameter(_ConstantParameter):
     """MillerIndex-valued constant parameter. Mirrors ``ConstantParameter<MillerIndex>``."""
 

--- a/neml2/models/common/CopyVariable.py
+++ b/neml2/models/common/CopyVariable.py
@@ -42,7 +42,7 @@ identity pushforward ``action(V) = V`` -- the canonical D-062 linear leaf
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import (
@@ -90,7 +90,7 @@ class _CopyVariable(Model):
         )
 
 
-@register_native("CopyScalar")
+@register_neml2_object("CopyScalar")
 class CopyScalar(_CopyVariable):
     """Scalar-valued variable copy. Mirrors ``CopyVariable<Scalar>``."""
 
@@ -100,7 +100,7 @@ class CopyScalar(_CopyVariable):
     )
 
 
-@register_native("CopyVec")
+@register_neml2_object("CopyVec")
 class CopyVec(_CopyVariable):
     """Vec-valued variable copy. Mirrors ``CopyVariable<Vec>``."""
 
@@ -110,7 +110,7 @@ class CopyVec(_CopyVariable):
     )
 
 
-@register_native("CopyRot")
+@register_neml2_object("CopyRot")
 class CopyRot(_CopyVariable):
     """Rot-valued variable copy. Mirrors ``CopyVariable<Rot>``."""
 
@@ -120,7 +120,7 @@ class CopyRot(_CopyVariable):
     )
 
 
-@register_native("CopyWR2")
+@register_neml2_object("CopyWR2")
 class CopyWR2(_CopyVariable):
     """WR2-valued variable copy. Mirrors ``CopyVariable<WR2>``."""
 
@@ -130,7 +130,7 @@ class CopyWR2(_CopyVariable):
     )
 
 
-@register_native("CopyR2")
+@register_neml2_object("CopyR2")
 class CopyR2(_CopyVariable):
     """R2-valued variable copy. Mirrors ``CopyVariable<R2>``."""
 
@@ -140,7 +140,7 @@ class CopyR2(_CopyVariable):
     )
 
 
-@register_native("CopySR2")
+@register_neml2_object("CopySR2")
 class CopySR2(_CopyVariable):
     """SR2-valued variable copy. Mirrors ``CopyVariable<SR2>``."""
 
@@ -150,7 +150,7 @@ class CopySR2(_CopyVariable):
     )
 
 
-@register_native("CopySSR4")
+@register_neml2_object("CopySSR4")
 class CopySSR4(_CopyVariable):
     """SSR4-valued variable copy. Mirrors ``CopyVariable<SSR4>``."""
 
@@ -160,7 +160,7 @@ class CopySSR4(_CopyVariable):
     )
 
 
-@register_native("CopyMillerIndex")
+@register_neml2_object("CopyMillerIndex")
 class CopyMillerIndex(_CopyVariable):
     """MillerIndex-valued variable copy. Mirrors ``CopyVariable<MillerIndex>``."""
 

--- a/neml2/models/common/Determinant.py
+++ b/neml2/models/common/Determinant.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import (
@@ -54,7 +54,7 @@ class _Determinant(Model):
     _value_type: type[TensorWrapper]
 
 
-@register_native("R2Determinant")
+@register_neml2_object("R2Determinant")
 class R2Determinant(_Determinant):
     """Determinant of a full ``R2`` tensor."""
 
@@ -85,7 +85,7 @@ class R2Determinant(_Determinant):
         return J, self.apply_chain_rule(v, "determinant", {"input": F_action}, output=J)
 
 
-@register_native("SR2Determinant")
+@register_neml2_object("SR2Determinant")
 class SR2Determinant(_Determinant):
     """Determinant of a symmetric ``SR2`` tensor."""
 

--- a/neml2/models/common/DynamicMean.py
+++ b/neml2/models/common/DynamicMean.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output
 from ...types import (
@@ -36,7 +36,7 @@ from ...types import (
 )
 
 
-@register_native("SR2DynamicMean")
+@register_neml2_object("SR2DynamicMean")
 class SR2DynamicMean(Model):
     """``to = mean(from, dim=dynamic_dim)``. Reduces a named dynamic batch dim.
 

--- a/neml2/models/common/DynamicSum.py
+++ b/neml2/models/common/DynamicSum.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output
 from ...types import (
@@ -36,7 +36,7 @@ from ...types import (
 )
 
 
-@register_native("SR2DynamicSum")
+@register_neml2_object("SR2DynamicSum")
 class SR2DynamicSum(Model):
     """Sum a dynamic dimension.
 

--- a/neml2/models/common/FBComplementarity.py
+++ b/neml2/models/common/FBComplementarity.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import torch
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output
 from ...types import (
@@ -38,7 +38,7 @@ from ...types import (
 )
 
 
-@register_native("FBComplementarity")
+@register_neml2_object("FBComplementarity")
 class FBComplementarity(Model):
     r"""If $a \ge 0, b \ge 0, ab = 0$ then the Fischer Burmeister (FB)
     complementarity condition is:$r = a+b-\sqrt(a^2+b^2) = 0$.

--- a/neml2/models/common/ForwardEulerTimeIntegration.py
+++ b/neml2/models/common/ForwardEulerTimeIntegration.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, derived_input, input, option, output
 from ...types import (
@@ -101,7 +101,7 @@ def _forward_euler_schema(t: type[TensorWrapper]) -> HitSchema:
     )
 
 
-@register_native("ScalarForwardEulerTimeIntegration")
+@register_neml2_object("ScalarForwardEulerTimeIntegration")
 class ScalarForwardEulerTimeIntegration(_ForwardEulerTimeIntegration):
     r"""Perform forward Euler time integration defined as
     $s = s_n + (t - t_n) \dot{s}$, where $s$ is the variable being
@@ -113,7 +113,7 @@ class ScalarForwardEulerTimeIntegration(_ForwardEulerTimeIntegration):
     hit = _forward_euler_schema(Scalar)
 
 
-@register_native("SR2ForwardEulerTimeIntegration")
+@register_neml2_object("SR2ForwardEulerTimeIntegration")
 class SR2ForwardEulerTimeIntegration(_ForwardEulerTimeIntegration):
     r"""Perform forward Euler time integration defined as
     $s = s_n + (t - t_n) \dot{s}$, where $s$ is the variable being

--- a/neml2/models/common/HermiteSmoothStep.py
+++ b/neml2/models/common/HermiteSmoothStep.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import torch
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output, parameter
 from ...types import Scalar, clamp
 
 
-@register_native("HermiteSmoothStep")
+@register_neml2_object("HermiteSmoothStep")
 class HermiteSmoothStep(Model):
     r"""The smooth step function defined by Hermite polynomials.
 

--- a/neml2/models/common/ImplicitUpdate.py
+++ b/neml2/models/common/ImplicitUpdate.py
@@ -41,7 +41,7 @@ from ...equation_systems import (
     _unflatten_sub_batch_and_base,
 )
 from ...factory import register_native
-from ...model import Model
+from ...model import Model, register_submodule
 from ...schema import HitSchema, dependency
 from ...solvers import Newton, RetCode
 from ...types import TensorWrapper
@@ -184,7 +184,10 @@ class ImplicitUpdate(Model):
         # ``named_parameters()`` reach the leaves' calibration parameters.
         # ``ModelNonlinearSystem`` is a plain Python object (not an nn.Module),
         # so its ``.model`` attribute is otherwise invisible to the walker.
-        self._residual_model = system.model
+        # Prefer the residual's HIT block name (e.g. ``surface.E``) over an
+        # opaque slot — falls back to ``_residual_model`` when the inner model
+        # was built directly in Python or the name would collide.
+        register_submodule(self, system.model, fallback="_residual_model")
         self.solver = solver
         self.predictor = predictor
         self.last_iterations = 0

--- a/neml2/models/common/ImplicitUpdate.py
+++ b/neml2/models/common/ImplicitUpdate.py
@@ -40,7 +40,7 @@ from ...equation_systems import (
     _flatten_sub_batch_and_base,
     _unflatten_sub_batch_and_base,
 )
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model, register_submodule
 from ...schema import HitSchema, dependency
 from ...solvers import Newton, RetCode
@@ -126,7 +126,7 @@ def _matrix_pushforward(
     return output_type(contribution, sub_batch_ndim=len(output_sub_batch_shape))
 
 
-@register_native("ImplicitUpdate")
+@register_neml2_object("ImplicitUpdate")
 class ImplicitUpdate(Model):
     """Update an implicit model by solving the underlying nonlinear system of equations."""
 

--- a/neml2/models/common/InputParameter.py
+++ b/neml2/models/common/InputParameter.py
@@ -44,7 +44,7 @@ input as a "parameter" output rather than a generic "to" copy.
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import (
@@ -93,7 +93,7 @@ class _InputParameter(Model):
         )
 
 
-@register_native("ScalarInputParameter")
+@register_neml2_object("ScalarInputParameter")
 class ScalarInputParameter(_InputParameter):
     """Scalar-valued input parameter. Mirrors ``InputParameter<Scalar>``."""
 
@@ -103,7 +103,7 @@ class ScalarInputParameter(_InputParameter):
     )
 
 
-@register_native("VecInputParameter")
+@register_neml2_object("VecInputParameter")
 class VecInputParameter(_InputParameter):
     """Vec-valued input parameter. Mirrors ``InputParameter<Vec>``."""
 
@@ -113,7 +113,7 @@ class VecInputParameter(_InputParameter):
     )
 
 
-@register_native("RotInputParameter")
+@register_neml2_object("RotInputParameter")
 class RotInputParameter(_InputParameter):
     """Rot-valued input parameter. Mirrors ``InputParameter<Rot>``."""
 
@@ -123,7 +123,7 @@ class RotInputParameter(_InputParameter):
     )
 
 
-@register_native("WR2InputParameter")
+@register_neml2_object("WR2InputParameter")
 class WR2InputParameter(_InputParameter):
     """WR2-valued input parameter. Mirrors ``InputParameter<WR2>``."""
 
@@ -133,7 +133,7 @@ class WR2InputParameter(_InputParameter):
     )
 
 
-@register_native("R2InputParameter")
+@register_neml2_object("R2InputParameter")
 class R2InputParameter(_InputParameter):
     """R2-valued input parameter. Mirrors ``InputParameter<R2>``."""
 
@@ -143,7 +143,7 @@ class R2InputParameter(_InputParameter):
     )
 
 
-@register_native("SR2InputParameter")
+@register_neml2_object("SR2InputParameter")
 class SR2InputParameter(_InputParameter):
     """SR2-valued input parameter. Mirrors ``InputParameter<SR2>``."""
 
@@ -153,7 +153,7 @@ class SR2InputParameter(_InputParameter):
     )
 
 
-@register_native("SSR4InputParameter")
+@register_neml2_object("SSR4InputParameter")
 class SSR4InputParameter(_InputParameter):
     """SSR4-valued input parameter. Mirrors ``InputParameter<SSR4>``."""
 
@@ -163,7 +163,7 @@ class SSR4InputParameter(_InputParameter):
     )
 
 
-@register_native("MillerIndexInputParameter")
+@register_neml2_object("MillerIndexInputParameter")
 class MillerIndexInputParameter(_InputParameter):
     """MillerIndex-valued input parameter. Mirrors ``InputParameter<MillerIndex>``."""
 

--- a/neml2/models/common/IntermediateDiff.py
+++ b/neml2/models/common/IntermediateDiff.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output
 from ...types import (
@@ -36,7 +36,7 @@ from ...types import (
 )
 
 
-@register_native("SR2IntermediateDiff")
+@register_neml2_object("SR2IntermediateDiff")
 class SR2IntermediateDiff(Model):
     """Finite difference along an intermediate dimension.
 

--- a/neml2/models/common/IntermediateMean.py
+++ b/neml2/models/common/IntermediateMean.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import (
@@ -36,7 +36,7 @@ from ...types import (
 )
 
 
-@register_native("SR2IntermediateMean")
+@register_neml2_object("SR2IntermediateMean")
 class SR2IntermediateMean(Model):
     """``to = mean(from, dim=trailing_sub_batch_axis)``; reduces sub_batch_ndim by 1.
 

--- a/neml2/models/common/IntermediateSum.py
+++ b/neml2/models/common/IntermediateSum.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import (
@@ -36,7 +36,7 @@ from ...types import (
 )
 
 
-@register_native("SR2IntermediateSum")
+@register_neml2_object("SR2IntermediateSum")
 class SR2IntermediateSum(Model):
     """Sum an intermediate dimension.
 

--- a/neml2/models/common/Interpolation.py
+++ b/neml2/models/common/Interpolation.py
@@ -34,7 +34,7 @@ as standalone native leaves; this base only documents the shared contract.
 
 Because the C++ template itself is not registered (no ``register_NEML2_object``
 on the abstract base), this native port is also unregistered:
-``@register_native`` is intentionally omitted. Native models are flat (no
+``@register_neml2_object`` is intentionally omitted. Native models are flat (no
 schema inheritance), so concrete leaves declare their own ``HitSchema``
 independently rather than inheriting from this base; ``forward`` raises
 ``NotImplementedError`` so any accidental direct use surfaces immediately.

--- a/neml2/models/common/IrreversibleScalar.py
+++ b/neml2/models/common/IrreversibleScalar.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, derived_input, input, output
 from ...types import Scalar, gt, where
 
 
-@register_native("IrreversibleScalar")
+@register_neml2_object("IrreversibleScalar")
 class IrreversibleScalar(Model):
     r"""Monotonically-increasing ratchet on a Scalar:
     $y = \max(y_{n-1}, x)$ where $x$ is the trial value (`from`)

--- a/neml2/models/common/LinearCombination.py
+++ b/neml2/models/common/LinearCombination.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict, SecondOrderChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, output, parameter, parameters, var_inputs
 from ...types import (
@@ -138,7 +138,7 @@ class _LinearCombination(Model):
         return out, *self.propagate_tangents(v, self._to, actions_1, output=out, v2=v2, vh=vh)
 
 
-@register_native("ScalarLinearCombination")
+@register_neml2_object("ScalarLinearCombination")
 class ScalarLinearCombination(_LinearCombination):
     r"""Calculate linear combination of multiple Scalar tensors as
     $u = w_i v_i + b$ (Einstein summation assumed), where $w_i$ are
@@ -155,7 +155,7 @@ class ScalarLinearCombination(_LinearCombination):
     )
 
 
-@register_native("SR2LinearCombination")
+@register_neml2_object("SR2LinearCombination")
 class SR2LinearCombination(_LinearCombination):
     r"""Calculate linear combination of multiple SR2 tensors as
     $u = w_i v_i + b$ (Einstein summation assumed), where $w_i$ are

--- a/neml2/models/common/LinearExtrapolationPredictor.py
+++ b/neml2/models/common/LinearExtrapolationPredictor.py
@@ -31,7 +31,7 @@ from typing import cast
 import torch
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...schema import HitSchema, option
 from ...types import (
     R2,
@@ -61,7 +61,7 @@ def _opt_str(node, name, default):  # noqa: ANN001, ANN202
     return node.param_str(name) if node.find(name) is not None else default
 
 
-@register_native("LinearExtrapolationPredictor")
+@register_neml2_object("LinearExtrapolationPredictor")
 class LinearExtrapolationPredictor(ConstantExtrapolationPredictor):
     r"""Use temporal extrapolation assuming constant rate of change as the initial guess for the
     unknowns at the current time step. The linear extrapolation can be written as

--- a/neml2/models/common/LinearInterpolation.py
+++ b/neml2/models/common/LinearInterpolation.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict, SecondOrderChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import BLOCK_NAME, HitSchema, input, output, parameter
 from ...types import (
@@ -37,7 +37,7 @@ from ...types import (
 )
 
 
-@register_native("ScalarLinearInterpolation")
+@register_neml2_object("ScalarLinearInterpolation")
 class ScalarLinearInterpolation(Model):
     """Interpolate a Scalar as a function of the given argument. See
     neml2::Interpolation for rules on shapes of the interpolant and the

--- a/neml2/models/common/MacaulaySplit.py
+++ b/neml2/models/common/MacaulaySplit.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import Scalar, heaviside, macaulay
 
 
-@register_native("MacaulaySplit")
+@register_neml2_object("MacaulaySplit")
 class MacaulaySplit(Model):
     r"""Split a Scalar into its Macaulay (positive) and negative parts:
     $\langle x \rangle_+ = \max(x, 0)$ and

--- a/neml2/models/common/MixedControlSetup.py
+++ b/neml2/models/common/MixedControlSetup.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output
 from ...types import (
@@ -37,7 +37,7 @@ from ...types import (
 )
 
 
-@register_native("MixedControlSetup")
+@register_neml2_object("MixedControlSetup")
 class MixedControlSetup(Model):
     """Per-component selection between strain- and stress-controlled inputs.
 

--- a/neml2/models/common/ParameterToVariable.py
+++ b/neml2/models/common/ParameterToVariable.py
@@ -46,7 +46,7 @@ that mirrors the C++ "no Jacobian" behavior.
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, output, parameter
 from ...types import (
@@ -118,7 +118,7 @@ class _ParameterToVariable(Model):
         )
 
 
-@register_native("ScalarParameterToVariable")
+@register_neml2_object("ScalarParameterToVariable")
 class ScalarParameterToVariable(_ParameterToVariable):
     """Scalar parameter-to-variable. Mirrors ``ParameterToVariable<Scalar>``."""
 
@@ -137,7 +137,7 @@ class ScalarParameterToVariable(_ParameterToVariable):
     )
 
 
-@register_native("VecParameterToVariable")
+@register_neml2_object("VecParameterToVariable")
 class VecParameterToVariable(_ParameterToVariable):
     """Vec parameter-to-variable. Mirrors ``ParameterToVariable<Vec>``."""
 
@@ -156,7 +156,7 @@ class VecParameterToVariable(_ParameterToVariable):
     )
 
 
-@register_native("RotParameterToVariable")
+@register_neml2_object("RotParameterToVariable")
 class RotParameterToVariable(_ParameterToVariable):
     """Rot parameter-to-variable. Mirrors ``ParameterToVariable<Rot>``."""
 
@@ -175,7 +175,7 @@ class RotParameterToVariable(_ParameterToVariable):
     )
 
 
-@register_native("WR2ParameterToVariable")
+@register_neml2_object("WR2ParameterToVariable")
 class WR2ParameterToVariable(_ParameterToVariable):
     """WR2 parameter-to-variable. Mirrors ``ParameterToVariable<WR2>``."""
 
@@ -194,7 +194,7 @@ class WR2ParameterToVariable(_ParameterToVariable):
     )
 
 
-@register_native("R2ParameterToVariable")
+@register_neml2_object("R2ParameterToVariable")
 class R2ParameterToVariable(_ParameterToVariable):
     """R2 parameter-to-variable. Mirrors ``ParameterToVariable<R2>``."""
 
@@ -213,7 +213,7 @@ class R2ParameterToVariable(_ParameterToVariable):
     )
 
 
-@register_native("SR2ParameterToVariable")
+@register_neml2_object("SR2ParameterToVariable")
 class SR2ParameterToVariable(_ParameterToVariable):
     """SR2 parameter-to-variable. Mirrors ``ParameterToVariable<SR2>``."""
 
@@ -232,7 +232,7 @@ class SR2ParameterToVariable(_ParameterToVariable):
     )
 
 
-@register_native("SSR4ParameterToVariable")
+@register_neml2_object("SSR4ParameterToVariable")
 class SSR4ParameterToVariable(_ParameterToVariable):
     """SSR4 parameter-to-variable. Mirrors ``ParameterToVariable<SSR4>``."""
 
@@ -251,7 +251,7 @@ class SSR4ParameterToVariable(_ParameterToVariable):
     )
 
 
-@register_native("MillerIndexParameterToVariable")
+@register_neml2_object("MillerIndexParameterToVariable")
 class MillerIndexParameterToVariable(_ParameterToVariable):
     """MillerIndex parameter-to-variable. Mirrors ``ParameterToVariable<MillerIndex>``."""
 

--- a/neml2/models/common/R2Multiplication.py
+++ b/neml2/models/common/R2Multiplication.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output
 from ...types import R2, inv
 
 
-@register_native("R2Multiplication")
+@register_neml2_object("R2Multiplication")
 class R2Multiplication(Model):
     r"""Multiplication of form ``A B``, where $A$ and $B$ are second order
     tensors. A and B can be inverted and/or transposed per request.

--- a/neml2/models/common/R2ToSR2.py
+++ b/neml2/models/common/R2ToSR2.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import (
@@ -37,7 +37,7 @@ from ...types import (
 )
 
 
-@register_native("R2ToSR2")
+@register_neml2_object("R2ToSR2")
 class R2ToSR2(Model):
     """Extract the symmetric part of a R2 tensor."""
 

--- a/neml2/models/common/R2ToWR2.py
+++ b/neml2/models/common/R2ToWR2.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import (
@@ -37,7 +37,7 @@ from ...types import (
 )
 
 
-@register_native("R2ToWR2")
+@register_neml2_object("R2ToWR2")
 class R2ToWR2(Model):
     """Extract the skew symmetric part of a second order tensor."""
 

--- a/neml2/models/common/Reduction.py
+++ b/neml2/models/common/Reduction.py
@@ -32,7 +32,7 @@ actual reduction operator and its differential pushforward.
 
 Because the C++ template itself is not registered (no
 ``register_NEML2_object`` on the abstract base), this native port is also
-unregistered: ``@register_native`` is intentionally omitted. Native models are
+unregistered: ``@register_neml2_object`` is intentionally omitted. Native models are
 flat (no schema inheritance), so concrete leaves declare their own
 ``HitSchema`` independently rather than inheriting from this base; ``forward``
 raises ``NotImplementedError`` so any accidental direct use surfaces

--- a/neml2/models/common/RotationMatrix.py
+++ b/neml2/models/common/RotationMatrix.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import (
@@ -38,7 +38,7 @@ from ...types import (
 )
 
 
-@register_native("RotationMatrix")
+@register_neml2_object("RotationMatrix")
 class RotationMatrix(Model):
     """``orientation_matrix = euler_rodrigues(orientation)``.
 

--- a/neml2/models/common/SR2Invariant.py
+++ b/neml2/models/common/SR2Invariant.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import torch
 
 from ...chain_rule import ChainRuleDict, SecondOrderChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output
 from ...types import (
@@ -42,7 +42,7 @@ from ...types import (
 )
 
 
-@register_native("SR2Invariant")
+@register_neml2_object("SR2Invariant")
 class SR2Invariant(Model):
     """Scalar invariants of an ``SR2`` tensor.
 

--- a/neml2/models/common/SR2ToR2.py
+++ b/neml2/models/common/SR2ToR2.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import (
@@ -37,7 +37,7 @@ from ...types import (
 )
 
 
-@register_native("SR2ToR2")
+@register_neml2_object("SR2ToR2")
 class SR2ToR2(Model):
     """Convert a symmetric rank two tensor to a full tensor."""
 

--- a/neml2/models/common/ScalarMultiplication.py
+++ b/neml2/models/common/ScalarMultiplication.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict, SecondOrderChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, option, output, parameter, var_inputs
 from ...types import Scalar
@@ -47,7 +47,7 @@ def _opt_list_bool(node: nmhit.Node, name: str, default: list[bool]) -> list[boo
     return list(node.param_list_bool(name)) if node.find(name) is not None else list(default)
 
 
-@register_native("ScalarMultiplication")
+@register_neml2_object("ScalarMultiplication")
 class ScalarMultiplication(Model):
     """Calculate the product of multiple Scalar variables with a constant scaling
     coefficient. Using reciprocal, one can have the reciprocity of each variable

--- a/neml2/models/common/ScalarPNorm.py
+++ b/neml2/models/common/ScalarPNorm.py
@@ -31,13 +31,13 @@ from collections.abc import Callable
 import torch
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, output, parameter, parameters, var_inputs
 from ...types import Scalar, abs, pow, sign
 
 
-@register_native("ScalarPNorm")
+@register_neml2_object("ScalarPNorm")
 class ScalarPNorm(Model):
     r"""Weighted $p$-norm of an arbitrary number of Scalar inputs:
     $y = (\sum_i w_i |x_i|^p + \varepsilon)^{1/p}$. The weights default

--- a/neml2/models/common/ScalarToDiagonalSR2.py
+++ b/neml2/models/common/ScalarToDiagonalSR2.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import (
@@ -36,7 +36,7 @@ from ...types import (
 )
 
 
-@register_native("ScalarToDiagonalSR2")
+@register_neml2_object("ScalarToDiagonalSR2")
 class ScalarToDiagonalSR2(Model):
     """Create a diagonal symmetric rank 2 tensor with values filled by a scalar."""
 

--- a/neml2/models/common/SymmetricHermiteInterpolation.py
+++ b/neml2/models/common/SymmetricHermiteInterpolation.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import torch
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import BLOCK_NAME, HitSchema, input, output, parameter
 from ...types import Scalar, clamp, lt, where
 
 
-@register_native("SymmetricHermiteInterpolation")
+@register_neml2_object("SymmetricHermiteInterpolation")
 class SymmetricHermiteInterpolation(Model):
     r"""Define the symmetric Hermite interpolation function, taking the form of
     $\dfrac{1}{x_h-x_l}(24c^2-32c^3)$ for $0 le c le 0.5$;

--- a/neml2/models/common/VariableRate.py
+++ b/neml2/models/common/VariableRate.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, derived_input, derived_output, input
 from ...types import (
@@ -110,7 +110,7 @@ def _variable_rate_schema(t: type[TensorWrapper]) -> HitSchema:
     )
 
 
-@register_native("ScalarVariableRate")
+@register_neml2_object("ScalarVariableRate")
 class ScalarVariableRate(_VariableRate):
     r"""Calculate the first order discrete time derivative of a variable as
     $\dot{f} = \frac{f-f_n}{t-t_n}$, where $f$ is the variable, $f_n$ is the variable at the
@@ -121,7 +121,7 @@ class ScalarVariableRate(_VariableRate):
     hit = _variable_rate_schema(Scalar)
 
 
-@register_native("VecVariableRate")
+@register_neml2_object("VecVariableRate")
 class VecVariableRate(_VariableRate):
     r"""Calculate the first order discrete time derivative of a variable as
     $\dot{f} = \frac{f-f_n}{t-t_n}$, where $f$ is the variable, $f_n$ is the variable at the
@@ -132,7 +132,7 @@ class VecVariableRate(_VariableRate):
     hit = _variable_rate_schema(Vec)
 
 
-@register_native("SR2VariableRate")
+@register_neml2_object("SR2VariableRate")
 class SR2VariableRate(_VariableRate):
     r"""Calculate the first order discrete time derivative of a variable as
     $\dot{f} = \frac{f-f_n}{t-t_n}$, where $f$ is the variable, $f_n$ is the variable at the
@@ -143,7 +143,7 @@ class SR2VariableRate(_VariableRate):
     hit = _variable_rate_schema(SR2)
 
 
-@register_native("R2VariableRate")
+@register_neml2_object("R2VariableRate")
 class R2VariableRate(_VariableRate):
     r"""Calculate the first order discrete time derivative of a variable as
     $\dot{f} = \frac{f-f_n}{t-t_n}$, where $f$ is the variable, $f_n$ is the variable at the

--- a/neml2/models/common/VecComponents.py
+++ b/neml2/models/common/VecComponents.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option
 from ...types import (
@@ -42,7 +42,7 @@ def _read_list_str(node, name):  # noqa: ANN001, ANN202
     return list(node.param_list_str(name))
 
 
-@register_native("VecComponents")
+@register_neml2_object("VecComponents")
 class VecComponents(Model):
     """Decompose a Vec into its three Scalar components.
 

--- a/neml2/models/common/WR2ExplicitExponentialTimeIntegration.py
+++ b/neml2/models/common/WR2ExplicitExponentialTimeIntegration.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, derived_input, input, option, output
 from ...types import (
@@ -41,7 +41,7 @@ from ...types import (
 )
 
 
-@register_native("WR2ExplicitExponentialTimeIntegration")
+@register_neml2_object("WR2ExplicitExponentialTimeIntegration")
 class WR2ExplicitExponentialTimeIntegration(Model):
     r"""Perform explicit discrete exponential time integration of a rotation. The
     update can be written as $s = \exp\left[ (t-t_n)\dot{s}\right] \circ s_n$,

--- a/neml2/models/common/WR2ImplicitExponentialTimeIntegration.py
+++ b/neml2/models/common/WR2ImplicitExponentialTimeIntegration.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, derived_input, derived_output, input, option
 from ...types import (
@@ -41,7 +41,7 @@ from ...types import (
 )
 
 
-@register_native("WR2ImplicitExponentialTimeIntegration")
+@register_neml2_object("WR2ImplicitExponentialTimeIntegration")
 class WR2ImplicitExponentialTimeIntegration(Model):
     r"""Define the implicit discrete exponential time integration residual of a
     rotation variable. The residual can be written as

--- a/neml2/models/common/__init__.py
+++ b/neml2/models/common/__init__.py
@@ -26,7 +26,7 @@
 """Native common models.
 
 One file per C++ header under ``include/neml2/models/common/``; this package
-re-imports each file so ``@register_native`` side effects fire on package import.
+re-imports each file so ``@register_neml2_object`` side effects fire on package import.
 """
 
 from .ArrheniusParameter import ArrheniusParameter

--- a/neml2/models/finite_volume/DumpInSmallestBin.py
+++ b/neml2/models/finite_volume/DumpInSmallestBin.py
@@ -27,14 +27,14 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar
 from ...types.functions import sub_batch_zeros_like
 
 
-@register_native("DumpInSmallestBin")
+@register_neml2_object("DumpInSmallestBin")
 class DumpInSmallestBin(Model):
     """Dump the source magnitude into the smallest cell-center bin.
 

--- a/neml2/models/finite_volume/FiniteVolumeAppendBoundaryCondition.py
+++ b/neml2/models/finite_volume/FiniteVolumeAppendBoundaryCondition.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import torch
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output, parameter
 from ...types import Scalar
 
 
-@register_native("FiniteVolumeAppendBoundaryCondition")
+@register_neml2_object("FiniteVolumeAppendBoundaryCondition")
 class FiniteVolumeAppendBoundaryCondition(Model):
     """Concatenate a single BC value onto the trailing sub-batch axis.
 

--- a/neml2/models/finite_volume/FiniteVolumeGradient.py
+++ b/neml2/models/finite_volume/FiniteVolumeGradient.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar
 
 
-@register_native("FiniteVolumeGradient")
+@register_neml2_object("FiniteVolumeGradient")
 class FiniteVolumeGradient(Model):
     """Compute prefactor-weighted gradients at cell edges using first-order reconstruction."""
 

--- a/neml2/models/finite_volume/FiniteVolumeUpwindedAdvectiveFlux.py
+++ b/neml2/models/finite_volume/FiniteVolumeUpwindedAdvectiveFlux.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import torch
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import Scalar
 
 
-@register_native("FiniteVolumeUpwindedAdvectiveFlux")
+@register_neml2_object("FiniteVolumeUpwindedAdvectiveFlux")
 class FiniteVolumeUpwindedAdvectiveFlux(Model):
     """Compute upwinded advective fluxes at cell edges."""
 

--- a/neml2/models/finite_volume/LinearlyInterpolateToCellEdges.py
+++ b/neml2/models/finite_volume/LinearlyInterpolateToCellEdges.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import torch
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, output, parameter
 from ...types import Scalar
 
 
-@register_native("LinearlyInterpolateToCellEdges")
+@register_neml2_object("LinearlyInterpolateToCellEdges")
 class LinearlyInterpolateToCellEdges(Model):
     """Linear interpolation from cell centers to interior cell edges.
 

--- a/neml2/models/finite_volume/SemiInfiniteCoordinateTransform.py
+++ b/neml2/models/finite_volume/SemiInfiniteCoordinateTransform.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar
 
 
-@register_native("SemiInfiniteCoordinateTransform")
+@register_neml2_object("SemiInfiniteCoordinateTransform")
 class SemiInfiniteCoordinateTransform(Model):
     """Transform a semi-infinite coordinate to x / (x + s).
 

--- a/neml2/models/finite_volume/SmearedDeltaSource.py
+++ b/neml2/models/finite_volume/SmearedDeltaSource.py
@@ -29,14 +29,14 @@ from __future__ import annotations
 import math
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar
 from ...types.functions import exp
 
 
-@register_native("SmearedDeltaSource")
+@register_neml2_object("SmearedDeltaSource")
 class SmearedDeltaSource(Model):
     """Smeared Gaussian source for a Dirac delta distribution.
 

--- a/neml2/models/finite_volume/__init__.py
+++ b/neml2/models/finite_volume/__init__.py
@@ -26,7 +26,7 @@
 """Native finite-volume models.
 
 One file per C++ header under ``include/neml2/models/finite_volume/``; this
-package re-imports each file so ``@register_native`` side effects fire on
+package re-imports each file so ``@register_neml2_object`` side effects fire on
 package import.
 """
 

--- a/neml2/models/kwn/ChemicalGibbsFreeEnergyDifference.py
+++ b/neml2/models/kwn/ChemicalGibbsFreeEnergyDifference.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, output, parameters, var_inputs
 from ...types import Scalar
 
 
-@register_native("ChemicalGibbsFreeEnergyDifference")
+@register_neml2_object("ChemicalGibbsFreeEnergyDifference")
 class ChemicalGibbsFreeEnergyDifference(Model):
     r"""Chemical Gibbs free energy difference for a set of species.
 

--- a/neml2/models/kwn/CurrentConcentration.py
+++ b/neml2/models/kwn/CurrentConcentration.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, output, parameter, parameters, var_inputs
 from ...types import Scalar
 
 
-@register_native("CurrentConcentration")
+@register_neml2_object("CurrentConcentration")
 class CurrentConcentration(Model):
     r"""Compute the current matrix concentration from precipitate volume fractions.
 

--- a/neml2/models/kwn/IdealSolutionVolumetricDrivingForce.py
+++ b/neml2/models/kwn/IdealSolutionVolumetricDrivingForce.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter, parameters, var_inputs
 from ...types import Scalar, log
 
 
-@register_native("IdealSolutionVolumetricDrivingForce")
+@register_neml2_object("IdealSolutionVolumetricDrivingForce")
 class IdealSolutionVolumetricDrivingForce(Model):
     r"""Ideal-solution volumetric Gibbs free energy of precipitation.
 

--- a/neml2/models/kwn/KineticFactor.py
+++ b/neml2/models/kwn/KineticFactor.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import math
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar, pow
 
 
-@register_native("KineticFactor")
+@register_neml2_object("KineticFactor")
 class KineticFactor(Model):
     r"""Nucleation kinetic factor.
 

--- a/neml2/models/kwn/NucleationBarrierAndCriticalRadius.py
+++ b/neml2/models/kwn/NucleationBarrierAndCriticalRadius.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import math
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, output, parameter
 from ...types import Scalar
 
 
-@register_native("NucleationBarrierAndCriticalRadius")
+@register_neml2_object("NucleationBarrierAndCriticalRadius")
 class NucleationBarrierAndCriticalRadius(Model):
     r"""Compute the nucleation critical radius and Gibbs free energy barrier.
 

--- a/neml2/models/kwn/NucleationFluxMagnitude.py
+++ b/neml2/models/kwn/NucleationFluxMagnitude.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar, exp
 
 
-@register_native("NucleationFluxMagnitude")
+@register_neml2_object("NucleationFluxMagnitude")
 class NucleationFluxMagnitude(Model):
     r"""Magnitude of the nucleation flux (excluding the Dirac delta term).
 

--- a/neml2/models/kwn/PrecipitateVolumeFraction.py
+++ b/neml2/models/kwn/PrecipitateVolumeFraction.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import math
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar, pow, sum
 
 
-@register_native("PrecipitateVolumeFraction")
+@register_neml2_object("PrecipitateVolumeFraction")
 class PrecipitateVolumeFraction(Model):
     r"""Compute the precipitate volume fraction from a discrete size distribution.
 

--- a/neml2/models/kwn/ProjectedDiffusivitySum.py
+++ b/neml2/models/kwn/ProjectedDiffusivitySum.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, output, parameters, var_inputs
 from ...types import Scalar, pow
 
 
-@register_native("ProjectedDiffusivitySum")
+@register_neml2_object("ProjectedDiffusivitySum")
 class ProjectedDiffusivitySum(Model):
     """Compute the projected diffusivity sum for SFFK and nucleation."""
 

--- a/neml2/models/kwn/RateLimitedPrecipitateGrowthRate.py
+++ b/neml2/models/kwn/RateLimitedPrecipitateGrowthRate.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar
 
 
-@register_native("RateLimitedPrecipitateGrowthRate")
+@register_neml2_object("RateLimitedPrecipitateGrowthRate")
 class RateLimitedPrecipitateGrowthRate(Model):
     """Compute the rate-limited precipitate growth rate for a single species."""
 

--- a/neml2/models/kwn/SFFKPrecipitationGrowthRate.py
+++ b/neml2/models/kwn/SFFKPrecipitationGrowthRate.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar
 
 
-@register_native("SFFKPrecipitationGrowthRate")
+@register_neml2_object("SFFKPrecipitationGrowthRate")
 class SFFKPrecipitationGrowthRate(Model):
     """Compute the SFFK precipitate growth rate."""
 

--- a/neml2/models/kwn/ZeldovichFactor.py
+++ b/neml2/models/kwn/ZeldovichFactor.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import math
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar, sqrt
 
 
-@register_native("ZeldovichFactor")
+@register_neml2_object("ZeldovichFactor")
 class ZeldovichFactor(Model):
     r"""Zeldovich factor for nucleation.
 

--- a/neml2/models/kwn/__init__.py
+++ b/neml2/models/kwn/__init__.py
@@ -26,7 +26,7 @@
 """Native KWN (Kampmann--Wagner Numerical) models.
 
 One file per C++ header under ``include/neml2/models/kwn/``; this package
-re-imports each file so ``@register_native`` side effects fire on package
+re-imports each file so ``@register_neml2_object`` side effects fire on package
 import.
 """
 

--- a/neml2/models/phase_field_fracture/CrackGeometricFunction.py
+++ b/neml2/models/phase_field_fracture/CrackGeometricFunction.py
@@ -32,7 +32,7 @@ the canonical ``phase : Scalar`` input and ``crack : Scalar`` output that all
 crack geometric functions share, leaving the forward map to subclasses.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical input/output names; ``forward``
 raises ``NotImplementedError`` so any accidental direct use surfaces
 immediately. Native models are flat (no schema inheritance), so existing

--- a/neml2/models/phase_field_fracture/CrackGeometricFunctionAT1.py
+++ b/neml2/models/phase_field_fracture/CrackGeometricFunctionAT1.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import Scalar
 
 
-@register_native("CrackGeometricFunctionAT1")
+@register_neml2_object("CrackGeometricFunctionAT1")
 class CrackGeometricFunctionAT1(Model):
     r"""Crack geometric function associated with the AT-1 functional,
     $\alpha = d$ where $d$ is the phase-field variable.

--- a/neml2/models/phase_field_fracture/CrackGeometricFunctionAT2.py
+++ b/neml2/models/phase_field_fracture/CrackGeometricFunctionAT2.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict, SecondOrderChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output
 from ...types import Scalar
 
 
-@register_native("CrackGeometricFunctionAT2")
+@register_neml2_object("CrackGeometricFunctionAT2")
 class CrackGeometricFunctionAT2(Model):
     r"""Crack geometric function associated with the AT-2 functional,
     $\alpha = d^2$ where $d$ is the phase-field variable.

--- a/neml2/models/phase_field_fracture/DegradationFunction.py
+++ b/neml2/models/phase_field_fracture/DegradationFunction.py
@@ -33,7 +33,7 @@ that maps the phase-field variable to a scalar degradation factor:
 the actual ``g(d)`` expression and its differential pushforward.
 
 Because the C++ class is not registered with ``register_NEML2_object``, this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. Native models are flat (no schema inheritance), so existing
 concrete leaves declare their own ``HitSchema`` instead of inheriting from
 this base. ``forward`` raises ``NotImplementedError`` so any accidental

--- a/neml2/models/phase_field_fracture/LinearIsotropicStrainEnergyDensity.py
+++ b/neml2/models/phase_field_fracture/LinearIsotropicStrainEnergyDensity.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ...chain_rule import ChainRuleDict, SecondOrderChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output
 from ...types import SR2, Scalar, dev, heaviside, inner, macaulay, tr
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     from ...factory import _NativeInputFile
 
 
-@register_native("LinearIsotropicStrainEnergyDensity")
+@register_neml2_object("LinearIsotropicStrainEnergyDensity")
 class LinearIsotropicStrainEnergyDensity(Model):
     """Calculates elastic strain energy density based on linear elastic isotropic response"""
 

--- a/neml2/models/phase_field_fracture/PowerDegradationFunction.py
+++ b/neml2/models/phase_field_fracture/PowerDegradationFunction.py
@@ -27,14 +27,14 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict, SecondOrderChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output, parameter
 from ...types import Scalar
 from ...types.functions import pow as type_pow
 
 
-@register_native("PowerDegradationFunction")
+@register_neml2_object("PowerDegradationFunction")
 class PowerDegradationFunction(Model):
     r"""Power degradation function used to degrade the elastic strain energy
     density,

--- a/neml2/models/phase_field_fracture/RationalDegradationFunction.py
+++ b/neml2/models/phase_field_fracture/RationalDegradationFunction.py
@@ -27,14 +27,14 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output, parameter
 from ...types import Scalar
 from ...types.functions import pow as type_pow
 
 
-@register_native("RationalDegradationFunction")
+@register_neml2_object("RationalDegradationFunction")
 class RationalDegradationFunction(Model):
     r"""Rational degradation function used to degrade the elastic strain energy
     density,

--- a/neml2/models/phase_field_fracture/StrainEnergyDensity.py
+++ b/neml2/models/phase_field_fracture/StrainEnergyDensity.py
@@ -35,7 +35,7 @@ an active part (driving fracture) and an inactive part: ``strain : SR2`` in,
 actual decomposition and its differential pushforward.
 
 Because the C++ class is not registered with ``register_NEML2_object``, this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. Native models are flat (no schema inheritance), so concrete leaves
 declare their own ``HitSchema`` instead of inheriting from this base.
 ``forward`` raises ``NotImplementedError`` so any accidental direct use

--- a/neml2/models/phase_field_fracture/__init__.py
+++ b/neml2/models/phase_field_fracture/__init__.py
@@ -26,7 +26,7 @@
 """Native phase-field-fracture models.
 
 One file per C++ header under ``include/neml2/models/phase_field_fracture/``;
-this package re-imports each file so ``@register_native`` side effects fire on
+this package re-imports each file so ``@register_neml2_object`` side effects fire on
 package import.
 """
 

--- a/neml2/models/porous_flow/AdvectiveStress.py
+++ b/neml2/models/porous_flow/AdvectiveStress.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import R2, Scalar, inner, pow
 
 
-@register_native("AdvectiveStress")
+@register_neml2_object("AdvectiveStress")
 class AdvectiveStress(Model):
     r"""Variational advective stress associated with swelling-induced volume change.
 

--- a/neml2/models/porous_flow/BrooksCoreyCapillaryPressure.py
+++ b/neml2/models/porous_flow/BrooksCoreyCapillaryPressure.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import math
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output, parameter
 from ...types import Scalar, log10, lt, pow, where
 
 
-@register_native("BrooksCoreyCapillaryPressure")
+@register_neml2_object("BrooksCoreyCapillaryPressure")
 class BrooksCoreyCapillaryPressure(Model):
     r"""Define the Brooks-Corey correlation for capillary pressure
     $P_c = P_t S_e^{-\frac{1}{p}}$. Here $S_e$ is the effective

--- a/neml2/models/porous_flow/CapillaryPressure.py
+++ b/neml2/models/porous_flow/CapillaryPressure.py
@@ -34,7 +34,7 @@ extension knobs ``log_extension`` / ``transition_saturation``; concrete
 subclasses implement ``calculate_pressure`` on the base branch.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical I/O names and option surface;
 ``forward`` raises ``NotImplementedError`` so any accidental direct use
 surfaces immediately. Native models are flat (no schema inheritance), so

--- a/neml2/models/porous_flow/EffectiveSaturation.py
+++ b/neml2/models/porous_flow/EffectiveSaturation.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar
 
 
-@register_native("EffectiveSaturation")
+@register_neml2_object("EffectiveSaturation")
 class EffectiveSaturation(Model):
     r"""Define the effective saturation, taking the form of
     $S = \frac{\frac{\phi}{\phi_\mathrm{max}} - S_r}{1-S_r}$ where

--- a/neml2/models/porous_flow/ExponentialLawPermeability.py
+++ b/neml2/models/porous_flow/ExponentialLawPermeability.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar, exp
 
 
-@register_native("ExponentialLawPermeability")
+@register_neml2_object("ExponentialLawPermeability")
 class ExponentialLawPermeability(Model):
     r"""Define the relationship between non-dimensionalized porosity and permeability.
 

--- a/neml2/models/porous_flow/KozenyCarmanPermeability.py
+++ b/neml2/models/porous_flow/KozenyCarmanPermeability.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar, pow
 
 
-@register_native("KozenyCarmanPermeability")
+@register_neml2_object("KozenyCarmanPermeability")
 class KozenyCarmanPermeability(Model):
     r"""Define the relationship between non-dimensionalized porosity and permeability.
 

--- a/neml2/models/porous_flow/PorosityPermeabilityRelation.py
+++ b/neml2/models/porous_flow/PorosityPermeabilityRelation.py
@@ -33,7 +33,7 @@ and ``permeability : Scalar`` output; concrete subclasses implement the
 forward operator and its differential pushforward.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical I/O names; ``forward`` raises
 ``NotImplementedError`` so any accidental direct use surfaces immediately.
 Native models are flat (no schema inheritance), so existing concrete leaves

--- a/neml2/models/porous_flow/PowerLawPermeability.py
+++ b/neml2/models/porous_flow/PowerLawPermeability.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleAction, ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import Scalar, pow
 
 
-@register_native("PowerLawPermeability")
+@register_neml2_object("PowerLawPermeability")
 class PowerLawPermeability(Model):
     r"""Power-law porosity-permeability relation
     $K = K_0 \left( \frac{\varphi}{\varphi_0} \right)^p$ where

--- a/neml2/models/porous_flow/VanGenuchtenCapillaryPressure.py
+++ b/neml2/models/porous_flow/VanGenuchtenCapillaryPressure.py
@@ -31,13 +31,13 @@ import math
 import torch
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, option, output, parameter
 from ...types import Scalar, log10, lt, pow, where
 
 
-@register_native("VanGenuchtenCapillaryPressure")
+@register_neml2_object("VanGenuchtenCapillaryPressure")
 class VanGenuchtenCapillaryPressure(Model):
     r"""Define the van Genuchten correlation for capillary pressure
     $P_c = a \left( S_e^{-\frac{1}{m}} - 1 \right)^{1-m}$. Here

--- a/neml2/models/porous_flow/__init__.py
+++ b/neml2/models/porous_flow/__init__.py
@@ -26,7 +26,7 @@
 """Native porous-flow models.
 
 One file per C++ header under ``include/neml2/models/porous_flow/``; this
-package re-imports each file so ``@register_native`` side effects fire on
+package re-imports each file so ``@register_neml2_object`` side effects fire on
 package import.
 """
 

--- a/neml2/models/solid_mechanics/TwoStageThermalAnnealing.py
+++ b/neml2/models/solid_mechanics/TwoStageThermalAnnealing.py
@@ -33,7 +33,7 @@ registered variant only differs in the ``hit`` schema's wrapper type.
 from __future__ import annotations
 
 from ...chain_rule import ChainRuleDict
-from ...factory import register_native
+from ...factory import register_neml2_object
 from ...model import Model
 from ...schema import HitSchema, input, output, parameter
 from ...types import SR2, Scalar, TensorWrapper, lt, where
@@ -111,7 +111,7 @@ class _TwoStageThermalAnnealing(Model):
         )
 
 
-@register_native("ScalarTwoStageThermalAnnealing")
+@register_neml2_object("ScalarTwoStageThermalAnnealing")
 class ScalarTwoStageThermalAnnealing(_TwoStageThermalAnnealing):
     """Scalar-valued two-stage thermal annealing. Mirrors ``TwoStageThermalAnnealing<Scalar>``."""
 
@@ -128,7 +128,7 @@ class ScalarTwoStageThermalAnnealing(_TwoStageThermalAnnealing):
     )
 
 
-@register_native("SR2TwoStageThermalAnnealing")
+@register_neml2_object("SR2TwoStageThermalAnnealing")
 class SR2TwoStageThermalAnnealing(_TwoStageThermalAnnealing):
     """SR2-valued two-stage thermal annealing. Mirrors ``TwoStageThermalAnnealing<SR2>``."""
 

--- a/neml2/models/solid_mechanics/crystal_plasticity/CrystalPlasticityStrainPredictor.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/CrystalPlasticityStrainPredictor.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, parameter
 from ....types import SR2, Scalar, lt, norm, where
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from ....factory import _NativeInputFile
 
 
-@register_native("CrystalPlasticityStrainPredictor")
+@register_neml2_object("CrystalPlasticityStrainPredictor")
 class CrystalPlasticityStrainPredictor(Model):
     r"""Warm-up predictor for crystal plasticity models. Computes an initial guess
     for the elastic strain as $\varepsilon^e = s \cdot \Delta t \cdot d$

--- a/neml2/models/solid_mechanics/crystal_plasticity/DislocationObstacleStrengthMap.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/DislocationObstacleStrengthMap.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleAction, ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar, sqrt
 
 
-@register_native("DislocationObstacleStrengthMap")
+@register_neml2_object("DislocationObstacleStrengthMap")
 class DislocationObstacleStrengthMap(Model):
     r"""Dislocation density to strength as in Taylor
     $\tau_i = \tau_{const} + \alpha \mu b \sqrt{\rho_i}$.

--- a/neml2/models/solid_mechanics/crystal_plasticity/ElasticStrainRate.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/ElasticStrainRate.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import SR2, WR2, r2_from_sr2, r2_from_wr2, sym
 
 
-@register_native("ElasticStrainRate")
+@register_neml2_object("ElasticStrainRate")
 class ElasticStrainRate(Model):
     r"""Calculates the elastic strain rate as
     $\dot{\varepsilon} = d - d^p - \varepsilon w + w \varepsilon$ where

--- a/neml2/models/solid_mechanics/crystal_plasticity/FixOrientation.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/FixOrientation.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, option, output
 from ....types import Rot, inner, lt, where
 
 
-@register_native("FixOrientation")
+@register_neml2_object("FixOrientation")
 class FixOrientation(Model):
     r"""Swap the modified-Rodrigues representation to the shadow parameter set
     when $\left\lVert r \right\rVert^2 \geq t$ (default threshold

--- a/neml2/models/solid_mechanics/crystal_plasticity/LinearSingleSlipHardeningRule.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/LinearSingleSlipHardeningRule.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar
 
 
-@register_native("LinearSingleSlipHardeningRule")
+@register_neml2_object("LinearSingleSlipHardeningRule")
 class LinearSingleSlipHardeningRule(Model):
     r"""Simple linear slip system hardening defined by
     $\dot{\tau} = \theta \sum_{i=1}^{n_{slip}} \left| \dot{\gamma}_i \right|$

--- a/neml2/models/solid_mechanics/crystal_plasticity/OrientationRate.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/OrientationRate.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import SR2, WR2, r2_from_sr2, skew
 
 
-@register_native("OrientationRate")
+@register_neml2_object("OrientationRate")
 class OrientationRate(Model):
     r"""Defines the rate of the crystal orientations as a spin given by
     $\Omega^e = w - w^p - \varepsilon d^p + d^p \varepsilon$ where

--- a/neml2/models/solid_mechanics/crystal_plasticity/PerSlipForestDislocationEvolution.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/PerSlipForestDislocationEvolution.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_output, input, parameter
 from ....types import Scalar, abs, sign, sqrt
 
 
-@register_native("PerSlipForestDislocationEvolution")
+@register_neml2_object("PerSlipForestDislocationEvolution")
 class PerSlipForestDislocationEvolution(Model):
     r"""Standard forest hardening model per slip system defined by
     $\dot{\rho}_i = (k_1 \sqrt{\rho_i} - k_2 \rho_i) \left| \dot{\gamma}_i \right|$.

--- a/neml2/models/solid_mechanics/crystal_plasticity/PlasticDeformationRate.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/PlasticDeformationRate.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, dependency, input, output
 from ....types import R2, SR2, Scalar, jvp_rotate, rotate, sum
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from ....data import CrystalGeometry
 
 
-@register_native("PlasticDeformationRate")
+@register_neml2_object("PlasticDeformationRate")
 class PlasticDeformationRate(Model):
     r"""Caclulates the plastic deformation rate as
     $d^p = \sum_{i=1}^{n_{slip}} \dot{\gamma}_i Q \operatorname{sym}{\left(d_i \otimes n_i \right)} Q^T$

--- a/neml2/models/solid_mechanics/crystal_plasticity/PlasticSpatialVelocityGradient.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/PlasticSpatialVelocityGradient.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, dependency, input, output
 from ....types import R2, Scalar, jvp_rotate, rotate, sum
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from ....data import CrystalGeometry
 
 
-@register_native("PlasticSpatialVelocityGradient")
+@register_neml2_object("PlasticSpatialVelocityGradient")
 class PlasticSpatialVelocityGradient(Model):
     r"""Caclulates the plastic spatial velocity gradient as
     $l^p = \sum_{i=1}^{n_{slip}} \dot{\gamma}_i Q \left(d_i \otimes n_i \right) Q^T$

--- a/neml2/models/solid_mechanics/crystal_plasticity/PlasticVorticity.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/PlasticVorticity.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, dependency, input, output
 from ....types import R2, WR2, Scalar, jvp_rotate, rotate, sum
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from ....data import CrystalGeometry
 
 
-@register_native("PlasticVorticity")
+@register_neml2_object("PlasticVorticity")
 class PlasticVorticity(Model):
     r"""Caclulates the plastic vorcitity as
     $w^p = \sum_{i=1}^{n_{slip}} \dot{\gamma}_i Q \operatorname{skew}{\left(d_i \otimes n_i \right)} Q^T$

--- a/neml2/models/solid_mechanics/crystal_plasticity/PowerLawSlipRule.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/PowerLawSlipRule.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar
@@ -35,7 +35,7 @@ from ....types import abs as tensor_abs
 from ....types import pow as tensor_pow
 
 
-@register_native("PowerLawSlipRule")
+@register_neml2_object("PowerLawSlipRule")
 class PowerLawSlipRule(Model):
     r"""Power law slip rule defined as
     $\dot{\gamma}_i = \dot{\gamma}_0 \left| \frac{\tau_i}{\hat{\tau}_i} \right|^{n-1} \frac{\tau_i}{\hat{\tau}_i}$

--- a/neml2/models/solid_mechanics/crystal_plasticity/ResolvedShear.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/ResolvedShear.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, dependency, input, output
 from ....types import R2, SR2, Scalar, inner, jvp_rotate, rotate
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from ....data import CrystalGeometry
 
 
-@register_native("ResolvedShear")
+@register_neml2_object("ResolvedShear")
 class ResolvedShear(Model):
     r"""Calculates the resolved shears as
     $\tau_i = \sigma : Q \operatorname{sym}\left(d_i \otimes n_i \right) Q^T$ where $\tau_i$ is the

--- a/neml2/models/solid_mechanics/crystal_plasticity/SingleSlipHardeningRule.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/SingleSlipHardeningRule.py
@@ -33,7 +33,7 @@ The C++ base declares the ``slip_hardening`` input, the corresponding rate
 output via ``rate_name(...)``, and the ``sum_slip_rates`` input.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical input/output names (matching the
 concrete native leaves' explicit ``slip_hardening_rate`` output);
 ``forward`` raises ``NotImplementedError`` so any accidental direct use

--- a/neml2/models/solid_mechanics/crystal_plasticity/SingleSlipStrengthMap.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/SingleSlipStrengthMap.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, dependency, input, output, parameter
 from ....types import Scalar
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from ....data import CrystalGeometry
 
 
-@register_native("SingleSlipStrengthMap")
+@register_neml2_object("SingleSlipStrengthMap")
 class SingleSlipStrengthMap(Model):
     r"""Calculates the slip system strength for all slip systems as
     $\hat{\tau}_i = \bar{\tau} + \tau_0$ where $\hat{\tau}_i$ is

--- a/neml2/models/solid_mechanics/crystal_plasticity/SlipRule.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/SlipRule.py
@@ -32,7 +32,7 @@ rules (``PowerLawSlipRule`` and future variants). It declares the canonical
 leaving the actual flow law to subclasses.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical input/output names so any future
 shared logic has a home; ``forward`` raises ``NotImplementedError`` so any
 accidental direct use surfaces immediately. Native models are flat (no schema

--- a/neml2/models/solid_mechanics/crystal_plasticity/SlipStrengthMap.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/SlipStrengthMap.py
@@ -33,7 +33,7 @@ declares the canonical ``slip_strengths`` output; the input set varies by
 subclass.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical output name; ``forward`` raises
 ``NotImplementedError`` so any accidental direct use surfaces immediately.
 Native models are flat (no schema inheritance), so existing concrete leaves

--- a/neml2/models/solid_mechanics/crystal_plasticity/SumSlipRates.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/SumSlipRates.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import Scalar, sum
@@ -35,7 +35,7 @@ from ....types import abs as tensor_abs
 from ....types import sign as tensor_sign
 
 
-@register_native("SumSlipRates")
+@register_neml2_object("SumSlipRates")
 class SumSlipRates(Model):
     r"""Calculates the sum of the absolute value of all the slip rates as
     $\sum_{i=1}^{n_{slip}} \left| \dot{\gamma}_i \right|$.

--- a/neml2/models/solid_mechanics/crystal_plasticity/VoceSingleSlipHardeningRule.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/VoceSingleSlipHardeningRule.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar
 
 
-@register_native("VoceSingleSlipHardeningRule")
+@register_neml2_object("VoceSingleSlipHardeningRule")
 class VoceSingleSlipHardeningRule(Model):
     r"""Voce hardening for a SingleSlipStrength type model defined by
     $\dot{\tau} = \theta_0 \left( 1 - \frac{\tau}{\tau_f} \right) \sum_{i=1}^{n_{slip}} \left| \dot{\gamma}_i \right|$

--- a/neml2/models/solid_mechanics/crystal_plasticity/__init__.py
+++ b/neml2/models/solid_mechanics/crystal_plasticity/__init__.py
@@ -27,7 +27,7 @@
 
 One file per C++ header under
 ``include/neml2/models/solid_mechanics/crystal_plasticity/``; this package
-re-imports each so the ``@register_native`` side effects fire on package import.
+re-imports each so the ``@register_neml2_object`` side effects fire on package import.
 """
 
 from .CrystalPlasticityStrainPredictor import CrystalPlasticityStrainPredictor

--- a/neml2/models/solid_mechanics/elasticity/AnisotropicElasticity.py
+++ b/neml2/models/solid_mechanics/elasticity/AnisotropicElasticity.py
@@ -32,7 +32,7 @@ adds the ``orientation : Rot`` input (active convention) to the elastic
 strain / stress contract while leaving ``set_value`` to subclasses.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical input/output names plus the
 ``orientation`` input that concrete native anisotropic leaves can reuse;
 ``forward`` raises ``NotImplementedError`` so any accidental direct use

--- a/neml2/models/solid_mechanics/elasticity/CubicElasticityTensor.py
+++ b/neml2/models/solid_mechanics/elasticity/CubicElasticityTensor.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import BLOCK_NAME, HitSchema, option, output
 from ....types import SSR4, Scalar
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
     from ....factory import _NativeInputFile
 
 
-@register_native("CubicElasticityTensor")
+@register_neml2_object("CubicElasticityTensor")
 class CubicElasticityTensor(Model):
     """This class defines a cubic anisotropic elasticity tensor using three
     parameters.  Various options are available for which three parameters to

--- a/neml2/models/solid_mechanics/elasticity/Elasticity.py
+++ b/neml2/models/solid_mechanics/elasticity/Elasticity.py
@@ -36,7 +36,7 @@ concrete elastic relation:
   so the model defines the relation between rates instead of totals.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical input/output names so concrete
 native elasticity leaves can reuse the contract; ``forward`` raises
 ``NotImplementedError`` so any accidental direct use surfaces immediately.

--- a/neml2/models/solid_mechanics/elasticity/ElasticityInterface.py
+++ b/neml2/models/solid_mechanics/elasticity/ElasticityInterface.py
@@ -44,7 +44,7 @@ to map the user-chosen parameterization into the model's canonical pair (K, G)
 or triple (C1, C2, C3).
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical option surface so concrete native
 elasticity leaves can be authored consistently; ``forward`` raises
 ``NotImplementedError`` so any accidental direct use surfaces immediately.

--- a/neml2/models/solid_mechanics/elasticity/GeneralElasticity.py
+++ b/neml2/models/solid_mechanics/elasticity/GeneralElasticity.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import (
@@ -41,7 +41,7 @@ from ....types import (
 )
 
 
-@register_native("GeneralElasticity")
+@register_neml2_object("GeneralElasticity")
 class GeneralElasticity(Model):
     """``stress = (T.rotate(R)) : strain`` with ``T : SSR4`` the lab-frame stiffness.
 

--- a/neml2/models/solid_mechanics/elasticity/GreenLagrangeStrain.py
+++ b/neml2/models/solid_mechanics/elasticity/GreenLagrangeStrain.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import R2, SR2, sym
 
 
-@register_native("GreenLagrangeStrain")
+@register_neml2_object("GreenLagrangeStrain")
 class GreenLagrangeStrain(Model):
     r"""Green-Lagrange strain, $E = \frac{1}{2} (C - I)$, where
     $C = F^T F$ is the right Cauchy-Green tensor and $I$ is the

--- a/neml2/models/solid_mechanics/elasticity/IsotropicElasticityTensor.py
+++ b/neml2/models/solid_mechanics/elasticity/IsotropicElasticityTensor.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import BLOCK_NAME, HitSchema, option, output
 from ....types import SSR4, Scalar
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from ....factory import _NativeInputFile
 
 
-@register_native("IsotropicElasticityTensor")
+@register_neml2_object("IsotropicElasticityTensor")
 class IsotropicElasticityTensor(Model):
     """This class defines an isotropic elasticity tensor using two parameters.
     Various options are available for which two parameters to provide.

--- a/neml2/models/solid_mechanics/elasticity/LinearIsotropicElasticity.py
+++ b/neml2/models/solid_mechanics/elasticity/LinearIsotropicElasticity.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, option, output
 from ....types import SR2, Scalar, dev, vol
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     from ....factory import _NativeInputFile
 
 
-@register_native("LinearIsotropicElasticity")
+@register_neml2_object("LinearIsotropicElasticity")
 class LinearIsotropicElasticity(Model):
     r"""Relate elastic strain to stress (or stress to strain, in compliance form)
     for a linear isotropic material.

--- a/neml2/models/solid_mechanics/elasticity/__init__.py
+++ b/neml2/models/solid_mechanics/elasticity/__init__.py
@@ -25,7 +25,7 @@
 """Solid-mechanics elasticity models.
 
 One file per registered type; this package re-imports each so the
-``@register_native`` side effects fire on package import.
+``@register_neml2_object`` side effects fire on package import.
 """
 
 from .AnisotropicElasticity import AnisotropicElasticity

--- a/neml2/models/solid_mechanics/kinematics/Eigenstrain.py
+++ b/neml2/models/solid_mechanics/kinematics/Eigenstrain.py
@@ -34,7 +34,7 @@ surface is the ``eigenstrain : SR2`` output declared in
 and parameters.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical ``eigenstrain`` output name so
 the documented surface is visible in one place; ``forward`` raises
 ``NotImplementedError`` so any accidental direct use surfaces immediately.

--- a/neml2/models/solid_mechanics/kinematics/PhaseTransformationEigenstrain.py
+++ b/neml2/models/solid_mechanics/kinematics/PhaseTransformationEigenstrain.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import SR2, Scalar
 
 
-@register_native("PhaseTransformationEigenstrain")
+@register_neml2_object("PhaseTransformationEigenstrain")
 class PhaseTransformationEigenstrain(Model):
     r"""Define the (cummulative, as opposed to instantaneous) linear isotropic phase
     transformation (from phase A to phase B) eigenstrain, i.e.

--- a/neml2/models/solid_mechanics/kinematics/SwellingAndPhaseChangeDeformationJacobian.py
+++ b/neml2/models/solid_mechanics/kinematics/SwellingAndPhaseChangeDeformationJacobian.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar
 
 
-@register_native("SwellingAndPhaseChangeDeformationJacobian")
+@register_neml2_object("SwellingAndPhaseChangeDeformationJacobian")
 class SwellingAndPhaseChangeDeformationJacobian(Model):
     r"""Define the linear isotropic phase change deformation Jacobian for a freezing liquid or a
     melting solid, i.e. $J = \left( 1 + \alpha c \phi^f + (1-c) \phi^f \Delta \Omega \right)$, where

--- a/neml2/models/solid_mechanics/kinematics/ThermalDeformationJacobian.py
+++ b/neml2/models/solid_mechanics/kinematics/ThermalDeformationJacobian.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar
 
 
-@register_native("ThermalDeformationJacobian")
+@register_neml2_object("ThermalDeformationJacobian")
 class ThermalDeformationJacobian(Model):
     r"""Define the linear isotropic thermal deformation Jacobian, i.e. $J = 1 + \alpha (T - T_0)$,
     where $\alpha$ is the coefficient of thermal expansion (CTE), $T$ is

--- a/neml2/models/solid_mechanics/kinematics/ThermalEigenstrain.py
+++ b/neml2/models/solid_mechanics/kinematics/ThermalEigenstrain.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import SR2, Scalar
 
 
-@register_native("ThermalEigenstrain")
+@register_neml2_object("ThermalEigenstrain")
 class ThermalEigenstrain(Model):
     r"""Define the (cummulative, as opposed to instantaneous) linear isotropic thermal
     eigenstrain, i.e. $\boldsymbol{\varepsilon}_T = \alpha (T - T_0) \boldsymbol{I}$,

--- a/neml2/models/solid_mechanics/kinematics/VolumeAdjustDeformationGradient.py
+++ b/neml2/models/solid_mechanics/kinematics/VolumeAdjustDeformationGradient.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import R2, Scalar, pow
 
 
-@register_native("VolumeAdjustDeformationGradient")
+@register_neml2_object("VolumeAdjustDeformationGradient")
 class VolumeAdjustDeformationGradient(Model):
     r"""Calculate the volume-adjusted deformation gradient, i.e. $F_e = J^{-\frac{1}/{3}} F$, where
     $F$ is the pre-adjusted deformation

--- a/neml2/models/solid_mechanics/kinematics/VolumeChangeEigenstrain.py
+++ b/neml2/models/solid_mechanics/kinematics/VolumeChangeEigenstrain.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import SR2, Scalar, pow
 
 
-@register_native("VolumeChangeEigenstrain")
+@register_neml2_object("VolumeChangeEigenstrain")
 class VolumeChangeEigenstrain(Model):
     r"""Define the (cumulative, as opposed to instantaneous) linear isotropic
     volume expansion eigenstrain, i.e.

--- a/neml2/models/solid_mechanics/kinematics/__init__.py
+++ b/neml2/models/solid_mechanics/kinematics/__init__.py
@@ -26,7 +26,7 @@
 
 One file per C++ header under
 ``include/neml2/models/solid_mechanics/kinematics/``; this package re-imports
-each so the ``@register_native`` side effects fire on package import.
+each so the ``@register_neml2_object`` side effects fire on package import.
 """
 
 from .Eigenstrain import Eigenstrain

--- a/neml2/models/solid_mechanics/plasticity/AssociativeIsotropicPlasticHardening.py
+++ b/neml2/models/solid_mechanics/plasticity/AssociativeIsotropicPlasticHardening.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import Scalar
 
 
-@register_native("AssociativeIsotropicPlasticHardening")
+@register_neml2_object("AssociativeIsotropicPlasticHardening")
 class AssociativeIsotropicPlasticHardening(Model):
     r"""Map the flow rate (i.e., the consistency parameter in the KKT conditions)
     to the rate of internal variables. This object calculates the rate of

--- a/neml2/models/solid_mechanics/plasticity/AssociativeJ2FlowDirection.py
+++ b/neml2/models/solid_mechanics/plasticity/AssociativeJ2FlowDirection.py
@@ -31,14 +31,14 @@ import math
 import torch
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import SR2
 from ....types.functions import dev, inner, norm
 
 
-@register_native("AssociativeJ2FlowDirection")
+@register_neml2_object("AssociativeJ2FlowDirection")
 class AssociativeJ2FlowDirection(Model):
     """The plastic flow direction assuming an associative J2 flow."""
 

--- a/neml2/models/solid_mechanics/plasticity/AssociativeKinematicPlasticHardening.py
+++ b/neml2/models/solid_mechanics/plasticity/AssociativeKinematicPlasticHardening.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import SR2, Scalar
 
 
-@register_native("AssociativeKinematicPlasticHardening")
+@register_neml2_object("AssociativeKinematicPlasticHardening")
 class AssociativeKinematicPlasticHardening(Model):
     r"""Map the flow rate (i.e., the consistency parameter in the KKT conditions)
     to the rate of internal variables. This object calculates the rate of

--- a/neml2/models/solid_mechanics/plasticity/AssociativePlasticFlow.py
+++ b/neml2/models/solid_mechanics/plasticity/AssociativePlasticFlow.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import SR2, Scalar
 
 
-@register_native("AssociativePlasticFlow")
+@register_neml2_object("AssociativePlasticFlow")
 class AssociativePlasticFlow(Model):
     r"""Map the flow rate (i.e., the consistency parameter in the KKT conditions)
     to the rate of internal variables. This object calculates the rate of

--- a/neml2/models/solid_mechanics/plasticity/ChabochePlasticHardening.py
+++ b/neml2/models/solid_mechanics/plasticity/ChabochePlasticHardening.py
@@ -29,14 +29,14 @@ from __future__ import annotations
 import torch
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_output, input, parameter
 from ....types import SR2, Scalar, inner, log, norm
 from ....types import pow as wpow
 
 
-@register_native("ChabochePlasticHardening")
+@register_neml2_object("ChabochePlasticHardening")
 class ChabochePlasticHardening(Model):
     r"""Map the flow rate (i.e., the consistency parameter in the KKT conditions)
     to the rate of internal variables. This object defines the non-associative

--- a/neml2/models/solid_mechanics/plasticity/FlowRule.py
+++ b/neml2/models/solid_mechanics/plasticity/FlowRule.py
@@ -32,7 +32,7 @@ produce internal-variable rates (associative plastic flow, associative
 isotropic/kinematic plastic hardening, etc.).
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds only the canonical ``flow_rate`` input; concrete
 native subclasses declare their own ``HitSchema`` (native models are flat, no
 schema inheritance) and implement the forward mapping. ``forward`` raises

--- a/neml2/models/solid_mechanics/plasticity/FredrickArmstrongPlasticHardening.py
+++ b/neml2/models/solid_mechanics/plasticity/FredrickArmstrongPlasticHardening.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_output, input, parameter
 from ....types import SR2, Scalar
 
 
-@register_native("FredrickArmstrongPlasticHardening")
+@register_neml2_object("FredrickArmstrongPlasticHardening")
 class FredrickArmstrongPlasticHardening(Model):
     r"""Map the flow rate (i.e., the consistency parameter in the KKT conditions)
     to the rate of internal variables. This object defines the non-associative

--- a/neml2/models/solid_mechanics/plasticity/GTNYieldFunction.py
+++ b/neml2/models/solid_mechanics/plasticity/GTNYieldFunction.py
@@ -32,13 +32,13 @@ from ....chain_rule import (
     SecondOrderChainRuleAction,
     SecondOrderChainRuleDict,
 )
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar, cosh, sinh
 
 
-@register_native("GTNYieldFunction")
+@register_neml2_object("GTNYieldFunction")
 class GTNYieldFunction(Model):
     r"""Gurson-Tvergaard-Needleman yield function for poroplasticity. The yield
     function is defined as

--- a/neml2/models/solid_mechanics/plasticity/GursonCavitation.py
+++ b/neml2/models/solid_mechanics/plasticity/GursonCavitation.py
@@ -27,14 +27,14 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import SR2, Scalar
 from ....types.functions import tr
 
 
-@register_native("GursonCavitation")
+@register_neml2_object("GursonCavitation")
 class GursonCavitation(Model):
     r"""Local mass balance used in conjunction with the GTNYieldFunction,
     $\dot{\phi} = (1-\phi) \dot{\varepsilon}_p$.

--- a/neml2/models/solid_mechanics/plasticity/IsotropicHardening.py
+++ b/neml2/models/solid_mechanics/plasticity/IsotropicHardening.py
@@ -32,7 +32,7 @@ out. Concrete laws (Linear, Voce, SlopeSaturationVoce, ...) supply the
 constitutive form.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical input/output names; native models
 are flat (no schema inheritance), so concrete leaves like
 ``VoceIsotropicHardening`` declare their own ``HitSchema`` instead of

--- a/neml2/models/solid_mechanics/plasticity/IsotropicHardeningStaticRecovery.py
+++ b/neml2/models/solid_mechanics/plasticity/IsotropicHardeningStaticRecovery.py
@@ -33,7 +33,7 @@ suffix). Concrete children -- e.g. ``PowerLawIsotropicHardeningStaticRecovery``
 -- supply the actual recovery law in ``set_value``.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical input/output names that concrete
 native isotropic static recovery leaves reuse; ``forward`` raises
 ``NotImplementedError`` so any accidental direct use surfaces immediately.

--- a/neml2/models/solid_mechanics/plasticity/IsotropicMandelStress.py
+++ b/neml2/models/solid_mechanics/plasticity/IsotropicMandelStress.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import SR2
 
 
-@register_native("IsotropicMandelStress")
+@register_neml2_object("IsotropicMandelStress")
 class IsotropicMandelStress(Model):
     """``mandel_stress = cauchy_stress`` (isotropic, small-strain).
 

--- a/neml2/models/solid_mechanics/plasticity/KinematicHardening.py
+++ b/neml2/models/solid_mechanics/plasticity/KinematicHardening.py
@@ -32,7 +32,7 @@ Concrete laws (Linear, FredrickArmstrong, Chaboche, ...) supply the
 constitutive form.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical input/output names; native models
 are flat (no schema inheritance), so concrete leaves like
 ``LinearKinematicHardening`` declare their own ``HitSchema`` instead of

--- a/neml2/models/solid_mechanics/plasticity/KinematicHardeningStaticRecovery.py
+++ b/neml2/models/solid_mechanics/plasticity/KinematicHardeningStaticRecovery.py
@@ -33,7 +33,7 @@ suffix). Concrete children -- e.g. ``PowerLawKinematicHardeningStaticRecovery``
 -- supply the actual recovery law in ``set_value``.
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical input/output names that concrete
 native kinematic static recovery leaves reuse; ``forward`` raises
 ``NotImplementedError`` so any accidental direct use surfaces immediately.

--- a/neml2/models/solid_mechanics/plasticity/KocksMeckingActivationEnergy.py
+++ b/neml2/models/solid_mechanics/plasticity/KocksMeckingActivationEnergy.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, option, output, parameter
 from ....types import Scalar, log
 
 
-@register_native("KocksMeckingActivationEnergy")
+@register_neml2_object("KocksMeckingActivationEnergy")
 class KocksMeckingActivationEnergy(Model):
     r"""Calculates the Kocks-Mecking normalized activation as
     $g = \frac{kT}{\mu b^3} \log \frac{\dot{\varepsilon}_0}{\dot{\varepsilon}}$

--- a/neml2/models/solid_mechanics/plasticity/KocksMeckingFlowSwitch.py
+++ b/neml2/models/solid_mechanics/plasticity/KocksMeckingFlowSwitch.py
@@ -27,14 +27,14 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, option, output, parameter
 from ....types import Scalar, cosh, tanh
 from ....types import pow as wpow
 
 
-@register_native("KocksMeckingFlowSwitch")
+@register_neml2_object("KocksMeckingFlowSwitch")
 class KocksMeckingFlowSwitch(Model):
     """Switches between rate independent and rate dependent flow rules based on the value of the
     Kocks-Mecking normalized activation energy.  For activation energies less than the threshold

--- a/neml2/models/solid_mechanics/plasticity/KocksMeckingFlowViscosity.py
+++ b/neml2/models/solid_mechanics/plasticity/KocksMeckingFlowViscosity.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import math
 
 from ....chain_rule import ChainRuleAction, ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import BLOCK_NAME, HitSchema, input, option, output, parameter
 from ....types import Scalar, exp
 
 
-@register_native("KocksMeckingFlowViscosity")
+@register_neml2_object("KocksMeckingFlowViscosity")
 class KocksMeckingFlowViscosity(Model):
     r"""Calculates the temperature-dependent flow viscosity for a Perzyna-type
     model using the Kocks-Mecking model.  The value is

--- a/neml2/models/solid_mechanics/plasticity/KocksMeckingIntercept.py
+++ b/neml2/models/solid_mechanics/plasticity/KocksMeckingIntercept.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict, SecondOrderChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, output, parameter
 from ....types import Scalar
 
 
-@register_native("KocksMeckingIntercept")
+@register_neml2_object("KocksMeckingIntercept")
 class KocksMeckingIntercept(Model):
     r"""The critical value of the normalized activation energy given by
     $g_0 \frac{C-B}{A}$

--- a/neml2/models/solid_mechanics/plasticity/KocksMeckingRateSensitivity.py
+++ b/neml2/models/solid_mechanics/plasticity/KocksMeckingRateSensitivity.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, option, output, parameter
 from ....types import Scalar
 
 
-@register_native("KocksMeckingRateSensitivity")
+@register_neml2_object("KocksMeckingRateSensitivity")
 class KocksMeckingRateSensitivity(Model):
     r"""Calculates the temperature-dependent rate sensitivity for a Perzyna-type model using the
     Kocks-Mecking model.  The value is $n = \frac{\mu b^3}{k T A}$ with $\mu$ the

--- a/neml2/models/solid_mechanics/plasticity/KocksMeckingYieldStress.py
+++ b/neml2/models/solid_mechanics/plasticity/KocksMeckingYieldStress.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleAction, ChainRuleDict, SecondOrderChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, output, parameter
 from ....types import Scalar, exp
 
 
-@register_native("KocksMeckingYieldStress")
+@register_neml2_object("KocksMeckingYieldStress")
 class KocksMeckingYieldStress(Model):
     r"""The yield stress given by the Kocks-Mecking model. $\sigma_y = \exp{C} \mu$ with $\mu$ the
     shear modulus and $C$ the

--- a/neml2/models/solid_mechanics/plasticity/LinearIsotropicElasticJ2TrialStressUpdate.py
+++ b/neml2/models/solid_mechanics/plasticity/LinearIsotropicElasticJ2TrialStressUpdate.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_input, input, option, output
 
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from ....factory import _NativeInputFile
 
 
-@register_native("LinearIsotropicElasticJ2TrialStressUpdate")
+@register_neml2_object("LinearIsotropicElasticJ2TrialStressUpdate")
 class LinearIsotropicElasticJ2TrialStressUpdate(Model):
     r"""Update the trial stress under the assumptions of J2 plasticity and
     isotropic linear elasticity.

--- a/neml2/models/solid_mechanics/plasticity/LinearIsotropicHardening.py
+++ b/neml2/models/solid_mechanics/plasticity/LinearIsotropicHardening.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar
 
 
-@register_native("LinearIsotropicHardening")
+@register_neml2_object("LinearIsotropicHardening")
 class LinearIsotropicHardening(Model):
     r"""Map equivalent plastic strain to isotropic hardening following a linear
     relationship, i.e., $h = K \bar{\varepsilon}_p$ where $K$ is

--- a/neml2/models/solid_mechanics/plasticity/LinearKinematicHardening.py
+++ b/neml2/models/solid_mechanics/plasticity/LinearKinematicHardening.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import SR2, Scalar
 
 
-@register_native("LinearKinematicHardening")
+@register_neml2_object("LinearKinematicHardening")
 class LinearKinematicHardening(Model):
     r"""Map kinematic plastic strain to back stress following a linear
     relationship, i.e., $\boldsymbol{X} = H \boldsymbol{K}_p$ where

--- a/neml2/models/solid_mechanics/plasticity/MandelStress.py
+++ b/neml2/models/solid_mechanics/plasticity/MandelStress.py
@@ -31,7 +31,7 @@ Cauchy stress to Mandel stress (e.g. ``IsotropicMandelStress``, future
 anisotropic variants).
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical input/output names; native models
 are flat (no schema inheritance), so concrete leaves like
 ``IsotropicMandelStress`` declare their own ``HitSchema`` instead of

--- a/neml2/models/solid_mechanics/plasticity/Normality.py
+++ b/neml2/models/solid_mechanics/plasticity/Normality.py
@@ -36,7 +36,7 @@ import torch
 
 from ....chain_rule import ChainRuleDict, SecondOrderChainRuleDict
 from ....factory import register_native
-from ....model import Model
+from ....model import Model, register_submodule
 from ....schema import HitSchema, dependency, option
 from ....types import TensorWrapper
 
@@ -161,16 +161,10 @@ class Normality(Model):
         # Register the inner model under its HIT block name (stashed on the
         # object by the factory) instead of a fixed ``_inner`` slot, so
         # ``self.named_parameters()`` returns readable names like
-        # ``yld.sy`` rather than ``_inner.sy``. Mirrors the same trick in
-        # ``ComposedModel.__init__``. Falls back to ``_inner`` when no HIT
-        # name is available (direct Python construction) or when the HIT name
-        # would collide with an existing attribute.
-        hit_name = getattr(model, "_hit_name", None)
-        attr = hit_name if hit_name and hit_name.isidentifier() else None
-        if attr is None or hasattr(self, attr):
-            attr = "_inner"
-        self._inner_attr = attr
-        self.add_module(attr, model)
+        # ``yld.sy`` rather than ``_inner.sy``. Falls back to ``_inner`` when
+        # no HIT name is available (direct Python construction) or when the
+        # HIT name would collide with an existing attribute.
+        self._inner_attr = register_submodule(self, model, fallback="_inner")
         self._function = function
         self._from = list(from_)
         self._to = list(to)

--- a/neml2/models/solid_mechanics/plasticity/Normality.py
+++ b/neml2/models/solid_mechanics/plasticity/Normality.py
@@ -35,7 +35,7 @@ from math import prod
 import torch
 
 from ....chain_rule import ChainRuleDict, SecondOrderChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model, register_submodule
 from ....schema import HitSchema, dependency, option
 from ....types import TensorWrapper
@@ -114,7 +114,7 @@ def _check_inner_supports_second_order(inner: Model) -> None:
         )
 
 
-@register_native("Normality")
+@register_neml2_object("Normality")
 class Normality(Model):
     r"""Store the first derivatives of a scalar-valued function in given variables,
     i.e. $u_i = \dfrac{f(\boldsymbol{v})}{v_i}$.

--- a/neml2/models/solid_mechanics/plasticity/OlevskySinteringStress.py
+++ b/neml2/models/solid_mechanics/plasticity/OlevskySinteringStress.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict, SecondOrderChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar
 
 
-@register_native("OlevskySinteringStress")
+@register_neml2_object("OlevskySinteringStress")
 class OlevskySinteringStress(Model):
     r"""Define the Olevsky-Skorohod sintering stress to be used in conjunction with poroplasticity
     yield functions such as the GTNYieldFunction. The sintering stress is defined as

--- a/neml2/models/solid_mechanics/plasticity/PerzynaPlasticFlowRate.py
+++ b/neml2/models/solid_mechanics/plasticity/PerzynaPlasticFlowRate.py
@@ -27,14 +27,14 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar, abs, heaviside, log
 from ....types import pow as wpow
 
 
-@register_native("PerzynaPlasticFlowRate")
+@register_neml2_object("PerzynaPlasticFlowRate")
 class PerzynaPlasticFlowRate(Model):
     r"""Perzyna's viscous approximation of the consistent yield envelope (with a
     power law), i.e. $\dot{\gamma} = \left( \frac{\left< f \right>}{\eta} \right)^n$, where $f$ is

--- a/neml2/models/solid_mechanics/plasticity/PlasticFlowRate.py
+++ b/neml2/models/solid_mechanics/plasticity/PlasticFlowRate.py
@@ -31,7 +31,7 @@ function -> flow-rate map (e.g. ``PerzynaPlasticFlowRate``,
 ``KocksMeckingFlowSwitch``, ...).
 
 Because the C++ class is not registered (no ``register_NEML2_object``), this
-native port is also unregistered: ``@register_native`` is intentionally
+native port is also unregistered: ``@register_neml2_object`` is intentionally
 omitted. The class scaffolds the canonical input/output names; native models
 are flat (no schema inheritance), so concrete leaves like
 ``PerzynaPlasticFlowRate`` declare their own ``HitSchema`` instead of

--- a/neml2/models/solid_mechanics/plasticity/PowerLawIsotropicHardeningStaticRecovery.py
+++ b/neml2/models/solid_mechanics/plasticity/PowerLawIsotropicHardeningStaticRecovery.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import torch
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_output, input, parameter
 from ....types import Scalar, abs, log, pow
 
 
-@register_native("PowerLawIsotropicHardeningStaticRecovery")
+@register_neml2_object("PowerLawIsotropicHardeningStaticRecovery")
 class PowerLawIsotropicHardeningStaticRecovery(Model):
     r"""This particular model implements a power law recovery of the type
     $\dot{k} = -\left(\frac{\lVert k \rVert}{\tau}\right)^{n-1} \frac{k}{\tau}$

--- a/neml2/models/solid_mechanics/plasticity/PowerLawKinematicHardeningStaticRecovery.py
+++ b/neml2/models/solid_mechanics/plasticity/PowerLawKinematicHardeningStaticRecovery.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import torch
 
 from ....chain_rule import ChainRuleAction, ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_output, input, parameter
 from ....types import SR2, Scalar, inner, log, norm, pow
 
 
-@register_native("PowerLawKinematicHardeningStaticRecovery")
+@register_neml2_object("PowerLawKinematicHardeningStaticRecovery")
 class PowerLawKinematicHardeningStaticRecovery(Model):
     r"""This object defines kinematic hardening static recovery on a backstress term.
     This particular model uses a power law for recovery

--- a/neml2/models/solid_mechanics/plasticity/SlopeSaturationVoceIsotropicHardening.py
+++ b/neml2/models/solid_mechanics/plasticity/SlopeSaturationVoceIsotropicHardening.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_output, input, parameter
 from ....types import Scalar, sign
 
 
-@register_native("SlopeSaturationVoceIsotropicHardening")
+@register_neml2_object("SlopeSaturationVoceIsotropicHardening")
 class SlopeSaturationVoceIsotropicHardening(Model):
     r"""SlopeSaturationVoce isotropic hardening model,
     $\dot{h} = \theta_0 \left(1 - \frac{h}{R} \right) \varepsilon_p$, where $R$ is the

--- a/neml2/models/solid_mechanics/plasticity/VoceIsotropicHardening.py
+++ b/neml2/models/solid_mechanics/plasticity/VoceIsotropicHardening.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar, exp
 
 
-@register_native("VoceIsotropicHardening")
+@register_neml2_object("VoceIsotropicHardening")
 class VoceIsotropicHardening(Model):
     r"""Voce isotropic hardening model, $h = R \left[ 1 - \exp(-d \bar{\varepsilon}_p) \right]$,
     where $R$ is the isotropic

--- a/neml2/models/solid_mechanics/plasticity/YieldFunction.py
+++ b/neml2/models/solid_mechanics/plasticity/YieldFunction.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import math
 
 from ....chain_rule import ChainRuleDict, SecondOrderChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar
 
 
-@register_native("YieldFunction")
+@register_neml2_object("YieldFunction")
 class YieldFunction(Model):
     r"""Classical macroscale plasticity yield function,
     $f = \bar{\sigma} - \sigma_y - h$, where $\bar{\sigma}$ is the

--- a/neml2/models/solid_mechanics/plasticity/__init__.py
+++ b/neml2/models/solid_mechanics/plasticity/__init__.py
@@ -26,7 +26,7 @@
 
 One file per C++ header under
 ``include/neml2/models/solid_mechanics/plasticity/``; this package re-imports
-each so the ``@register_native`` side effects fire on package import.
+each so the ``@register_neml2_object`` side effects fire on package import.
 """
 
 from .AssociativeIsotropicPlasticHardening import AssociativeIsotropicPlasticHardening

--- a/neml2/models/solid_mechanics/traction_separation_law/BenzeggaghKenaneFullSeparation.py
+++ b/neml2/models/solid_mechanics/traction_separation_law/BenzeggaghKenaneFullSeparation.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import torch
 
 from ....chain_rule import ChainRuleAction, ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar, gt, pow, where
 
 
-@register_native("BenzeggaghKenaneFullSeparation")
+@register_neml2_object("BenzeggaghKenaneFullSeparation")
 class BenzeggaghKenaneFullSeparation(Model):
     r"""Mixed-mode full (failure) separation under the Benzeggagh-Kenane criterion.
     Opening: $\delta_f = (2/(K \delta_c))(G_{Ic} + (G_{IIc}-G_{Ic}) (\beta^2/(1+\beta^2))^\eta)$,

--- a/neml2/models/solid_mechanics/traction_separation_law/BilinearTraction.py
+++ b/neml2/models/solid_mechanics/traction_separation_law/BilinearTraction.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleAction, ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_input, input, output, parameter
 from ....types import Scalar, Vec, gt, lt, vec_from_scalars, where
 
 
-@register_native("BilinearTraction")
+@register_neml2_object("BilinearTraction")
 class BilinearTraction(Model):
     r"""Bilinear cohesive-zone traction with internal damage state. Computes the
     bilinear damage variable from $(\delta_m, \delta_c, \delta_f)$

--- a/neml2/models/solid_mechanics/traction_separation_law/CamanhoDavilaCriticalSeparation.py
+++ b/neml2/models/solid_mechanics/traction_separation_law/CamanhoDavilaCriticalSeparation.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import torch
 
 from ....chain_rule import ChainRuleAction, ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar, gt, sqrt, where
 
 
-@register_native("CamanhoDavilaCriticalSeparation")
+@register_neml2_object("CamanhoDavilaCriticalSeparation")
 class CamanhoDavilaCriticalSeparation(Model):
     r"""Camanho-Davila mixed-mode critical (damage-onset) separation. Opening branch:
     $\delta_c = \delta_{n0} \delta_{s0} \sqrt{1+\beta^2} / \sqrt{\delta_{s0}^2 + \beta^2 \delta_{n0}^2}$

--- a/neml2/models/solid_mechanics/traction_separation_law/ModeMixity.py
+++ b/neml2/models/solid_mechanics/traction_separation_law/ModeMixity.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleAction, ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output
 from ....types import Scalar, gt, where
 
 
-@register_native("ModeMixity")
+@register_neml2_object("ModeMixity")
 class ModeMixity(Model):
     r"""Mode-mixity ratio $\beta = \delta_s / \delta_n^+$ in the opening
     branch; $\beta = 0$ in compression. Uses a safe-divisor

--- a/neml2/models/solid_mechanics/traction_separation_law/OrthotropicLinearTraction.py
+++ b/neml2/models/solid_mechanics/traction_separation_law/OrthotropicLinearTraction.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleAction, ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar, Vec, vec_from_scalars
 
 
-@register_native("OrthotropicLinearTraction")
+@register_neml2_object("OrthotropicLinearTraction")
 class OrthotropicLinearTraction(Model):
     r"""Orthotropic linear-elastic interface traction:
     $T_n = K_n \delta_n^\text{sep}$, $T_{si} = K_t \delta_{si}$.

--- a/neml2/models/solid_mechanics/traction_separation_law/PowerLawFullSeparation.py
+++ b/neml2/models/solid_mechanics/traction_separation_law/PowerLawFullSeparation.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import torch
 
 from ....chain_rule import ChainRuleAction, ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import Scalar, gt, pow, where
 
 
-@register_native("PowerLawFullSeparation")
+@register_neml2_object("PowerLawFullSeparation")
 class PowerLawFullSeparation(Model):
     r"""Mixed-mode full (failure) separation under the Alfano-Crisfield power-law criterion.
     Opening:

--- a/neml2/models/solid_mechanics/traction_separation_law/SalehaniIraniTraction.py
+++ b/neml2/models/solid_mechanics/traction_separation_law/SalehaniIraniTraction.py
@@ -29,13 +29,13 @@ from __future__ import annotations
 import math
 
 from ....chain_rule import ChainRuleAction, ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_input, input, output, parameter
 from ....types import Scalar, Vec, exp, gt, vec_from_scalars, where
 
 
-@register_native("SalehaniIraniTraction")
+@register_neml2_object("SalehaniIraniTraction")
 class SalehaniIraniTraction(Model):
     r"""3D coupled exponential cohesive law of Salehani & Irani with internal damage state.
     Computes $d_\text{trial} = 1 - \exp(-x)$ where $x = b_n + b_{s1}^2 + b_{s2}^2$, caps it for

--- a/neml2/models/solid_mechanics/traction_separation_law/__init__.py
+++ b/neml2/models/solid_mechanics/traction_separation_law/__init__.py
@@ -26,7 +26,7 @@
 
 One file per C++ header under
 ``include/neml2/models/solid_mechanics/traction_separation_law/``; this
-package re-imports each so the ``@register_native`` side effects fire on
+package re-imports each so the ``@register_neml2_object`` side effects fire on
 package import.
 """
 

--- a/neml2/models/solid_mechanics/viscoelasticity/BurgersElement.py
+++ b/neml2/models/solid_mechanics/viscoelasticity/BurgersElement.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_output, input, output, parameter
 from ....types import SR2, Scalar
 
 
-@register_native("BurgersElement")
+@register_neml2_object("BurgersElement")
 class BurgersElement(Model):
     r"""Burgers viscoelastic model: a Maxwell element in series with a Kelvin-Voigt
     element. The shared stress is

--- a/neml2/models/solid_mechanics/viscoelasticity/KelvinVoigtElement.py
+++ b/neml2/models/solid_mechanics/viscoelasticity/KelvinVoigtElement.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_input, input, output, parameter
 from ....types import SR2, Scalar
 
 
-@register_native("KelvinVoigtElement")
+@register_neml2_object("KelvinVoigtElement")
 class KelvinVoigtElement(Model):
     r"""Stress response of a Kelvin-Voigt viscoelastic element (spring and
     dashpot in parallel),

--- a/neml2/models/solid_mechanics/viscoelasticity/LinearDashpot.py
+++ b/neml2/models/solid_mechanics/viscoelasticity/LinearDashpot.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, input, output, parameter
 from ....types import SR2, Scalar
 
 
-@register_native("LinearDashpot")
+@register_neml2_object("LinearDashpot")
 class LinearDashpot(Model):
     r"""Newtonian dashpot constitutive law,
     $\dot{\boldsymbol{\varepsilon}} = \boldsymbol{\sigma} / \eta$, where $\eta$ is the viscosity.

--- a/neml2/models/solid_mechanics/viscoelasticity/WiechertElement.py
+++ b/neml2/models/solid_mechanics/viscoelasticity/WiechertElement.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_output, input, output, parameter
 from ....types import SR2, Scalar
 
 
-@register_native("WiechertElement")
+@register_neml2_object("WiechertElement")
 class WiechertElement(Model):
     r"""Wiechert (generalized Maxwell) viscoelastic model with two Maxwell branches in
     parallel with an equilibrium spring. Total stress is

--- a/neml2/models/solid_mechanics/viscoelasticity/ZenerElement.py
+++ b/neml2/models/solid_mechanics/viscoelasticity/ZenerElement.py
@@ -27,13 +27,13 @@
 from __future__ import annotations
 
 from ....chain_rule import ChainRuleDict
-from ....factory import register_native
+from ....factory import register_neml2_object
 from ....model import Model
 from ....schema import HitSchema, derived_output, input, output, parameter
 from ....types import SR2, Scalar
 
 
-@register_native("ZenerElement")
+@register_neml2_object("ZenerElement")
 class ZenerElement(Model):
     r"""Zener (Standard Linear Solid) viscoelastic model: an equilibrium spring in
     parallel with a Maxwell branch. The total stress is

--- a/neml2/models/solid_mechanics/viscoelasticity/__init__.py
+++ b/neml2/models/solid_mechanics/viscoelasticity/__init__.py
@@ -26,7 +26,7 @@
 
 One file per C++ header under
 ``include/neml2/models/solid_mechanics/viscoelasticity/``; this package
-re-imports each so the ``@register_native`` side effects fire on package
+re-imports each so the ``@register_neml2_object`` side effects fire on package
 import.
 """
 

--- a/neml2/solvers.py
+++ b/neml2/solvers.py
@@ -40,7 +40,7 @@ from .equation_systems import (
     norm,
     norm_sq,
 )
-from .factory import register_native
+from .factory import register_neml2_object
 from .schema import HitSchema, dependency, option
 
 if TYPE_CHECKING:
@@ -65,7 +65,7 @@ class NonlinearResult:
     iterations: int
 
 
-@register_native("DenseLU")
+@register_neml2_object("DenseLU")
 class DenseLU:
     """Dense LU linear solver. This solver assembles the (possibly) sparse matrix into a
     dense one and uses a standard LU decomposition to solve the system of equations.
@@ -102,7 +102,7 @@ class DenseLU:
         return AssembledMatrix(A.col_layout, b.col_layout, [[x]])
 
 
-@register_native("SchurComplement")
+@register_neml2_object("SchurComplement")
 class SchurComplement:
     """Schur complement linear solver. Solves a block-partitioned system A x = b
     by forming and solving the Schur complement of the primary block.
@@ -252,7 +252,7 @@ class SchurComplement:
             )
 
 
-@register_native("Newton")
+@register_neml2_object("Newton")
 class Newton:
     """The standard Newton-Raphson solver which always takes the 'full' Newton step."""
 
@@ -339,7 +339,7 @@ class Newton:
         system.set_u(system.u() + du)
 
 
-@register_native("NewtonWithLineSearch")
+@register_neml2_object("NewtonWithLineSearch")
 class NewtonWithLineSearch(Newton):
     """The Newton-Raphson solver with line search."""
 

--- a/neml2/solvers.py
+++ b/neml2/solvers.py
@@ -71,6 +71,8 @@ class DenseLU:
     dense one and uses a standard LU decomposition to solve the system of equations.
     """
 
+    SECTION = "Solvers"
+
     # No tunable options; the empty schema documents that in the syntax catalog.
     hit = HitSchema()
 
@@ -105,6 +107,8 @@ class SchurComplement:
     """Schur complement linear solver. Solves a block-partitioned system A x = b
     by forming and solving the Schur complement of the primary block.
     """
+
+    SECTION = "Solvers"
 
     hit = HitSchema(
         option(
@@ -251,6 +255,9 @@ class SchurComplement:
 @register_native("Newton")
 class Newton:
     """The standard Newton-Raphson solver which always takes the 'full' Newton step."""
+
+    #: Inherited by ``NewtonWithLineSearch``.
+    SECTION = "Solvers"
 
     hit = HitSchema(
         dependency(

--- a/neml2/user_tensors/CSVTensor.py
+++ b/neml2/user_tensors/CSVTensor.py
@@ -54,6 +54,7 @@ import nmhit
 import torch
 
 from ..factory import register_native
+from ..schema import HitSchema, option
 from ..types import SR2, WR2, Scalar, Vec
 
 if TYPE_CHECKING:
@@ -123,6 +124,36 @@ class _CSVTensorBase:
 
     TYPE_NAME: ClassVar[str]
     WRAPPER: ClassVar[type[TensorWrapper]]
+    SECTION: ClassVar[str] = "Tensors"
+
+    # Shared documentation schema — every CSV<Type> subclass inherits the same
+    # HIT surface via :meth:`from_hit`. ``variable`` and ``column_names`` are
+    # mutually exclusive (validated at parse time) but the schema can't express
+    # that constraint; both are declared optional and the constructor enforces
+    # the rule.
+    hit = HitSchema(
+        option(
+            "csv_file",
+            str,
+            "Path to the CSV file. Resolved relative to the input file's directory when "
+            "not absolute.",
+        ),
+        option(
+            "variable",
+            str,
+            "Column-name prefix expanded via the per-type suffix convention (e.g. "
+            "``stress`` -> ``stress_xx``, ``stress_yy``, ... for SR2). Mutually exclusive "
+            "with ``column_names``.",
+            default="",
+        ),
+        option(
+            "column_names",
+            list,
+            "Explicit whitespace-separated list of CSV column names; bypasses the "
+            "``variable`` suffix expansion. Mutually exclusive with ``variable``.",
+            default=[],
+        ),
+    )
 
     @classmethod
     def _default_column_names(cls, variable: str) -> list[str]:

--- a/neml2/user_tensors/CSVTensor.py
+++ b/neml2/user_tensors/CSVTensor.py
@@ -53,7 +53,7 @@ from typing import TYPE_CHECKING, ClassVar
 import nmhit
 import torch
 
-from ..factory import register_native
+from ..factory import register_neml2_object
 from ..schema import HitSchema, option
 from ..types import SR2, WR2, Scalar, Vec
 
@@ -188,7 +188,7 @@ class _CSVTensorBase:
         raise NotImplementedError
 
 
-@register_native("CSVScalar")
+@register_neml2_object("CSVScalar")
 class CSVScalar(_CSVTensorBase):
     """Load a single column from CSV as a ``Scalar`` with shape ``(N,)``."""
 
@@ -206,7 +206,7 @@ class CSVScalar(_CSVTensorBase):
         return Scalar(columns[0])
 
 
-@register_native("CSVSR2")
+@register_neml2_object("CSVSR2")
 class CSVSR2(_CSVTensorBase):
     """Load 6 columns from CSV as an ``SR2`` with shape ``(N, 6)``.
 
@@ -231,7 +231,7 @@ class CSVSR2(_CSVTensorBase):
         return SR2(torch.stack(columns, dim=-1))
 
 
-@register_native("CSVVec")
+@register_neml2_object("CSVVec")
 class CSVVec(_CSVTensorBase):
     """Load 3 columns from CSV as a ``Vec`` with shape ``(N, 3)``."""
 
@@ -250,7 +250,7 @@ class CSVVec(_CSVTensorBase):
         return Vec(torch.stack(columns, dim=-1))
 
 
-@register_native("CSVWR2")
+@register_neml2_object("CSVWR2")
 class CSVWR2(_CSVTensorBase):
     """Load 3 columns from CSV as a ``WR2`` (skew) with shape ``(N, 3)``.
 

--- a/neml2/user_tensors/PythonTensor.py
+++ b/neml2/user_tensors/PythonTensor.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from ..factory import _build_tensor_eval_namespace, _eval_tensor_code, register_native
+from ..factory import _build_tensor_eval_namespace, _eval_tensor_code, register_neml2_object
 from ..schema import HitSchema, option
 
 if TYPE_CHECKING:
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from ..factory import _NativeInputFile
 
 
-@register_native("Python")
+@register_neml2_object("Python")
 class PythonTensor:
     """Tensor built from an inline Python expression.
 

--- a/neml2/user_tensors/PythonTensor.py
+++ b/neml2/user_tensors/PythonTensor.py
@@ -1,0 +1,82 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""``Python`` user-tensor — inline Python expression evaluated at parse time.
+
+Previously a special case inside ``factory.get_tensor``; promoted to a
+properly registered ``[Tensors]`` class so the syntax catalog documents it
+alongside the ``CSV<Type>`` family.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from ..factory import _build_tensor_eval_namespace, _eval_tensor_code, register_native
+from ..schema import HitSchema, option
+
+if TYPE_CHECKING:
+    import nmhit
+
+    from ..factory import _NativeInputFile
+
+
+@register_native("Python")
+class PythonTensor:
+    """Tensor built from an inline Python expression.
+
+    The ``expr`` option is evaluated in a namespace pre-populated with
+    ``torch``, every public name from ``neml2.types`` (``Scalar``, ``SR2``,
+    ``SSR4``, free functions), ``math``, and ``np`` (numpy, if importable).
+    Cross-references to other ``[Tensors]`` entries resolve by bare
+    identifier: writing ``base`` is equivalent to ``tensor('base')``, which
+    avoids HIT's restriction on nested quotes.
+
+    The expression's value (``torch.Tensor`` or a ``TensorWrapper`` subclass)
+    is returned verbatim; the call site (typically
+    :meth:`neml2.model.Model.declare_typed_parameter` mode 2) is responsible
+    for wrapping a raw tensor into a typed wrapper if needed.
+    """
+
+    SECTION: ClassVar[str] = "Tensors"
+
+    hit = HitSchema(
+        option(
+            "expr",
+            str,
+            "Python expression producing the tensor value. A multi-line block "
+            "must assign its result to a variable named ``result``.",
+        ),
+    )
+
+    @classmethod
+    def from_hit(cls, node: nmhit.Node, factory: _NativeInputFile) -> Any:
+        return _eval_tensor_code(
+            node.param_str("expr"),
+            node.path().rsplit("/", 1)[-1],
+            _build_tensor_eval_namespace(factory),
+        )
+
+
+__all__ = ["PythonTensor"]

--- a/neml2/user_tensors/__init__.py
+++ b/neml2/user_tensors/__init__.py
@@ -22,14 +22,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-"""Native [Tensors] block types other than ``Python`` inline expressions.
+"""Native ``[Tensors]`` block types.
 
-Currently exposes the ``CSV<Type>`` family used by the verification test
-suite to load reference snapshots from on-disk CSV files. New tensor types
-that need a registered HIT type (rather than an inline Python expression)
-belong here.
+Exposes :class:`~neml2.user_tensors.PythonTensor.PythonTensor` (HIT
+``type = Python``) for inline Python expressions and the ``CSV<Type>``
+family used by the verification test suite to load reference snapshots from
+on-disk CSV files.
 """
 
 from .CSVTensor import CSVSR2, CSVWR2, CSVScalar, CSVVec  # noqa: F401 (register)
+from .PythonTensor import PythonTensor  # noqa: F401 (register)
 
-__all__ = ["CSVScalar", "CSVSR2", "CSVVec", "CSVWR2"]
+__all__ = ["CSVScalar", "CSVSR2", "CSVVec", "CSVWR2", "PythonTensor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ NEML2_WHEEL = "ON"
 [project]
 name = "neml2"
 # dependencies: neml2.version
-version = "3.0.1"
+version = "3.0.2"
 authors = [
   { name = "Mark Messner", email = "messner@anl.gov" },
   { name = "Gary Hu", email = "thu@anl.gov" },

--- a/tests/_fixtures/TabulatedPolynomialModel.py
+++ b/tests/_fixtures/TabulatedPolynomialModel.py
@@ -37,7 +37,7 @@ Mirrors ``tests/src/TabulatedPolynomialModel.cxx``. Forward semantics:
 
 with ``smooth_index(x, lb, ub) = 0.5 (sigmoid(k(x-lb)) - sigmoid(k(x-ub)))``.
 
-Test-fixture only. Self-registers via ``@register_native`` so the
+Test-fixture only. Self-registers via ``@register_neml2_object`` so the
 ``polynomial`` regression scenario can instantiate it from HIT.
 """
 
@@ -50,7 +50,7 @@ import torch
 
 from neml2 import allow_autograd
 from neml2.chain_rule import ChainRuleDict
-from neml2.factory import _NativeInputFile, register_native
+from neml2.factory import _NativeInputFile, register_neml2_object
 from neml2.model import Model
 from neml2.schema import HitSchema, input, option, output
 from neml2.types import Scalar
@@ -65,7 +65,7 @@ def _resolve_tensor(factory: _NativeInputFile, spec: str) -> torch.Tensor:
     return val.data
 
 
-@register_native("TabulatedPolynomialModel")
+@register_neml2_object("TabulatedPolynomialModel")
 class TabulatedPolynomialModel(Model):
     """Native mirror of the C++ test helper.
 

--- a/tests/_fixtures/TorchScriptFlowRate.py
+++ b/tests/_fixtures/TorchScriptFlowRate.py
@@ -30,7 +30,7 @@ calls ``surrogate(s, T, G, C)`` with ``G = 0.1`` / ``C = 0.2`` constants
 (matching the C++ hard-coded scalar fills). The TorchScript surrogate
 returns a single scalar ``ep_dot``.
 
-Test-fixture only. Self-registers via ``@register_native``.
+Test-fixture only. Self-registers via ``@register_neml2_object``.
 """
 
 from __future__ import annotations
@@ -43,13 +43,13 @@ import torch
 
 from neml2 import allow_autograd
 from neml2.chain_rule import ChainRuleDict
-from neml2.factory import _NativeInputFile, register_native
+from neml2.factory import _NativeInputFile, register_neml2_object
 from neml2.model import Model
 from neml2.schema import HitSchema, input, option, output
 from neml2.types import Scalar
 
 
-@register_native("TorchScriptFlowRate")
+@register_neml2_object("TorchScriptFlowRate")
 class TorchScriptFlowRate(Model):
     """Native mirror of the C++ test helper.
 

--- a/tests/_fixtures/__init__.py
+++ b/tests/_fixtures/__init__.py
@@ -31,7 +31,7 @@ These are the native counterparts of the C++ test helpers under
 inputs — they have no place in the production native package.
 
 Importing this package side-effect-registers every fixture with the native
-factory registry via ``@register_native``. The native ``regression/conftest.py``
+factory registry via ``@register_neml2_object``. The native ``regression/conftest.py``
 imports it so the registrations fire before pytest collects the input files.
 """
 

--- a/tests/aoti/test_aoti.py
+++ b/tests/aoti/test_aoti.py
@@ -145,7 +145,7 @@ def test_aoti_stub_loads_through_native_factory(scenario: Path, tmp_path: Path):
     shim drives like a native Model (typed-wrapper positional args, tuple
     output) -- the path TransientDriver / TransientRegression will use.
 
-    This covers the HIT shim (``register_native("AOTIModel")``) end-to-end:
+    This covers the HIT shim (``register_neml2_object("AOTIModel")``) end-to-end:
     factory dispatch, ``from_hit`` meta-path resolution, typed-wrapper
     marshalling at the call boundary, output matches eager.
     """

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -25,7 +25,7 @@
 """Pytest conftest for the native regression suite.
 
 Side-effect-imports the test-only ``_fixtures`` package so its
-``@register_native``-decorated models (``TabulatedPolynomialModel``,
+``@register_neml2_object``-decorated models (``TabulatedPolynomialModel``,
 ``TorchScriptFlowRate``) are registered with the native factory before any
 scenario ``.i`` file is collected. The package lives alongside the regression
 tests under ``python/tests/native/_fixtures/`` rather than in
@@ -44,4 +44,4 @@ _NATIVE_TESTS_DIR = Path(__file__).resolve().parent.parent
 if str(_NATIVE_TESTS_DIR) not in sys.path:
     sys.path.insert(0, str(_NATIVE_TESTS_DIR))
 
-import _fixtures  # noqa: E402, F401  (side-effect: @register_native fires)
+import _fixtures  # noqa: E402, F401  (side-effect: @register_neml2_object fires)

--- a/tests/test_cli_extensions.py
+++ b/tests/test_cli_extensions.py
@@ -42,11 +42,11 @@ _EXT_BODY = textwrap.dedent(
     '''
     """Minimal user extension for the --load CLI tests."""
 
-    from neml2.factory import register_native
+    from neml2.factory import register_neml2_object
     from neml2.schema import HitSchema, option
 
 
-    @register_native("{type_name}")
+    @register_neml2_object("{type_name}")
     class {class_name}:
         """A custom user-defined Tensors class."""
 
@@ -74,7 +74,7 @@ def _write_extension(dir_path: Path, filename: str, type_name: str, class_name: 
 def cleanup_registry():
     """Remove any test-registered type names from the global registry on teardown.
 
-    Module-level side effects (``@register_native``) are not reversible by
+    Module-level side effects (``@register_neml2_object``) are not reversible by
     Python alone — this fixture undoes them so registry-mutation tests don't
     pollute downstream tests.
     """

--- a/tests/test_cli_extensions.py
+++ b/tests/test_cli_extensions.py
@@ -1,0 +1,197 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Tests for the shared ``--load`` extension loader."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from neml2.cli import _extensions  # noqa: PLC2701
+from neml2.cli import syntax as _syntax_cli
+from neml2.factory import _registry
+
+_EXT_BODY = textwrap.dedent(
+    '''
+    """Minimal user extension for the --load CLI tests."""
+
+    from neml2.factory import register_native
+    from neml2.schema import HitSchema, option
+
+
+    @register_native("{type_name}")
+    class {class_name}:
+        """A custom user-defined Tensors class."""
+
+        SECTION = "Tensors"
+
+        hit = HitSchema(
+            option("dummy", str, "Placeholder option."),
+        )
+
+        @classmethod
+        def from_hit(cls, node, factory):
+            del node, factory
+            return cls()
+    '''
+)
+
+
+def _write_extension(dir_path: Path, filename: str, type_name: str, class_name: str) -> Path:
+    target = dir_path / filename
+    target.write_text(_EXT_BODY.format(type_name=type_name, class_name=class_name))
+    return target
+
+
+@pytest.fixture
+def cleanup_registry():
+    """Remove any test-registered type names from the global registry on teardown.
+
+    Module-level side effects (``@register_native``) are not reversible by
+    Python alone — this fixture undoes them so registry-mutation tests don't
+    pollute downstream tests.
+    """
+    snapshot = set(_registry.keys())
+    yield
+    for added in set(_registry.keys()) - snapshot:
+        _registry.pop(added, None)
+
+
+def test_load_extension_by_file_path_registers_native_type(tmp_path: Path, cleanup_registry: None):
+    """A user .py file passed to ``--load`` makes its registered class visible
+    in :data:`neml2.factory._registry` after :func:`load_user_extensions`."""
+    _write_extension(tmp_path, "ext.py", "TestExtTypeFile", "TestExtFileClass")
+
+    assert "TestExtTypeFile" not in _registry
+    _extensions.load_user_extensions([str(tmp_path / "ext.py")])
+    assert "TestExtTypeFile" in _registry
+
+
+def test_load_extension_by_package_directory(tmp_path: Path, cleanup_registry: None):
+    """Pointing ``--load`` at a directory imports its ``__init__.py``."""
+    pkg = tmp_path / "ext_pkg"
+    pkg.mkdir()
+    _write_extension(pkg, "__init__.py", "TestExtTypePkg", "TestExtPkgClass")
+
+    _extensions.load_user_extensions([str(pkg)])
+    assert "TestExtTypePkg" in _registry
+
+
+def test_load_extension_by_dotted_module_name(tmp_path: Path, cleanup_registry: None):
+    """A dotted module on ``sys.path`` is imported via :func:`importlib.import_module`."""
+    pkg = tmp_path / "ext_dotted_pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    _write_extension(pkg, "sub.py", "TestExtTypeDotted", "TestExtDottedClass")
+    sys.path.insert(0, str(tmp_path))
+    try:
+        _extensions.load_user_extensions(["ext_dotted_pkg.sub"])
+    finally:
+        sys.path.remove(str(tmp_path))
+        # Drop the imported submodules so a re-import next test goes through
+        # the spec loader fresh — repeated runs in the same pytest session
+        # otherwise see a cached module that already registered its types.
+        for name in [n for n in sys.modules if n.startswith("ext_dotted_pkg")]:
+            sys.modules.pop(name, None)
+    assert "TestExtTypeDotted" in _registry
+
+
+def test_load_extension_bad_path_raises_import_error_with_clear_message(tmp_path: Path):
+    """A non-existent path is reported through :class:`ImportError` with a
+    message that points at the user-supplied value, so the CLI's outer
+    error-printing surfaces what was tried."""
+    with pytest.raises(ImportError, match="not a filesystem path and not an importable"):
+        _extensions.load_user_extensions([str(tmp_path / "does_not_exist.py")])
+
+
+def test_load_extension_directory_without_init_raises(tmp_path: Path):
+    bare = tmp_path / "bare_dir"
+    bare.mkdir()
+    with pytest.raises(ImportError, match="no __init__.py"):
+        _extensions.load_user_extensions([str(bare)])
+
+
+def test_load_extension_ordering_is_preserved(tmp_path: Path, cleanup_registry: None):
+    """Modules are imported in argument order — verifying so users can rely on
+    one extension depending on names registered by an earlier one."""
+    _write_extension(tmp_path, "first.py", "TestExtOrderFirst", "TestExtOrderFirstClass")
+    second = tmp_path / "second.py"
+    second.write_text(
+        textwrap.dedent(
+            '''
+            """Depends on the first extension being already imported."""
+            from neml2.factory import _registry
+
+            assert "TestExtOrderFirst" in _registry, "second.py imported before first.py"
+            '''
+        )
+    )
+    _extensions.load_user_extensions([str(tmp_path / "first.py"), str(second)])
+    # Reaching here means the assertion in second.py held — i.e. ordering was preserved.
+    assert "TestExtOrderFirst" in _registry
+
+
+def test_load_extension_rolls_back_sys_modules_on_failure(tmp_path: Path):
+    """A broken extension must not leave a half-loaded entry in ``sys.modules``,
+    otherwise a retry sees a successful no-op import."""
+    broken = tmp_path / "broken.py"
+    broken.write_text("raise RuntimeError('boom')\n")
+    with pytest.raises(RuntimeError, match="boom"):
+        _extensions.load_user_extensions([str(broken)])
+    # No leftover module in sys.modules from the failed load.
+    assert not any(name.endswith("broken") for name in sys.modules if "_neml2_ext_" in name)
+
+
+def test_neml2_syntax_cli_load_surfaces_user_type(tmp_path: Path, cleanup_registry: None):
+    """End-to-end smoke: ``neml2-syntax --load ... --type Foo --json -``
+    returns the user-defined type's record."""
+    _write_extension(tmp_path, "ext.py", "TestExtEndToEnd", "TestExtEndToEndClass")
+    stdout = io.StringIO()
+    rc = _syntax_cli.main(
+        ["--load", str(tmp_path / "ext.py"), "--json", "-", "--type", "TestExtEndToEnd"],
+        stdout=stdout,
+    )
+    assert rc == 0
+    payload = json.loads(stdout.getvalue())
+    assert len(payload) == 1
+    assert payload[0]["type"] == "TestExtEndToEnd"
+    assert payload[0]["section"] == "Tensors"
+    assert [opt["name"] for opt in payload[0]["options"]] == ["dummy"]
+
+
+def test_neml2_syntax_cli_reports_bad_load(tmp_path: Path):
+    err = io.StringIO()
+    rc = _syntax_cli.main(
+        ["--load", str(tmp_path / "missing.py"), "--json", "-"],
+        stdout=io.StringIO(),
+        stderr=err,
+    )
+    assert rc == 1
+    assert "missing.py" in err.getvalue()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -31,7 +31,7 @@ from pathlib import Path
 import pytest
 import torch
 
-from neml2.factory import _NativeInputFile, load_input, load_model, register_native
+from neml2.factory import _NativeInputFile, load_input, load_model, register_neml2_object
 from neml2.model import Model
 from neml2.models.common import ComposedModel
 from neml2.models.solid_mechanics.elasticity import LinearIsotropicElasticity
@@ -46,14 +46,14 @@ _ELASTICITY_I = (
 
 
 # ---------------------------------------------------------------------------
-# register_native / from_hit protocol
+# register_neml2_object / from_hit protocol
 # ---------------------------------------------------------------------------
 
 
 def test_schema_less_model_requires_hit_schema_or_from_hit_override():
     import nmhit
 
-    @register_native("_MissingHitSchema")
+    @register_neml2_object("_MissingHitSchema")
     class _Bad(Model):
         input_spec = {}
         output_spec = {}
@@ -73,15 +73,15 @@ def test_schema_less_model_requires_hit_schema_or_from_hit_override():
         factory.get_model("m")
 
 
-def test_register_native_requires_from_hit_for_non_model_classes():
+def test_register_neml2_object_requires_from_hit_for_non_model_classes():
     with pytest.raises(TypeError, match="from_hit"):
 
-        @register_native("_MissingFromHit")
+        @register_neml2_object("_MissingFromHit")
         class _Bad:
             pass
 
 
-def test_register_native_tags_class():
+def test_register_neml2_object_tags_class():
     from neml2.models.solid_mechanics.elasticity import LinearIsotropicElasticity
 
     assert LinearIsotropicElasticity._native_type_name == "LinearIsotropicElasticity"  # type: ignore[attr-defined]

--- a/tests/test_implicit_update.py
+++ b/tests/test_implicit_update.py
@@ -93,3 +93,60 @@ def test_implicit_update_input_output_specs():
 
     assert list(update.input_spec) == ["x", "c"]
     assert list(update.output_spec) == ["x"]
+
+
+class _ParamResidual(Model):
+    """Toy residual with a parameter, for naming tests only.
+
+    Forward returns ``K * x - c`` so the converged ``x`` is ``c / K`` and
+    ``self.K`` is exposed as a registered parameter.
+    """
+
+    input_spec = {"x": Scalar, "c": Scalar}
+    output_spec = {"x_residual": Scalar}
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.K = torch.nn.Parameter(torch.tensor(2.0, dtype=torch.float64))
+
+    def forward(self, x: Scalar, c: Scalar, v=None):
+        r = self.K * x - c
+        if v is None:
+            return r
+        return r, self.apply_chain_rule(
+            v,
+            "x_residual",
+            {"x": lambda V: self.K * V, "c": lambda V: -V},
+            output=r,
+        )
+
+
+def test_implicit_update_routes_residual_params_under_hit_name():
+    """When the residual model carries a HIT block name, ImplicitUpdate must
+    register it as a submodule under that name — not the opaque
+    ``_residual_model`` attribute slot. Mirrors the same convention used by
+    ComposedModel / Normality so ``named_parameters()`` reads as
+    ``surface.K`` instead of ``_residual_model.K``.
+    """
+    inner = _ParamResidual()
+    # Simulate the factory stamping the HIT block name onto the constructed
+    # object (see factory._get_object). Bypasses the full HIT round-trip so the
+    # test stays focused on the naming routing — the residual surface itself
+    # doesn't need to round-trip through HIT for that.
+    inner._hit_name = "surface"  # type: ignore[assignment]
+    system = ModelNonlinearSystem(inner, unknowns=[["x"]])
+    update = ImplicitUpdate(system, Newton())
+    names = {n for n, _ in update.named_parameters()}
+    assert names == {"surface.K"}
+
+
+def test_implicit_update_falls_back_to_residual_model_without_hit_name():
+    """When the residual model is built directly in Python (no ``_hit_name``),
+    fall back to the ``_residual_model`` attribute slot so existing eager-
+    construction call sites keep working.
+    """
+    inner = _ParamResidual()
+    system = ModelNonlinearSystem(inner, unknowns=[["x"]])
+    update = ImplicitUpdate(system, Newton())
+    names = {n for n, _ in update.named_parameters()}
+    assert names == {"_residual_model.K"}

--- a/tests/test_syntax_cli.py
+++ b/tests/test_syntax_cli.py
@@ -46,6 +46,23 @@ def test_collect_records_covers_native_sections():
     assert records["Newton"].section == "Solvers"
     assert records["NonlinearSystem"].section == "EquationSystems"
     assert records["CubicCrystal"].section == "Data"
+    # AOTIModel deliberately inherits from nn.Module rather than Model so the
+    # bound AOTIModelPackageLoader runtime drives evaluation; the explicit
+    # _MODEL_TYPES entry in cli/syntax.py keeps it visible under [Models].
+    assert records["AOTIModel"].section == "Models"
+    # The non-Model registered classes now expose HitSchema so the syntax
+    # catalog and auto-doc pipeline can render their HIT surface.
+    for type_name in (
+        "TransientDriver",
+        "TransientRegression",
+        "Verification",
+        "AOTIModel",
+        "CSVScalar",
+        "CSVSR2",
+        "CSVVec",
+        "CSVWR2",
+    ):
+        assert records[type_name].hit is not None, type_name
 
 
 def test_hit_schema_record_emits_option_metadata():
@@ -79,6 +96,21 @@ def test_schema_backed_solver_emits_option_metadata():
         "rel_tol",
         "max_its",
     }
+
+
+def test_collect_records_rejects_type_without_section(monkeypatch: pytest.MonkeyPatch):
+    """A registered class missing ``SECTION`` is a programming bug — the
+    catalog would silently drop the type otherwise. Fake a stale registry entry
+    and assert :func:`collect_records` raises with a clear pointer at the
+    offending class.
+    """
+
+    class _SectionlessType:
+        """Stand-in for a registered class whose base forgot to declare SECTION."""
+
+    monkeypatch.setitem(_syntax_cli._registry, "_SectionlessType", _SectionlessType)
+    with pytest.raises(ValueError, match="no SECTION declared"):
+        _syntax_cli.collect_records()
 
 
 def test_record_without_schema_is_summary_only():

--- a/tests/test_tensor_exprs.py
+++ b/tests/test_tensor_exprs.py
@@ -336,7 +336,7 @@ def test_old_type_format_raises_helpful_error(tmp_path):
 []
 """,
     )
-    with pytest.raises(ValueError, match="expected 'Python' or a registered tensor type"):
+    with pytest.raises(ValueError, match="expected a registered tensor type"):
         f.get_tensor("t")
 
 


### PR DESCRIPTION
This pull request introduces a unified mechanism for loading user-defined Python extensions into all `neml2-*` CLI utilities via a new `--load` flag. This allows users to register custom `Model`, `Driver`, `Solver`, `Data`, or tensor classes without modifying the core package or writing wrapper scripts. The implementation is accompanied by documentation updates and a refactor that standardizes how HIT section membership is declared for registered classes, improving extensibility and maintainability.