### PR TITLE
fix: keep opaque_pow opaque under AOTI (restore the pow fusion barrier)

### DIFF
--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -105,6 +105,22 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Where to write .pt2 + meta + stub. Defaults to a fresh tmpdir.",
     )
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        help=(
+            "Instead of a single timed run, warm up then capture the driver run "
+            "under torch.profiler (CPU+CUDA) and print the per-kernel breakdown "
+            "(flat + grouped by input shape)."
+        ),
+    )
+    parser.add_argument(
+        "--profile-runs",
+        type=int,
+        default=3,
+        metavar="N",
+        help="Number of driver runs to capture under the profiler (default 3).",
+    )
     return parser
 
 
@@ -165,6 +181,78 @@ def run_one(
     return t_compile, t_run
 
 
+def profile_one(
+    scenario: str,
+    batch: int,
+    device: str,
+    output_dir: Path,
+    driver_name: str = "driver",
+    warmup: int = 3,
+    profile_runs: int = 3,
+) -> None:
+    """Compile + load one scenario, then ``torch.profiler`` the driver run.
+
+    Reuses the same compile/load path as :func:`run_one` (so the device /
+    dtype defaults and the AOTI stub flow are identical), but instead of a
+    single timed run it warms up, then captures ``profile_runs`` driver runs
+    under the CPU+CUDA profiler and prints the per-kernel breakdown -- both a
+    flat ``self_cuda_time_total`` ranking and one grouped by input shape, so
+    a blow-up along a sub-batch axis (e.g. 12 slip systems materialised where
+    a size-1 broadcast would do) shows up directly in the shape column.
+    """
+    import time
+
+    import torch
+    from torch.profiler import ProfilerActivity, profile
+
+    from neml2 import load_input
+    from neml2.cli.aoti_compile import compile_and_emit_stub
+
+    model_i = _BENCHMARK_DIR / scenario / "model.i"
+    if not model_i.exists():
+        raise FileNotFoundError(f"no model.i under benchmark/{scenario}/")
+
+    pre = (f"nbatch={batch}", f"device={device}")
+    t0 = time.perf_counter()
+    stub_path = compile_and_emit_stub(
+        model_i, output_dir, driver=driver_name, device=device, pre=pre
+    )
+    print(f"[{scenario}] compile: {time.perf_counter() - t0:.1f}s", flush=True)
+
+    driver = load_input(stub_path, pre=pre).get_driver(driver_name)
+
+    for _ in range(warmup):
+        driver.run()
+    if device == "cuda":
+        torch.cuda.synchronize()
+
+    t0 = time.perf_counter()
+    for _ in range(profile_runs):
+        driver.run()
+    if device == "cuda":
+        torch.cuda.synchronize()
+    print(
+        f"[{scenario}] batch={batch} device={device} "
+        f"avg run: {(time.perf_counter() - t0) / profile_runs * 1000:.1f} ms",
+        flush=True,
+    )
+
+    activities = [ProfilerActivity.CPU]
+    if device == "cuda":
+        activities.append(ProfilerActivity.CUDA)
+    sort_key = "self_cuda_time_total" if device == "cuda" else "self_cpu_time_total"
+    with profile(activities=activities, record_shapes=True) as prof:
+        for _ in range(profile_runs):
+            driver.run()
+        if device == "cuda":
+            torch.cuda.synchronize()
+
+    print(f"\n================ TOP KERNELS by {sort_key} ================")
+    print(prof.key_averages().table(sort_by=sort_key, row_limit=25))
+    print(f"\n================ TOP by {sort_key}, GROUPED BY INPUT SHAPE ================")
+    print(prof.key_averages(group_by_input_shape=True).table(sort_by=sort_key, row_limit=25))
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
 
@@ -191,6 +279,16 @@ def main(argv: list[str] | None = None) -> int:
         out_dir.mkdir(parents=True, exist_ok=True)
 
     try:
+        if args.profile:
+            profile_one(
+                args.scenario,
+                args.batch,
+                args.device,
+                out_dir,
+                driver_name=args.driver,
+                profile_runs=args.profile_runs,
+            )
+            return 0
         t_compile, t_run = run_one(
             args.scenario,
             args.batch,

--- a/neml2/types/functions.py
+++ b/neml2/types/functions.py
@@ -143,22 +143,46 @@ def _opaque_pow_meta(base: torch.Tensor, exponent: torch.Tensor) -> torch.Tensor
     return torch.empty_like(base)
 
 
-def _opaque_pow_autograd(base: torch.Tensor, exponent: torch.Tensor) -> torch.Tensor:
-    # Delegate to ``torch.pow`` on the Autograd key so eager-autograd paths
-    # (pyzag adjoint training, in-process Jacobian via ``.backward()``) get
-    # the standard ``d(x^n)/dx = n*x^(n-1)`` / ``d(x^n)/dn = x^n*ln(x)``
-    # backward for free. Without an Autograd-key impl, autograd silently
-    # zeros the gradient through ``opaque_pow`` -- PyTorch warns about this
-    # behaviour and will hard-error in a future release. The fusion barrier
-    # is preserved for the AOTI / explicit-Jacobian path because those use
-    # the ``CompositeExplicitAutograd`` impl, where Inductor still sees the
-    # ``neml2::opaque_pow`` call as an opaque node.
-    return torch.pow(base, exponent)
+def _opaque_pow_setup_context(ctx, inputs, output) -> None:
+    base, exponent = inputs
+    ctx.save_for_backward(base, exponent)
+
+
+def _opaque_pow_backward(ctx, grad):
+    # Explicit backward for the eager-autograd paths (pyzag adjoint training,
+    # in-process ``torch.compile`` Jacobian). Standard power-rule gradients
+    # ``d(b^e)/db = e*b^(e-1)`` and ``d(b^e)/de = b^e*ln(b)``, computed only
+    # for the inputs that require grad.
+    base, exponent = ctx.saved_tensors
+    grad_base = grad_exponent = None
+    if ctx.needs_input_grad[0]:
+        grad_base = grad * exponent * torch.pow(base, exponent - 1.0)
+    if ctx.needs_input_grad[1]:
+        grad_exponent = grad * torch.pow(base, exponent) * torch.log(base)
+    return grad_base, grad_exponent
 
 
 _NEML2_LIB.impl("opaque_pow", _opaque_pow_impl, "CompositeExplicitAutograd")
-_NEML2_LIB.impl("opaque_pow", _opaque_pow_meta, "Meta")
-_NEML2_LIB.impl("opaque_pow", _opaque_pow_autograd, "Autograd")
+# Mark ``neml2::opaque_pow`` as a proper opaque custom op via ``register_fake``
+# (abstract impl) + ``register_autograd`` (explicit backward). Two subtleties,
+# each load-bearing for keeping the op OPAQUE through ``torch.export`` /
+# ``run_decompositions()`` (the AOTI lowering path):
+#
+#   * a bare ``lib.impl(..., "Meta")`` does NOT mark the op as preservable, so
+#     export decomposes it back into its ``CompositeExplicitAutograd`` body
+#     (``torch.pow``); ``register_fake`` does mark it.
+#   * registering the *forward* on the ``Autograd`` key (the old approach) is
+#     itself a decomposition -- export inlines the Autograd-key body to
+#     ``aten.pow``; ``register_autograd`` supplies a backward while leaving the
+#     forward opaque.
+#
+# When the op decomposes, Inductor inlines the pow into the downstream
+# K-batched per-slip reduction and recomputes it K x n_slip times -- the exact
+# regression this op exists to prevent (~2x on the crystal-plasticity suite).
+torch.library.register_fake("neml2::opaque_pow", _opaque_pow_meta)
+torch.library.register_autograd(
+    "neml2::opaque_pow", _opaque_pow_backward, setup_context=_opaque_pow_setup_context
+)
 
 
 # ---- SR2 invariants / decompositions ----

--- a/tests/unit/test_opaque_pow.py
+++ b/tests/unit/test_opaque_pow.py
@@ -1,0 +1,95 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""``neml2::opaque_pow`` must stay an opaque Inductor fusion barrier under AOTI.
+
+``opaque_pow`` exists so the expensive ``pow`` in rate-dependent leaves
+(``PowerLawSlipRule``, ``PerzynaPlasticFlowRate``) is computed once per
+``(B, n_comp)`` rather than being inlined into the downstream K-batched
+per-component reduction and recomputed ``K x n_comp`` times. The barrier only
+helps if the op stays *opaque* through the AOTI lowering path
+(``torch.export`` + ``run_decompositions()``).
+
+This is fragile against the op's registration: a bare ``lib.impl(..., "Meta")``
+or registering the forward on the ``Autograd`` key both make
+``run_decompositions()`` inline the op back to ``aten.pow``, silently
+dissolving the barrier (it stays opaque in eager / ``torch.compile``, so only
+the AOTI path regresses -- a ~2x slowdown on the crystal-plasticity suite).
+The fix is ``register_fake`` + ``register_autograd``; these tests pin it.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import neml2.types.functions  # noqa: F401  -- registers neml2::opaque_pow
+
+
+class _Pow(torch.nn.Module):
+    def forward(self, x):
+        return torch.ops.neml2.opaque_pow(x, torch.tensor(7.0, dtype=x.dtype))
+
+
+def _post_decomposition_ops() -> list[str]:
+    x = torch.rand(8, dtype=torch.float64)
+    ep = torch.export.export(_Pow(), (x,)).run_decompositions()
+    return [str(n.target) for n in ep.graph.nodes if n.op == "call_function"]
+
+
+def test_opaque_pow_survives_aoti_decomposition():
+    """The op stays opaque through ``run_decompositions()`` (the AOTI path) --
+    it must NOT be inlined back to ``aten.pow``."""
+    ops = _post_decomposition_ops()
+    assert any("opaque_pow" in op for op in ops), (
+        f"opaque_pow was decomposed away (barrier lost): {ops}"
+    )
+    assert not any(op == "aten.pow.Tensor_Tensor" for op in ops), (
+        f"a bare aten.pow leaked into the lowered graph: {ops}"
+    )
+
+
+def test_opaque_pow_value_matches_torch_pow():
+    x = torch.rand(16, dtype=torch.float64) + 0.1
+    e = torch.tensor(3.5, dtype=torch.float64)
+    assert torch.allclose(torch.ops.neml2.opaque_pow(x, e), torch.pow(x, e))
+
+
+def test_opaque_pow_autograd_matches_torch_pow():
+    """Eager autograd through the op (pyzag adjoint / in-process compile path)
+    must match ``torch.pow`` for BOTH the base and the exponent."""
+    # Build the base as a leaf AFTER the +0.1 shift (positive base so the
+    # exponent gradient's log(base) is finite).
+    base = (torch.rand(5, dtype=torch.float64) + 0.1).requires_grad_(True)
+    expo = torch.tensor(7.0, dtype=torch.float64, requires_grad=True)
+    torch.ops.neml2.opaque_pow(base, expo).sum().backward()
+    assert base.grad is not None and expo.grad is not None
+    g_base, g_expo = base.grad, expo.grad
+
+    base_ref = base.detach().clone().requires_grad_(True)
+    expo_ref = torch.tensor(7.0, dtype=torch.float64, requires_grad=True)
+    torch.pow(base_ref, expo_ref).sum().backward()
+    assert base_ref.grad is not None and expo_ref.grad is not None
+
+    assert torch.allclose(g_base, base_ref.grad)
+    assert torch.allclose(g_expo, expo_ref.grad)

--- a/tests/unit/test_opaque_pow.py
+++ b/tests/unit/test_opaque_pow.py
@@ -93,3 +93,22 @@ def test_opaque_pow_autograd_matches_torch_pow():
 
     assert torch.allclose(g_base, base_ref.grad)
     assert torch.allclose(g_expo, expo_ref.grad)
+
+
+def test_opaque_pow_autograd_one_sided_inputs():
+    """Backward must handle each input independently requiring grad -- exercising
+    both ``ctx.needs_input_grad`` branches (the common case has a constant
+    exponent, so only the base needs a gradient)."""
+    # Only the base requires grad -> needs_input_grad == (True, False).
+    base = (torch.rand(4, dtype=torch.float64) + 0.1).requires_grad_(True)
+    expo = torch.tensor(5.0, dtype=torch.float64)  # constant, no grad
+    torch.ops.neml2.opaque_pow(base, expo).sum().backward()
+    assert base.grad is not None
+    assert torch.allclose(base.grad, 5.0 * torch.pow(base.detach(), 4.0))
+
+    # Only the exponent requires grad -> needs_input_grad == (False, True).
+    base2 = torch.rand(4, dtype=torch.float64) + 0.1  # no grad
+    expo2 = torch.tensor(5.0, dtype=torch.float64, requires_grad=True)
+    torch.ops.neml2.opaque_pow(base2, expo2).sum().backward()
+    assert expo2.grad is not None
+    assert torch.allclose(expo2.grad, (torch.pow(base2, 5.0) * torch.log(base2)).sum())


### PR DESCRIPTION
## Summary

`neml2::opaque_pow` is an Inductor fusion barrier: it lets the expensive `pow`
in rate-dependent leaves (`PowerLawSlipRule`, `PerzynaPlasticFlowRate`) be
computed **once** per `(B, n_comp)` instead of being inlined into the
downstream K-batched per-component reduction and recomputed `K × n_comp` times.

The barrier **silently dissolved under the AOTI lowering path**:

- the abstract impl was registered with a bare `lib.impl(..., "Meta")`, and
- the backward by registering the *forward* on the `"Autograd"` key.

Neither marks the op as a preservable custom op, so `torch.export`'s
`run_decompositions()` inlined it back to `aten.pow`. Eager and `torch.compile`
kept it opaque — so unit/regression and pyzag tests passed and the original
`opaque_pow` measurements held — **only the production AOTI path regressed**
(~2× on the crystal-plasticity suite).

## Fix

Register the abstract impl via `torch.library.register_fake` and the backward
via `torch.library.register_autograd`. Both keep the op opaque through
`run_decompositions()` while preserving eager-autograd gradients (pyzag adjoint
and in-process `torch.compile`).

## Impact

scpdecoup, CUDA, fresh AOTI compile:

| batch | before | after | baseline |
|---|---|---|---|
| **4096** | **1914 ms** | **939 ms** (2.04×) | ~922 ms |
| 8 | 406 ms | 474 ms¹ | 434 ms |

¹ At tiny batch the barrier is the documented net-loss case (the opaque call
costs more than the saved redundancy when launch-bound); production runs are
large-batch, so this is the intended `opaque_pow` tradeoff — the pre-regression
baseline had it too.

## Validation

- **AOTI perf**: 2.04× recovery at B=4096 (above).
- **Autograd through dynamo**: the existing
  `tests/unit/pyzag/test_compile.py::test_adjoint_matches_eager_under_compile`
  (`solve_adjoint` + `backward` through a `neml2.compile`'d residual on a
  `PerzynaPlasticFlowRate` model) passes — the deterministic-tutorial path.
- **Full unit suite** green (419) + all 19 pyzag tests.
- New `tests/unit/test_opaque_pow.py` pins the contract: the op survives
  `run_decompositions()` and value + autograd (base and exponent) match
  `torch.pow`.

Also adds a `--profile` mode to `benchmark/run_benchmark.py` (a `torch.profiler`
kernel breakdown), the tool used to localize this regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)