### PR TITLE
ci: run benchmark ctests in parallel

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -80,4 +80,8 @@ jobs:
       - name: Configure dev preset
         run: cmake --preset dev -GNinja -S .
       - name: Run benchmark smoke tests
-        run: ctest --test-dir build/dev -L benchmark --output-on-failure
+        # Parallel across scenarios: each has its own Inductor cache dir, and
+        # heavy scenarios carry PROCESSORS=2 (set in benchmark/CMakeLists.txt)
+        # so ctest's --parallel budget doesn't pile too many AOTI compiles onto
+        # the runner at once. -j 4 matches the ubuntu-latest vCPU count.
+        run: ctest --test-dir build/dev -L benchmark --output-on-failure --parallel 4

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -25,8 +25,12 @@
 # wrapper (e.g. crystal-plasticity's `model_with_stress`).
 #
 # Compiled .pt2 artifacts land in ${CMAKE_BINARY_DIR}/benchmark/<scenario>/.
-# The shared TORCHINDUCTOR_CACHE_DIR is build-tree-local so re-runs of
-# ctest hit a warm AOTI cache instead of recompiling every scenario.
+# Each scenario gets its OWN build-tree-local TORCHINDUCTOR_CACHE_DIR so the
+# tests can run concurrently under ``ctest --parallel`` without racing on a
+# shared cache; the per-scenario cache still persists across re-runs, so a
+# repeated single-scenario run stays warm. Heavy scenarios declare
+# ``PROCESSORS 2`` so ``ctest -j`` doesn't pack too many AOTI compiles (each
+# spawns a multi-threaded C++ build) onto the runner at once.
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
@@ -66,14 +70,17 @@ foreach(bench_input ${BENCH_INPUTS})
 
       if(${scenario} IN_LIST BENCH_HEAVY)
             set(_t 1800)
+            set(_procs 2)
       else()
             set(_t 600)
+            set(_procs 1)
       endif()
 
       set_tests_properties(benchmark_${scenario} PROPERTIES
             LABELS "benchmark"
             TIMEOUT ${_t}
+            PROCESSORS ${_procs}
             SKIP_RETURN_CODE 77
-            ENVIRONMENT "TORCHINDUCTOR_CACHE_DIR=${CMAKE_BINARY_DIR}/aoti-cache"
+            ENVIRONMENT "TORCHINDUCTOR_CACHE_DIR=${work_dir}/aoti-cache"
       )
 endforeach()


### PR DESCRIPTION
The `benchmark` smoke job in `cpp.yaml` ran ~14 AOTI compile+run scenarios **serially** — ~50 min, the slowest check in CI. This runs them with `ctest --parallel 4`.

## Why it was serial-only
Every benchmark ctest shared **one** Inductor cache dir (`${CMAKE_BINARY_DIR}/aoti-cache`), so concurrent compiles would race on it. Two changes make parallel safe:

- **Per-scenario cache** (`benchmark/CMakeLists.txt`): each scenario's `TORCHINDUCTOR_CACHE_DIR` is now `${work_dir}/aoti-cache` (distinct per scenario) instead of one shared dir. Still build-tree-local, so a repeated single-scenario run stays warm.
- **`PROCESSORS` weighting**: heavy scenarios (the existing `BENCH_HEAVY` set) declare `PROCESSORS 2` so `ctest`'s `--parallel` budget doesn't pack too many memory/CPU-heavy AOTI compiles (each spawns a multi-threaded C++ build) onto the runner at once. With `-j 4`, at most two heavy compiles run together.

`cpp.yaml`: `ctest ... --parallel 4` (matches ubuntu-latest's vCPU count).

## On the dev-preset configure
Kept — it's what **registers the ctests** (`build/dev/CTestTestfile.cmake`). `pip install -e` builds the runtime, but the wheel build has `BUILD_TESTING` off, so it doesn't register tests. The configure is seconds of overhead, not the bottleneck (serial execution was). Dropping it would mean moving benchmarks off ctest entirely (e.g. a per-scenario GH matrix), which would re-add ~14 checks.

Verified locally: configure clean, 14 tests registered, per-scenario cache dirs distinct, heavy=PROCESSORS 2 / light=1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
