### PR TITLE
ci: matrix-ify the wheel build (one python per job)

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -194,12 +194,31 @@ jobs:
           action_fail: true
           comment_mode: off
 
-  wheels:
+  # Python versions to build wheels for, emitted as a JSON list so `wheels` can
+  # fan out one (os, python) cell per wheel. Full set on a release; just the
+  # min+max python on PRs/pushes (a packaging smoke -- the full set is for the
+  # published artifacts).
+  wheel-matrix:
     needs: lint
+    runs-on: ubuntu-latest
+    outputs:
+      pythons: ${{ steps.set.outputs.pythons }}
+    steps:
+      - id: set
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo 'pythons=["3.10","3.11","3.12","3.13","3.14"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'pythons=["3.10","3.14"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  wheels:
+    needs: [lint, wheel-matrix]
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        python: ${{ fromJson(needs.wheel-matrix.outputs.pythons) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -217,34 +236,38 @@ jobs:
           swap-storage: true
       - name: Install cibuildwheel
         run: pip install cibuildwheel
-      - name: Build wheels
-        run: cibuildwheel --output-dir wheelhouse
+      - name: Build wheel
+        # One python per matrix cell so the per-python builds run in PARALLEL
+        # instead of serially within an OS job. Each cibuildwheel wheel
+        # reinstalls the build-time torch inside the manylinux container
+        # (~24 min/wheel on Linux), so the serial build was the dominant CI
+        # cost; wall time now caps at one wheel regardless of python count.
+        shell: bash
+        run: |
+          set -euo pipefail
+          export CIBW_BUILD="cp${PYVER//./}-*"
+          cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: ${{ github.event_name == 'release' && 'cp310-* cp311-* cp312-* cp313-* cp314-*' || 'cp310-* cp314-*' }}
-      - name: Set up Python for wheel smoke test
+          PYVER: ${{ matrix.python }}
+      - name: Set up Python for the wheel smoke test
         uses: actions/setup-python@v6
         with:
-          # dependencies: python.version_min  (matches cp310 in CIBW_BUILD)
-          python-version: "3.10"
+          python-version: ${{ matrix.python }}
       - name: Smoke-test the built wheel
-        # cibuildwheel's own ``test-command`` only runs on tag releases (the
-        # release-gated CIBW_BUILD line above). On every other build we still
-        # want a basic install + import check so packaging regressions surface
-        # at PR time rather than in the release rush.
-        #
-        # pip resolves ``torch>=2.10.0`` / ``pyzag`` / ``nmhit`` straight from
-        # pyproject.toml's runtime deps -- no manual prereqs, no index-url
-        # juggling. ABI-matched wheel is the cp310 one we just built.
+        # Install + import the wheel this cell just built. cibuildwheel's own
+        # test-command only runs on tag releases, so this gives every
+        # (os, python) cell a basic packaging check on PRs too. pip resolves the
+        # runtime deps (torch / pyzag / nmhit) straight from pyproject.toml.
         shell: bash
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install wheelhouse/*cp310*.whl
+          python -m pip install wheelhouse/*.whl
           python -c "import neml2; print(f'neml2 {neml2.__version__} loads from {neml2.__file__}')"
       - uses: actions/upload-artifact@v7
         if: github.event_name == 'release' && github.event.action == 'published'
         with:
-          name: packages-wheels-${{ matrix.os }}
+          name: packages-wheels-${{ matrix.os }}-py${{ matrix.python }}
           path: wheelhouse/*.whl
 
   sdist:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -194,23 +194,28 @@ jobs:
           action_fail: true
           comment_mode: off
 
-  # Python versions to build wheels for, emitted as a JSON list so `wheels` can
-  # fan out one (os, python) cell per wheel. Full set on a release; just the
-  # min+max python on PRs/pushes (a packaging smoke -- the full set is for the
-  # published artifacts).
+  # cibuildwheel build identifiers (cp310, ...) to build wheels for, sourced
+  # from compatibility.yaml so the wheel matrix tracks the supported-python set
+  # automatically. Full set on a release; just the min+max python on PRs/pushes
+  # (a packaging smoke -- the full set is for the published artifacts). Emitted
+  # as a JSON list so `wheels` fans out one (os, python) cell per wheel.
   wheel-matrix:
     needs: lint
     runs-on: ubuntu-latest
     outputs:
-      pythons: ${{ steps.set.outputs.pythons }}
+      cibw: ${{ steps.set.outputs.cibw }}
     steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          # dependencies: python.version_min
+          python-version: "3.10"
+      - run: pip install pyyaml
       - id: set
+        env:
+          MODE: ${{ github.event_name == 'release' && 'full' || 'pr' }}
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            echo 'pythons=["3.10","3.11","3.12","3.13","3.14"]' >> "$GITHUB_OUTPUT"
-          else
-            echo 'pythons=["3.10","3.14"]' >> "$GITHUB_OUTPUT"
-          fi
+          echo "cibw=$(python scripts/compat_matrix.py expand --kind cibuildwheel --mode "$MODE")" >> "$GITHUB_OUTPUT"
 
   wheels:
     needs: [lint, wheel-matrix]
@@ -218,7 +223,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: ${{ fromJson(needs.wheel-matrix.outputs.pythons) }}
+        python: ${{ fromJson(needs.wheel-matrix.outputs.cibw) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -237,22 +242,25 @@ jobs:
       - name: Install cibuildwheel
         run: pip install cibuildwheel
       - name: Build wheel
-        # One python per matrix cell so the per-python builds run in PARALLEL
-        # instead of serially within an OS job. Each cibuildwheel wheel
-        # reinstalls the build-time torch inside the manylinux container
-        # (~24 min/wheel on Linux), so the serial build was the dominant CI
-        # cost; wall time now caps at one wheel regardless of python count.
-        shell: bash
-        run: |
-          set -euo pipefail
-          export CIBW_BUILD="cp${PYVER//./}-*"
-          cibuildwheel --output-dir wheelhouse
+        # One python per matrix cell (matrix.python is a cibuildwheel build tag
+        # like cp310) so the per-python builds run in PARALLEL instead of
+        # serially within an OS job. Each cibuildwheel wheel reinstalls the
+        # build-time torch inside the manylinux container (~24 min/wheel on
+        # Linux), so the serial build was the dominant CI cost; wall time now
+        # caps at one wheel regardless of python count.
+        run: cibuildwheel --output-dir wheelhouse
         env:
-          PYVER: ${{ matrix.python }}
+          CIBW_BUILD: ${{ matrix.python }}-*
+      - name: Resolve python version for the smoke test
+        id: pyver
+        shell: bash
+        run: echo "version=3.${TAG#cp3}" >> "$GITHUB_OUTPUT"  # cp310 -> 3.10
+        env:
+          TAG: ${{ matrix.python }}
       - name: Set up Python for the wheel smoke test
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ steps.pyver.outputs.version }}
       - name: Smoke-test the built wheel
         # Install + import the wheel this cell just built. cibuildwheel's own
         # test-command only runs on tag releases, so this gives every
@@ -267,7 +275,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: github.event_name == 'release' && github.event.action == 'published'
         with:
-          name: packages-wheels-${{ matrix.os }}-py${{ matrix.python }}
+          name: packages-wheels-${{ matrix.os }}-${{ matrix.python }}
           path: wheelhouse/*.whl
 
   sdist:

--- a/scripts/compat_matrix.py
+++ b/scripts/compat_matrix.py
@@ -31,9 +31,11 @@ Usage:
         verify compatibility.yaml internal consistency and sync with
         dependencies.yaml
 
-  compat_matrix.py expand --kind {test|wheel} [--mode {full|pr}]
+  compat_matrix.py expand --kind {test|wheel|cibuildwheel} [--mode {full|pr}]
         print the matrix as JSON for use in a GitHub Actions strategy.matrix
-        (--mode pr emits the lean torch x python extremes subset for PRs)
+        (test/wheel emit {"include": [...]}; cibuildwheel emits a flat list of
+        cp tags, e.g. ["cp310","cp314"]; --mode pr emits the lean torch x
+        python extremes subset for PRs)
 
   compat_matrix.py render [--in-place FILE] [--check]
         render the matrix as a Markdown table; with --in-place, splice it into
@@ -196,6 +198,12 @@ def cmd_expand(args) -> None:
     combinations = data["combinations"]
     if args.mode == "pr":
         combinations = _subset(combinations)
+    if args.kind == "cibuildwheel":
+        # Distinct python versions in cibuildwheel build-identifier form
+        # (3.10 -> cp310), as a flat JSON list for a GitHub Actions matrix axis.
+        pys = sorted({r["python"] for r in combinations}, key=_ver_tuple)
+        print(json.dumps(["cp" + p.replace(".", "") for p in pys], separators=(",", ":")))
+        return
     if args.kind == "test":
         include = [
             {"torch": r["torch"], "python": r["python"], "os": r["os"]} for r in combinations
@@ -305,7 +313,7 @@ def main() -> None:
     subs.add_parser("check", help="validate compatibility.yaml")
 
     expand_p = subs.add_parser("expand", help="emit JSON matrix for GitHub Actions")
-    expand_p.add_argument("--kind", choices=["test", "wheel"], required=True)
+    expand_p.add_argument("--kind", choices=["test", "wheel", "cibuildwheel"], required=True)
     expand_p.add_argument(
         "--mode",
         choices=["full", "pr"],


### PR DESCRIPTION
The `wheels` job built all target pythons **serially per OS** in a single cibuildwheel invocation. Each wheel reinstalls the build-time torch inside the manylinux container (~24 min/wheel on Linux), so on PR #372 `wheels (ubuntu-latest)` took **48m46s** for cp310+cp314, and a **release** (all 5 pythons) would be ~2 h.

## Change
Fan out to **one `(os, python)` matrix cell per wheel** so the per-python builds run in parallel — wall time caps at ~one wheel regardless of python count.

- New `wheel-matrix` job sources the python set **from `compatibility.yaml`** via a new `compat_matrix.py expand --kind cibuildwheel` (emits cp tags, e.g. `["cp310","cp314"]`), so the wheel build automatically tracks the supported-python set: **min+max** on PR/push (`--mode pr`), the **full set** on release (`--mode full`).
- `matrix.python` carries the cp tag, so `CIBW_BUILD=${tag}-*` and the per-cell artifact `packages-wheels-<os>-<cp>` use it directly; the smoke step resolves `cp310 -> 3.10` for `setup-python`.
- Each cell **smoke-tests its own wheel** (install + import) — previously only cp310 was checked; now every python is.
- The `PyPI` job's existing `pattern: packages-wheels-* / merge-multiple` download is unchanged.

## Trade-off
More jobs/checks (PR: 4 vs 2; release: 10 vs 2) and more runner-minutes, but far less wall time. The extra release checks never appear on a PR merge box.

Validated: `compat_matrix.py expand --kind cibuildwheel` (full → 5 cp tags, pr → cp310/cp314), YAML valid, actionlint clean, `dep_manager check` consistent, PyPI download pattern still matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
