### PR TITLE
feat: selectable + per-variable-pair jvp/jacobian (opt-in compilation, schema v6)

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -155,7 +155,10 @@ jobs:
       - name: Install clang + llvm
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang llvm
+          # patchelf: cpp_coverage.sh stages a SONAME-patched copy of the
+          # instrumented libneml2 so the Python AOTI suite (driven through the
+          # pybind binding) loads the instrumented runtime via LD_PRELOAD.
+          sudo apt-get install -y clang llvm patchelf
           ver=$(clang --version | grep -oP 'clang version \K[0-9]+' | head -1)
           echo "LLVM_PROFDATA=llvm-profdata-$ver" >> "$GITHUB_ENV"
           echo "LLVM_COV=llvm-cov-$ver" >> "$GITHUB_ENV"

--- a/doc/content/deployment/cli.md
+++ b/doc/content/deployment/cli.md
@@ -158,6 +158,10 @@ into a frozen graph for performance.
 ```{program-output} neml2-compile --help
 ```
 
+Derivative graphs are opt-in: with no `-d` flag only `forward` is
+compiled and `jvp` / `jacobian` raise at runtime. Request the pairs you
+need with `-d OUT:IN` (e.g. `-d stress:strain`, or `-d :` for all).
+
 The end-to-end walkthrough — emitted file layout, loading the
 artifact from Python, parameter promotion (`-p <name>`), and the
 trade-offs against eager mode — lives in

--- a/doc/content/references/aoti_packages.md
+++ b/doc/content/references/aoti_packages.md
@@ -20,6 +20,31 @@ neml2-compile <input.i> --model <name>
                         [--output-dir <dir>]
                         [--device cpu|cuda [cpu|cuda ...]] [--dtype float64|float32]
                         [-p|--parameter NAME ...]
+                        [-d|--derivative OUT:IN ...]
+```
+
+Derivative graphs are **opt-in**. With no `-d` flag only the `forward`
+graph is compiled and the runtime `jvp` / `jacobian` raise. Each
+`-d OUT:IN` requests the Jacobian/JVP for that output-input pair; omit a
+side to select all on it (`stress:` = every input of `stress`, `:strain`
+= every output w.r.t. `strain`, `:` = all pairs). The requested master
+pairs are recorded in the metadata's top-level `derivatives` array.
+
+Each derivative is one per-variable-pair block. A block that does not
+depend on the dynamic batch (e.g. a constant stiffness tensor) is returned
+**unbatched** at its natural `(*out_base, *in_base)` shape.
+
+```{note}
+For an **implicit (Newton-solve) model with sub-batched (per-grain) state**
+— e.g. crystal plasticity — a derivative of a **non-sub-batched output
+w.r.t. a non-sub-batched input** (e.g. a global stress w.r.t. a global
+strain) is supported: the IFT solve handles the internal per-grain coupling
+and the returned block has no grain axis. A derivative that *touches* a
+per-grain variable (a sub-batched output or input) is not yet implemented
+and fails fast at `neml2-compile` with a clear "… involves the sub-batched
+variable …" error; use eager mode (`torch.autograd`) for per-grain
+sensitivities. Forward evaluation of such models, and all plain-batch /
+forward derivatives, are fully supported.
 ```
 
 See [](cli-utilities) for the broader CLI surface.
@@ -51,8 +76,8 @@ the metadata plus a value graph and an optional JVP graph:
 | File                  | Contents                                                                    |
 | :-------------------- | :-------------------------------------------------------------------------- |
 | `<name>.pt2`          | AOT-Inductor-compiled forward / value graph.                                |
-| `<name>_jvp.pt2`      | Flat-Jacobian graph: returns the outputs plus a stacked `dout/din` block.   |
-| `<name>_meta.json`    | Variable layout, dtype, device, promoted-parameter initial values.         |
+| `<name>_jvp.pt2`      | Per-pair Jacobian graph (only when `-d` requested a forward-segment pair): returns the outputs plus one block per requested `(out, in)`. A block that does not depend on the dynamic batch (e.g. a constant stiffness tensor) is emitted unbatched (`batch_independent` in the metadata). |
+| `<name>_meta.json`    | Variable layout, dtype, device, promoted-parameter initial values, and the top-level `derivatives` array (master `[out, in]` pairs the artifact supports; empty = none). |
 
 Implicit single-segment models emit the per-segment set covered in the
 segment table below in place of the forward graphs.
@@ -100,7 +125,7 @@ refuses any non-matching version with a clear "regenerate via
 `neml2-compile`" message; the only remediation is a re-compile.
 
 <!-- dependencies: aoti.schema_version -->
-The current schema version is `5`.
+The current schema version is `6`.
 
 ### Segment kinds
 

--- a/doc/content/references/aoti_packages.md
+++ b/doc/content/references/aoti_packages.md
@@ -89,10 +89,10 @@ boundary into separate **segments**, each numbered `_seg{i}_`:
 | File                            | Contents                                                |
 | :------------------------------ | :------------------------------------------------------ |
 | `<name>_seg{i}.pt2`             | Forward-segment value graph.                            |
-| `<name>_seg{i}_jvp.pt2`         | Forward-segment flat Jacobian graph (optional).         |
+| `<name>_seg{i}_jvp.pt2`         | Forward-segment per-pair Jacobian graph (only when `-d` requested a pair this segment contributes to). |
 | `<name>_seg{i}_rhs.pt2`         | Implicit-segment Newton residual `-r(u, g)`.            |
 | `<name>_seg{i}_step.pt2`        | Implicit-segment fused assemble + solve + update.       |
-| `<name>_seg{i}_ift.pt2`         | Implicit-function-theorem sensitivity `-A^{-1} B`.      |
+| `<name>_seg{i}_ift.pt2`         | Implicit-function-theorem sensitivity `-A^{-1} B` (only when `-d` requested a pair routed through this segment). |
 | `<name>_seg{i}_predictor.pt2`   | Newton initial guess (only if the source had one).      |
 
 The `_seg0_` infix is dropped in the single-segment shortcut, so
@@ -131,17 +131,20 @@ The current schema version is `6`.
 
 Two segment kinds appear inside `segments`:
 
-- **Forward** segments lower to a single value graph (`_seg{i}.pt2`)
-  plus an optional flat-Jacobian graph (`_seg{i}_jvp.pt2`). Call shape
+- **Forward** segments lower to a value graph (`_seg{i}.pt2`), plus a
+  per-variable-pair Jacobian graph (`_seg{i}_jvp.pt2`) when `-d`
+  requested a derivative pair this segment contributes to (a block that
+  does not depend on the dynamic batch is emitted unbatched). Call shape
   is `(*user_inputs, *promoted_params) -> outputs`.
-- **Implicit** segments lower to three graphs — `_rhs.pt2` (Newton
-  residual), `_step.pt2` (fused assemble + LU solve + update +
-  post-update residual), `_ift.pt2` (`-A^{-1} B`
-  implicit-function-theorem sensitivity at the converged state) —
-  plus an optional `_predictor.pt2` graph when the source had a
-  `Predictor`. The Newton loop body is one loader call per iteration
-  plus a convergence sync; the IFT graph is consumed by `jacobian()`
-  and `jvp()`.
+- **Implicit** segments always lower `_rhs.pt2` (Newton residual) and
+  `_step.pt2` (fused assemble + LU solve + update + post-update
+  residual), plus an optional `_predictor.pt2` graph when the source had
+  a `Predictor`. They additionally lower `_ift.pt2` (`-A^{-1} B`
+  implicit-function-theorem sensitivity at the converged state) **only
+  when `-d` requested a pair whose derivative path runs through this
+  segment**. The Newton loop body is one loader call per iteration plus a
+  convergence sync; the IFT graph, when present, is consumed by
+  `jacobian()` and `jvp()`.
 
   The Newton solve's convergence tolerances, iteration cap, and line-search
   settings are **not** baked into the metadata (schema v4+). They are carried

--- a/doc/content/references/cpp_aoti.md
+++ b/doc/content/references/cpp_aoti.md
@@ -26,6 +26,9 @@ auto model = neml2::aoti::load_model("aoti/elasticity_aoti.i", "elasticity");
 
 auto outputs = model.forward({{"strain", strain_tensor}});
 // J is nested: J["stress"]["strain"] is the (*B, *out_base, *in_base) block.
+// jacobian()/jvp() return only the pairs the artifact was compiled with
+// (`neml2-compile -d OUT:IN`); they throw a FatalError if none were requested.
+// A batch-independent block (constant stiffness) is returned unbatched.
 auto [outs, J] = model.jacobian({{"strain", strain_tensor}});
 
 // Promoted parameters are mutable in place.

--- a/doc/content/references/cpp_dispatch.md
+++ b/doc/content/references/cpp_dispatch.md
@@ -31,8 +31,13 @@ several devices needs one artifact per device. `neml2-compile` takes multiple
 ```
 
 ```console
-$ neml2-compile tests/aoti/forward_single/model.i --model model --device cpu cuda
+$ neml2-compile tests/aoti/forward_single/model.i --model model --device cpu cuda -d :
 ```
+
+(`-d :` compiles every Jacobian/JVP pair so the dispatched `jacobian` /
+`jvp` work; drop it for a forward-only artifact, or name specific pairs.)
+A batch-independent block is returned unbatched and the dispatcher passes
+it through unchanged (it is identical across batch chunks).
 
 produces a standalone stub next to a per-device artifact folder:
 

--- a/doc/content/references/pipeline.md
+++ b/doc/content/references/pipeline.md
@@ -177,15 +177,19 @@ promoted-parameter pack, or named positionals only — and the adapter
 normalizes the example list and dynamic-shape spec to whichever shape
 the target leaf expects.
 
-The lowered output is a `.pt2` package per graph. **Implicit
-segments** lower three graphs each (a Newton residual, a fused
-assemble + solve + update step, and an implicit-function-theorem
-sensitivity graph) plus an optional predictor; **forward segments**
-lower one value graph plus an optional flat-Jacobian graph (`jvp`).
-The implicit-segment graphs forward to whichever linear solver the
-source model is configured with (`DenseLU` for the common
-single-group case; `SchurComplement` for the `BLOCK + DENSE`
-2-group factorisation).
+The lowered output is a `.pt2` package per graph. Derivative graphs are
+**opt-in**: `neml2-compile` emits them only for the output-input pairs
+requested with `-d/--derivative` (none by default). **Forward segments**
+always lower a value graph and, when a requested pair runs through them, a
+per-variable-pair `jvp` graph emitting just the on-path blocks — a block
+that does not depend on the dynamic batch is traced, and returned,
+unbatched. **Implicit segments** always lower a Newton residual and a
+fused assemble + solve + update step (plus an optional predictor), and
+additionally an implicit-function-theorem sensitivity graph only when a
+requested pair's derivative path runs through them. The implicit-segment
+graphs forward to whichever linear solver the source model is configured
+with (`DenseLU` for the common single-group case; `SchurComplement` for
+the `BLOCK + DENSE` 2-group factorisation).
 
 The C++ orchestrator sees the same flat `(u_flat, g_flat) →
 (u_new, b_new)` contract either way — the multi-group / sub-batch

--- a/doc/content/references/py_aoti.md
+++ b/doc/content/references/py_aoti.md
@@ -46,9 +46,15 @@ wholesale:
 | Operation               | Returns                                             |
 | :---------------------- | :-------------------------------------------------- |
 | `forward(inputs)`       | One tensor per output name, at `(*B, *out_base)`.   |
-| `jvp(inputs, tangents)` | `(outputs, J @ v)`, each at `(*B, *out_base)`. Missing tangent keys → zero. |
-| `jacobian(inputs)`      | `(outputs, J)` with `J[out][in]` the block `(*B, *out_base, *in_base)`. |
+| `jvp(inputs, tangents)` | `(outputs, J @ v)` over the **requested** pairs. Missing tangent keys → zero. |
+| `jacobian(inputs)`      | `(outputs, J)` with `J[out][in]` the block for each **requested** pair, `(*B, *out_base, *in_base)`. |
 | `named_parameters()`    | Mutable dict of promoted parameters; empty if baked. |
+
+`jvp` / `jacobian` only return the output-input pairs the artifact was
+compiled with (`neml2-compile -d OUT:IN`); pairs absent from the
+`derivatives` metadata are absent from the returned maps. An artifact
+compiled with no `-d` raises from both. A batch-independent block (e.g. a
+constant stiffness tensor) comes back unbatched (`(*out_base, *in_base)`).
 
 All three call paths take a dict keyed by the master input names
 listed in `input_names`; missing keys throw.

--- a/doc/content/tutorials/models/compiled_models/main.md
+++ b/doc/content/tutorials/models/compiled_models/main.md
@@ -28,7 +28,7 @@ input.i ──► neml2-compile ──► elasticity_aoti.i             (standal
                               elasticity/
                                 cpu/  elasticity_meta.json   (variable layout, dtype, device)
                                       elasticity.pt2         (AOTI-compiled kernels)
-                                      elasticity_jvp.pt2     (flat dout/din graph)
+                                      elasticity_jvp.pt2     (per-pair Jacobian graph; only with -d)
 ```
 
 `neml2-compile` emits one artifact folder per device (`elasticity/<device>/`)
@@ -51,10 +51,14 @@ runs on.
 ## Compiling from the shell
 
 `neml2-compile` (see [](cli-utilities)) builds the package in one
-invocation:
+invocation. Derivative graphs are **opt-in**: with no `-d` flag only the
+`forward` graph is compiled (the smallest artifact). Request the
+derivatives you need with `-d OUT:IN` (here `stress:strain`; omit a side
+to select all on it, `-d :` for every pair) so the artifact also exposes
+`jvp` / `jacobian` for those pairs:
 
 ```{code-cell} ipython3
-!neml2-compile input.i --model elasticity
+!neml2-compile input.i --model elasticity -d stress:strain
 ```
 
 Compilation is a one-time cost (Inductor + C++ compile, typically
@@ -164,7 +168,7 @@ constant. That's fastest, but it also means you can't change them at
 runtime. To keep one mutable, promote it at compile time with `-p`:
 
 ```{code-cell} ipython3
-!neml2-compile input.i --model elasticity --output-dir aoti_promoted -p E
+!neml2-compile input.i --model elasticity --output-dir aoti_promoted -p E -d stress:strain
 ```
 
 The promoted artifact loads the same way; the difference is that the

--- a/neml2/cli/aoti_compile.py
+++ b/neml2/cli/aoti_compile.py
@@ -130,6 +130,21 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "-d",
+        "--derivative",
+        action="append",
+        default=[],
+        metavar="OUT:IN",
+        help=(
+            "Compile the derivative (Jacobian / JVP) graph for the OUT:IN "
+            "output-input pair. Repeatable. Omit a side to select all on that "
+            "side: 'stress:strain' is one pair, 'stress:' all inputs of stress, "
+            "':strain' all outputs wrt strain, ':' all pairs. With no -d flags "
+            "NO derivative graphs are compiled (smallest artifact) and the "
+            "runtime jvp()/jacobian() raise until recompiled with -d."
+        ),
+    )
+    parser.add_argument(
         "--example-batch-shape",
         action="append",
         default=[],
@@ -178,6 +193,7 @@ def compile_and_emit_stub(
     promoted: set[str] | None = None,
     example_batch_shape=None,
     dynamic_batch: bool | None = None,
+    derivatives: tuple[str, ...] = (),
     pre: tuple[str, ...] = (),
     additional_args: tuple[str, ...] = (),
 ) -> Path:
@@ -214,6 +230,7 @@ def compile_and_emit_stub(
         promoted=promoted or set(),
         example_batch_shape=example_batch_shape,
         dynamic_batch=dynamic_batch,
+        derivatives=derivatives,
         pre=pre,
         additional_args=additional_args,
     )
@@ -547,6 +564,7 @@ def main(argv: list[str] | None = None) -> int:
                 promoted=set(args.parameter),
                 example_batch_shape=example_batch_shape,
                 dynamic_batch=args.dynamic_batch,
+                derivatives=tuple(args.derivative),
                 additional_args=tuple(additional_args),
             )
         except Exception as exc:  # noqa: BLE001
@@ -571,13 +589,19 @@ def main(argv: list[str] | None = None) -> int:
     n_promoted = len(args.parameter)
     bake_note = "fully baked" if n_promoted == 0 else f"{n_promoted} promoted parameter(s)"
     driver_note = f", driven by [{keep_driver}]" if keep_driver else ""
+    n_deriv = len(meta.get("derivatives", []))
+    deriv_note = (
+        ", no derivative graphs (use -d to compile jvp/jacobian)"
+        if n_deriv == 0
+        else f", {n_deriv} derivative pair(s)"
+    )
 
     def _rel(p: Path) -> Path:
         return p.relative_to(Path.cwd()) if p.is_relative_to(Path.cwd()) else p
 
     dev_list = ", ".join(device for device, _ in compiled)
     print(
-        f"Compiled '{model_name}' ({meta['type']}, {bake_note}{driver_note}) "
+        f"Compiled '{model_name}' ({meta['type']}, {bake_note}{driver_note}{deriv_note}) "
         f"for [{dev_list}] -> {_rel(artifact_dir)}"
     )
     print(f"  stub: {_rel(stub_path)}")

--- a/neml2/cli/aoti_export.py
+++ b/neml2/cli/aoti_export.py
@@ -89,7 +89,7 @@ from ..types import TensorWrapper
 #: shape (per-variable ``sub_batch_shape`` / ``sub_batch_labels`` /
 #: ``base_shape`` recorded so the C++ side can reshape per-variable slots).
 #:
-#: v4 (current): solver convergence / line-search configuration is no longer
+#: v4: solver convergence / line-search configuration is no longer
 #: baked into the metadata. The implicit-segment ``atol`` / ``rtol`` /
 #: ``miters`` / ``linesearch`` keys are gone -- the generated stub ``.i``
 #: carries a minimal ``[Solvers]`` block (the honored knobs only; the linear
@@ -98,25 +98,34 @@ from ..types import TensorWrapper
 #: predictor is unchanged: it still lowers to its own ``_predictor.pt2``
 #: graph with ``predictor_package`` / ``predictor_inputs`` /
 #: ``predictor_outputs`` metadata.
+#:
+#: v5: per-group / per-cell metadata for implicit segments
+#: (``unknown_group_infos`` / ``given_group_infos`` / ``residual_group_infos``
+#: / ``ift_cells``) so the C++ Newton loop + IFT composition runs per group.
+#:
+#: v6 (current): derivative graphs are opt-in. A new top-level ``derivatives``
+#: array lists the master ``[out, in]`` pairs the artifact supports (empty =>
+#: none; ``jvp`` / ``jacobian`` raise). A forward segment's ``jvp_package`` /
+#: ``jacobian_pairs`` and an implicit segment's ``ift_package`` are present
+#: only when some requested pair needs them, and each ``jacobian_pairs`` entry
+#: gains a ``batch_independent`` flag (the block does not depend on the dynamic
+#: batch, e.g. a constant elasticity tensor, so the runtime may carry / return
+#: it unbatched).
 # dependencies: aoti.schema_version
-AOTI_META_SCHEMA_VERSION = 5
+AOTI_META_SCHEMA_VERSION = 6
 
 
 def _var_size(type_cls) -> int:
     return prod(type_cls.BASE_SHAPE) if type_cls.BASE_SHAPE else 1
 
 
-def _enumerate_groups_and_cells(system) -> dict:
-    """Canonical group + cell metadata for nonlinear-system segments.
+def _enumerate_group_infos(system) -> dict:
+    """Canonical per-group metadata for nonlinear-system segments.
 
     Single source of truth for the iteration order in which group
-    tensors appear in RHS/NewtonStep/IFT forward signatures, and for
-    the row-major (rows outer, cols inner) order of IFT cells. The
+    tensors appear in RHS/NewtonStep/IFT forward signatures. The
     matching reader side in :mod:`neml2.es.implicit` walks the same
-    order via :func:`~neml2.es.implicit.enumerate_group_var_names` for
-    the per-group tensors and via a nested
-    ``for row in row_groups: for col in col_groups`` loop for IFT
-    cells.
+    order via :func:`~neml2.es.implicit.enumerate_group_var_names`.
 
     Returns a dict with:
 
@@ -129,10 +138,10 @@ def _enumerate_groups_and_cells(system) -> dict:
       ``per_var_info`` (a list of per-variable
       ``{name, var_size, base_shape, sub_batch_shape}`` dicts ordered
       as in the group).
-    - ``ift_cells``: per-(row_group, col_group) list of dicts with
-      ``row_group_idx``, ``col_group_idx``, ``row_structure``,
-      ``col_structure``, ``sub_batch_shape`` (the cell tensor's own
-      sub axes), ``row_vars``, ``col_vars``.
+
+    The per-(unknown, given) IFT Jacobian-pair metadata is built
+    separately in :func:`_compile_implicit_segment` (the IFT graph emits
+    per-pair blocks via ``AssembledMatrix.disassemble``).
     """
 
     def _var_info(layout, name):
@@ -172,40 +181,6 @@ def _enumerate_groups_and_cells(system) -> dict:
     given_group_infos = _group_infos(glayout)
     residual_group_infos = _group_infos(blayout)
 
-    ift_cells: list[dict] = []
-    for i, ugroup in enumerate(ulayout.groups):
-        u_structure = ulayout.structure[i]
-        u_sb = list(int(s) for s in ulayout.sub_batch_shape(ugroup[0])) if ugroup else []
-        for j, ggroup in enumerate(glayout.groups):
-            g_structure = glayout.structure[j]
-            g_sb = list(int(s) for s in glayout.sub_batch_shape(ggroup[0])) if ggroup else []
-            # Cell sub_batch_shape: which sub axes survive on the cell
-            # tensor. Paired BLOCK+BLOCK with matching sub: single
-            # shared sub. Single-side BLOCK: that side's sub. Both
-            # DENSE: no sub.
-            if u_structure == "block" and g_structure == "block":
-                if u_sb == g_sb:
-                    cell_sb = list(u_sb)
-                else:
-                    cell_sb = list(u_sb) + list(g_sb)
-            elif u_structure == "block":
-                cell_sb = list(u_sb)
-            elif g_structure == "block":
-                cell_sb = list(g_sb)
-            else:
-                cell_sb = []
-            ift_cells.append(
-                {
-                    "row_group_idx": i,
-                    "col_group_idx": j,
-                    "row_structure": u_structure,
-                    "col_structure": g_structure,
-                    "sub_batch_shape": cell_sb,
-                    "row_vars": [_var_info(ulayout, n) for n in ugroup],
-                    "col_vars": [_var_info(glayout, n) for n in ggroup],
-                }
-            )
-
     return {
         "unknown_groups": [list(g) for g in ulayout.groups],
         "given_groups": [list(g) for g in glayout.groups],
@@ -218,7 +193,6 @@ def _enumerate_groups_and_cells(system) -> dict:
         "unknown_group_infos": unknown_group_infos,
         "given_group_infos": given_group_infos,
         "residual_group_infos": residual_group_infos,
-        "ift_cells": ift_cells,
     }
 
 
@@ -994,10 +968,20 @@ class _ForwardJacobianModule(nn.Module):
     consumer (`jacobian.cpp:_run_implicit_segment_jacobian`).
     """
 
-    def __init__(self, model, promoted_qnames: set[str] | None = None) -> None:
+    def __init__(
+        self,
+        model,
+        promoted_qnames: set[str] | None = None,
+        selected_pairs: set[tuple[str, str]] | None = None,
+    ) -> None:
         super().__init__()
         self.model = model
         self.promoted_qnames = set(promoted_qnames or ())
+        # Local ``(out_var, in_var)`` pairs to emit. ``None`` means all pairs
+        # (legacy / all-pairs export); a set restricts the emitted trailing
+        # tensors (and matching ``jacobian_pairs`` metadata) to that subset, in
+        # the same row-major order — the C++ consumes them positionally.
+        self.selected_pairs = selected_pairs
         self.input_names = tuple(model.input_spec)
         self.output_names = tuple(model.output_spec)
         self.in_types = tuple(model.input_spec.values())
@@ -1021,10 +1005,23 @@ class _ForwardJacobianModule(nn.Module):
         for i in self.structural_idx:
             ti = typed_inputs[i]
             name = self.input_names[i]
+            # Seed with a size-1 dynamic-batch identity ``(K, 1..1, *sub, *base)``
+            # rather than expanding to the input's full dynamic batch. A
+            # Jacobian block that does not depend on the dynamic batch then
+            # stays size-1 along those axes (``(1, ...)``), exposing
+            # batch-independence (e.g. a constant elasticity tensor); a block
+            # that does depend broadcasts up to the real batch through the
+            # ordinary chain-rule arithmetic. Real sub-batch extents are kept
+            # so the per-site chain rule is unaffected. ``torch.export``
+            # preserves the static size-1 axis under a dynamic batch ``Dim``.
+            full_batch = tuple(ti.batch_shape)
+            sub_ndim = ti.sub_batch_ndim
+            dyn_ndim = len(full_batch) - sub_ndim
+            seed_batch = (1,) * dyn_ndim + full_batch[dyn_ndim:]
             seed[name] = {
                 name: _leading_k_identity_seed(
                     self.in_types[i],
-                    ti.batch_shape,
+                    seed_batch,
                     dtype=ti.dtype,
                     device=ti.device,
                 )
@@ -1039,6 +1036,11 @@ class _ForwardJacobianModule(nn.Module):
             out_base = tuple(int(s) for s in out_type.BASE_SHAPE)
             for i in self.structural_idx:
                 in_name = self.input_names[i]
+                if (
+                    self.selected_pairs is not None
+                    and (out_name, in_name) not in self.selected_pairs
+                ):
+                    continue
                 in_type = self.in_types[i]
                 in_base = tuple(int(s) for s in in_type.BASE_SHAPE)
                 block = v_out.get(out_name, {}).get(in_name)
@@ -1075,6 +1077,53 @@ def _segment_param_inputs(seg_spec: dict, promoted_qnames: set[str]) -> list[str
     """Return the promoted names that appear in this segment's input_spec,
     preserving the spec's declared order (which is the graph-call order)."""
     return [k for k in seg_spec if k in promoted_qnames]
+
+
+def _resolve_derivative_specs(
+    specs: Sequence[str],
+    output_names: Sequence[str],
+    structural_input_names: Sequence[str],
+) -> set[tuple[str, str]]:
+    """Resolve ``-d/--derivative`` ``OUT:IN`` specs into master (out, in) pairs.
+
+    Each spec must contain exactly one ``:``. Either side may be empty, meaning
+    "all" on that side: ``stress:strain`` is one pair; ``stress:`` is every
+    structural input of ``stress``; ``:strain`` is every output w.r.t.
+    ``strain``; ``:`` is all pairs. An empty *specs* yields an empty set — no
+    derivative graphs are compiled and the runtime ``jvp`` / ``jacobian`` raise.
+
+    Unknown output / input names raise ``ValueError`` listing the available
+    names. A promoted-parameter name on the input side is rejected the same way
+    (it is not a structural input and never appears in the Jacobian).
+    """
+    outputs = list(output_names)
+    inputs = list(structural_input_names)
+    pairs: set[tuple[str, str]] = set()
+    for spec in specs:
+        if ":" not in spec:
+            raise ValueError(f"--derivative {spec!r}: expected OUT:IN (use ':' for all pairs).")
+        out_part, in_part = (s.strip() for s in spec.split(":", 1))
+        if out_part == "":
+            sel_out = outputs
+        elif out_part in outputs:
+            sel_out = [out_part]
+        else:
+            raise ValueError(
+                f"--derivative {spec!r}: unknown output {out_part!r}; available outputs: {outputs}."
+            )
+        if in_part == "":
+            sel_in = inputs
+        elif in_part in inputs:
+            sel_in = [in_part]
+        else:
+            raise ValueError(
+                f"--derivative {spec!r}: unknown input {in_part!r}; "
+                f"available (structural) inputs: {inputs}."
+            )
+        for o in sel_out:
+            for i in sel_in:
+                pairs.add((o, i))
+    return pairs
 
 
 def _build_example_inputs(
@@ -1165,11 +1214,16 @@ def _compile_forward_segment(
     promoted_snapshots: dict[str, torch.Tensor] | None = None,
     shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] | None = None,
     dynamic_batch: bool = True,
-    emit_jvp: bool = True,
+    selected_pairs: set[tuple[str, str]] | None = None,
 ) -> tuple[str, list[dict], list[dict], str | None, list[str], list[dict] | None]:
     """Compile a single forward-shape model to ``<pkg_basename>.pt2`` plus,
-    when ``emit_jvp`` is True, ``<pkg_basename>_jvp.pt2`` carrying the flat
-    ``dout/din`` Jacobian.
+    when derivatives are requested, ``<pkg_basename>_jvp.pt2`` carrying the
+    per-(out, in) Jacobian blocks.
+
+    *selected_pairs* selects which local ``(out_var, in_var)`` blocks to emit:
+    ``None`` emits all pairs (legacy / all-pairs export); an empty set emits no
+    derivative graph at all (forward value only); a non-empty set restricts the
+    emitted blocks (and matching ``jacobian_pairs`` metadata) to that subset.
 
     Promoted parameters are routed through the leaf's NLParam machinery
     (see :func:`_promote_to_nl_params`), which expanded the leaf's
@@ -1210,11 +1264,23 @@ def _compile_forward_segment(
 
     jvp_pkg_name: str | None = None
     jacobian_pairs: list[dict] | None = None
-    if emit_jvp:
+    do_jvp = selected_pairs is None or len(selected_pairs) > 0
+    if do_jvp:
         # JVP wrapper differentiates along structural inputs only -- promoted
         # inputs aren't seeded so they contribute structural zeros via
         # the default chain rule's ``v.get(name, {})`` empty fallback.
-        jvp_module = _ForwardJacobianModule(exportable, promoted_qnames).to(device)
+        jvp_module = _ForwardJacobianModule(
+            exportable, promoted_qnames, selected_pairs=selected_pairs
+        ).to(device)
+        # Probe eagerly first (example dynamic batch is >=2 by construction, see
+        # _DEFAULT_EXAMPLE_SHAPE) to classify each emitted pair: a block whose
+        # dynamic-batch axes stay size-1 does not depend on the runtime batch
+        # (e.g. a constant elasticity tensor) and is recorded as
+        # ``batch_independent`` so the runtime can carry / return it unbatched.
+        with torch.no_grad():
+            probe = jvp_module(*example_inputs)
+        n_outs = len(jvp_module.output_names)
+        probe_pairs = list(probe[n_outs:])
         jvp_pkg_name = f"{pkg_basename}_jvp.pt2"
         compile_model(
             jvp_module, example_inputs, output_dir / jvp_pkg_name, dynamic_batch_dim=dynamic_dim
@@ -1225,9 +1291,21 @@ def _compile_forward_segment(
         structural_in_spec = _structural_inputs(model.input_spec, promoted_qnames)
         shapes_local = shapes or {}
         jacobian_pairs = []
+        k = 0
         for out_name, out_type in model.output_spec.items():
+            out_base_ndim = len(out_type.BASE_SHAPE)
             for in_name, in_type in structural_in_spec.items():
+                if selected_pairs is not None and (out_name, in_name) not in selected_pairs:
+                    continue
                 in_sub = shapes_local.get(in_name, ((), ()))[1]
+                in_base_ndim = len(in_type.BASE_SHAPE)
+                pair_t = probe_pairs[k]
+                # Pair shape is (*dyn, *sub, *out_base, *in_base); the leading
+                # dyn axes are size-1 iff this block is batch-independent.
+                dyn_ndim = max(pair_t.dim() - len(in_sub) - out_base_ndim - in_base_ndim, 0)
+                batch_independent = bool(dynamic_batch) and all(
+                    int(pair_t.shape[d]) == 1 for d in range(dyn_ndim)
+                )
                 jacobian_pairs.append(
                     {
                         "out_var": out_name,
@@ -1235,8 +1313,10 @@ def _compile_forward_segment(
                         "out_base_shape": [int(s) for s in out_type.BASE_SHAPE],
                         "in_base_shape": [int(s) for s in in_type.BASE_SHAPE],
                         "in_sub_batch_shape": [int(s) for s in in_sub],
+                        "batch_independent": batch_independent,
                     }
                 )
+                k += 1
 
     structural_in = _structural_inputs(model.input_spec, promoted_qnames)
     in_sb = {n: sub for n, (_, sub) in (shapes or {}).items() if sub}
@@ -1260,8 +1340,14 @@ def _export_forward(
     promoted_snapshots: dict[str, torch.Tensor],
     shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] | None = None,
     dynamic_batch: bool = True,
+    derivatives: set[tuple[str, str]] | None = None,
 ) -> dict:
-    """Export a forward-shape model as a single-segment composed artifact."""
+    """Export a forward-shape model as a single-segment composed artifact.
+
+    *derivatives* is the resolved master ``(out, in)`` pair set (empty = no
+    derivative graph). For a single forward segment the master pairs *are* the
+    segment-local pairs, so they pass straight through as ``selected_pairs``.
+    """
     (
         pkg_name,
         in_infos,
@@ -1278,6 +1364,7 @@ def _export_forward(
         promoted_snapshots=promoted_snapshots,
         shapes=shapes,
         dynamic_batch=dynamic_batch,
+        selected_pairs=derivatives if derivatives is not None else set(),
     )
     seg = {
         "kind": "forward",
@@ -1311,10 +1398,27 @@ def _compile_implicit_segment(
     *,
     shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] | None = None,
     dynamic_batch: bool = True,
+    emit_ift: bool = True,
+    selected_ift_pairs: set[tuple[str, str]] | None = None,
 ) -> dict:
     """Compile an ImplicitUpdate to ``<pkg_basename>_rhs.pt2`` + ``_step.pt2``
-    + ``_ift.pt2`` (+ optional ``_predictor.pt2``), returning the metadata
-    dict (without the outer ``"type"`` key — caller adds it).
+    (+ ``_ift.pt2`` when *emit_ift*) (+ optional ``_predictor.pt2``), returning
+    the metadata dict (without the outer ``"type"`` key — caller adds it).
+
+    *selected_ift_pairs* restricts the IFT graph to the requested
+    ``(unknown, given)`` pairs (``None`` = all). A requested pair whose unknown
+    or given is **sub-batched** (per-grain, e.g. crystal plasticity) is rejected
+    here with a clear compile-time error: the per-pair IFT consumer only supports
+    plain-batch (DENSE) pairs today, so e.g. a global-output / global-input
+    derivative of a crystal-plasticity model compiles, while a per-grain pair
+    fails fast at ``neml2-compile`` rather than at runtime.
+
+    ``rhs`` + ``step`` drive the forward Newton solve and are always compiled.
+    ``ift`` is the user-facing derivative graph (the implicit-function-theorem
+    sensitivity of the converged solution); it is compiled only when *emit_ift*
+    is True (i.e. some derivative was requested via ``-d``). When False, the
+    ``ift_package`` key is omitted and the runtime leaves the segment's IFT
+    loader null.
 
     Per-variable I/O at the AOTI graph boundary (v5+): each unknown,
     given, and residual is its own positional tensor in the segment
@@ -1336,7 +1440,26 @@ def _compile_implicit_segment(
 
     rhs = RHS(system).to(device)
     step = NewtonStep(system, solver.linear_solver).to(device)
-    ift = IFT(system, solver.linear_solver).to(device)
+    ift = IFT(system, solver.linear_solver, selected_pairs=selected_ift_pairs).to(device)
+
+    # Compile-time guard: the per-pair IFT consumer only supports plain-batch
+    # (DENSE) variable pairs. A requested pair touching a sub-batched (per-grain)
+    # unknown or given -- e.g. crystal plasticity's per-grain state -- is not yet
+    # supported; fail fast here with a clear message instead of at runtime. A
+    # global-output / global-input pair of the same model compiles fine.
+    if emit_ift:
+        for u, g in ift.emitted_pairs():
+            u_sub = tuple(system.ulayout.sub_batch_shape(u))
+            g_sub = tuple(system.glayout.sub_batch_shape(g))
+            if u_sub or g_sub:
+                bad = f"{u!r} (sub_batch {u_sub})" if u_sub else f"{g!r} (sub_batch {g_sub})"
+                raise NotImplementedError(
+                    f"neml2-compile: derivative ({u}, {g}) of implicit model involves the "
+                    f"sub-batched variable {bad}; compiled Jacobian/JVP for sub-batched "
+                    f"(per-grain) implicit variables is not yet supported. Request only "
+                    f"non-sub-batched output:input pairs (e.g. a global-to-global "
+                    f"derivative), or use eager mode for the per-grain sensitivities."
+                )
 
     # Build per-variable example inputs at the user-declared natural
     # shapes first, then pack them into per-group tensors via
@@ -1380,12 +1503,34 @@ def _compile_implicit_segment(
     dynamic_dim = 0 if dynamic_batch else None
     compile_model(rhs, example_inputs, output_dir / rhs_name, dynamic_batch_dim=dynamic_dim)
     compile_model(step, example_inputs, output_dir / step_name, dynamic_batch_dim=dynamic_dim)
-    compile_model(ift, example_inputs, output_dir / ift_name, dynamic_batch_dim=dynamic_dim)
+    # Per-(unknown, given) pair metadata for the IFT graph. The IFT emits one
+    # block per variable pair (via AssembledMatrix.disassemble), in
+    # ift.emitted_pairs() order, so the C++ runtime composes them against
+    # dg_dmaster exactly like a forward segment's per-pair Jacobian blocks. An
+    # IFT block is always batch-dependent (it is a function of the converged
+    # solution + the residual Jacobians), so ``batch_independent`` is False -- no
+    # eager probe is run (the IFT solve would be singular at the zero example
+    # point anyway). The sub-batch (BLOCK) guard above guarantees every emitted
+    # pair is plain-batch, so ``in_sub_batch_shape`` is empty.
+    ift_jacobian_pairs: list[dict] | None = None
+    if emit_ift:
+        ift_jacobian_pairs = [
+            {
+                "out_var": u,
+                "in_var": g,
+                "out_base_shape": [int(s) for s in system.ulayout.specs[u].BASE_SHAPE],
+                "in_base_shape": [int(s) for s in system.glayout.specs[g].BASE_SHAPE],
+                "in_sub_batch_shape": [],
+                "batch_independent": False,
+            }
+            for (u, g) in ift.emitted_pairs()
+        ]
+        compile_model(ift, example_inputs, output_dir / ift_name, dynamic_batch_dim=dynamic_dim)
 
     # Per-variable infos retained at the segment level as the source of
     # truth for the C++ runtime's per-variable state map (predictor
     # routing, downstream forward composition). Per-group / per-cell
-    # metadata sits alongside via _enumerate_groups_and_cells.
+    # metadata sits alongside via _enumerate_group_infos.
     def _var_info(layout, name: str) -> dict:
         type_cls = layout.type_of(name)
         sb = tuple(int(s) for s in layout.sub_batch_shape(name))
@@ -1404,7 +1549,7 @@ def _compile_implicit_segment(
     given_infos = [_var_info(system.glayout, n) for n in system.given_names]
     residual_infos = [_var_info(system.blayout, n) for n in system.residual_names]
 
-    group_meta = _enumerate_groups_and_cells(system)
+    group_meta = _enumerate_group_infos(system)
 
     # NB: solver convergence / line-search configuration (atol / rtol / miters /
     # linesearch) is NOT baked here (schema v4). The generated stub `.i` carries
@@ -1414,26 +1559,24 @@ def _compile_implicit_segment(
     seg: dict = {
         "rhs_package": rhs_name,
         "step_package": step_name,
-        "ift_package": ift_name,
         "unknowns": unknown_infos,
         "givens": given_infos,
         "residuals": residual_infos,
-        # v7 per-group / per-cell metadata. The C++ runtime consumes
-        # ``unknown_group_infos`` / ``given_group_infos`` /
-        # ``residual_group_infos`` for the per-group pack/unpack at
-        # solve start/end and for the per-group Newton loop arithmetic.
-        # ``ift_cells`` orders one entry per (row_group, col_group) cell
-        # of the IFT loader's output tuple, row-major (rows outer, cols
-        # inner) -- matches
-        # :func:`~neml2.es.implicit._matrix_to_per_cell_raws`.
+        # Per-group metadata drives the per-group pack/unpack at solve
+        # start/end and the per-group Newton loop arithmetic (rhs/step).
         "unknown_group_infos": group_meta["unknown_group_infos"],
         "given_group_infos": group_meta["given_group_infos"],
         "residual_group_infos": group_meta["residual_group_infos"],
-        "ift_cells": group_meta["ift_cells"],
         # Always empty under this iteration's constraint -- promotion inside
         # implicit segments is rejected above. Recorded for schema uniformity.
         "param_inputs": [],
     }
+    if emit_ift:
+        seg["ift_package"] = ift_name
+        # Per-(unknown, given) pair metadata for the IFT loader's output tuple,
+        # in the same order the IFT graph emits blocks. Consumed via the
+        # per-pair Jacobian composition (same path as a forward segment).
+        seg["jacobian_pairs"] = ift_jacobian_pairs
 
     # Predictor: compile as an extra graph if present. Promoted tail not
     # threaded here either (same reason as the rhs/step/ift block above; the
@@ -1463,6 +1606,7 @@ def _export_implicit(
     promoted_qnames: set[str],
     shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] | None = None,
     dynamic_batch: bool = True,
+    derivatives: set[tuple[str, str]] | None = None,
 ) -> dict:
     """Export an ImplicitUpdate as a single-segment composed artifact.
 
@@ -1470,9 +1614,28 @@ def _export_implicit(
     in :func:`_validate_promoted`, so ``promoted_qnames`` only affects the
     metadata's master ``inputs`` filter here -- the trace itself is identical
     to the no-promotion case.
+
+    *derivatives* is the resolved master pair set; the single implicit segment
+    emits its IFT graph iff any pair was requested (the IFT couples every given
+    to every unknown, so a single requested pair pulls in the whole graph).
     """
+    # Map the requested master (out, in) pairs to local (unknown, given) IFT
+    # pairs. For a single ImplicitUpdate the outputs are the unknowns and the
+    # structural inputs are givens, so this is a direct filter.
+    master_pairs = derivatives or set()
+    sys = inner.system
+    selected_ift_pairs = {
+        (o, i) for (o, i) in master_pairs if o in sys.unknown_names and i in sys.given_names
+    }
     seg = _compile_implicit_segment(
-        inner, model_name, output_dir, device, shapes=shapes, dynamic_batch=dynamic_batch
+        inner,
+        model_name,
+        output_dir,
+        device,
+        shapes=shapes,
+        dynamic_batch=dynamic_batch,
+        emit_ift=bool(selected_ift_pairs),
+        selected_ift_pairs=selected_ift_pairs,
     )
     structural_in = _structural_inputs(model.input_spec, promoted_qnames)
     in_sb = {n: sub for n, (_, sub) in (shapes or {}).items() if sub}
@@ -1553,6 +1716,7 @@ def _export_composed(
     promoted_snapshots: dict[str, torch.Tensor],
     shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] | None = None,
     dynamic_batch: bool = True,
+    derivatives: set[tuple[str, str]] | None = None,
 ) -> dict:
     """Export a ComposedModel containing ImplicitUpdate children as multiple
     .pt2 artifacts.
@@ -1560,10 +1724,20 @@ def _export_composed(
     Each non-implicit run of leaves becomes one forward segment .pt2; each
     ImplicitUpdate becomes the standard rhs/step (+ optional predictor) set.
     The C++ ``AOTIModel`` orchestrates the segments in order.
+
+    *derivatives* is the resolved master ``(out, in)`` pair set. Forward
+    segments emit only the local pairs that lie on a dependency path between a
+    requested master input and a requested master output (a forward segment with
+    no such pair emits no derivative graph); an implicit segment emits its IFT
+    graph iff it lies on any requested path. Correctness gate: a local pair is
+    kept whenever its row reaches a requested output AND its column is reachable
+    from a requested input — never dropping a pair that carries a requested
+    sensitivity. Empty *derivatives* → no derivative graphs anywhere.
     """
     from ..models.common import ComposedModel, ImplicitUpdate
 
     segments = _partition_into_segments(model)
+    master_pairs = derivatives or set()
 
     # Each segment's ComposedModel wrapper would otherwise hide variables that
     # are consumed inside the segment, dropping inter-segment data flow on the
@@ -1587,12 +1761,43 @@ def _export_composed(
         return set(payload.input_spec)  # type: ignore[attr-defined]
 
     seg_output_sets = [_seg_outputs(payload) for _, payload in segments]
+    seg_input_sets = [_seg_inputs(payload) for _, payload in segments]
     downstream_demands: list[set[str]] = [set() for _ in segments]
     for j, (_, payload_j) in enumerate(segments):
         inputs_j = _seg_inputs(payload_j)
         for i in range(j):
             downstream_demands[i] |= inputs_j
     master_outs = set(model.output_spec)
+
+    # --- Dependency reachability for the per-segment derivative prune ---
+    # ``reach[V]`` = master (structural) inputs that can flow into V; ``canreach
+    # [V]`` = master outputs V can reach. Each segment is modelled as "every
+    # output depends on every input" (the all-pairs internal Jacobian; an
+    # implicit segment's IFT couples every given to every unknown), which is the
+    # correct conservative data-flow model. A local pair (o, i) carries a
+    # requested master sensitivity (o_m, i_m) iff ``i_m ∈ reach[i]`` and
+    # ``o_m ∈ canreach[o]`` — keep it iff that holds for some requested pair.
+    structural_master_in = set(_structural_inputs(model.input_spec, promoted_qnames))
+    reach: dict[str, set[str]] = {i: {i} for i in structural_master_in}
+    for sin, sout in zip(seg_input_sets, seg_output_sets, strict=True):
+        flowed: set[str] = set()
+        for x in sin:
+            flowed |= reach.get(x, set())
+        for o in sout:
+            reach[o] = reach.get(o, set()) | flowed
+    canreach: dict[str, set[str]] = {o: {o} for o in master_outs}
+    for sin, sout in zip(reversed(seg_input_sets), reversed(seg_output_sets), strict=True):
+        reachable: set[str] = set()
+        for o in sout:
+            reachable |= canreach.get(o, set())
+        for x in sin:
+            canreach[x] = canreach.get(x, set()) | reachable
+
+    def _keep_local_pair(o: str, i: str) -> bool:
+        return any(
+            (i_m in reach.get(i, ())) and (o_m in canreach.get(o, ()))
+            for (o_m, i_m) in master_pairs
+        )
 
     seg_metas: list[dict] = []
     for i, (kind, payload) in enumerate(segments):
@@ -1606,6 +1811,15 @@ def _export_composed(
             needed = (master_outs | downstream_demands[i]) & seg_output_sets[i]
             extra = sorted(needed)
             seg_model = ComposedModel(payload, additional_outputs=extra).to(device)
+            # Local pairs to emit: those on a dependency path between a requested
+            # master input and a requested master output (empty -> no jvp graph).
+            seg_struct_in = _structural_inputs(seg_model.input_spec, promoted_qnames)
+            seg_selected = {
+                (o, i)
+                for o in seg_model.output_spec
+                for i in seg_struct_in
+                if _keep_local_pair(o, i)
+            }
             (
                 pkg_name,
                 in_infos,
@@ -1622,6 +1836,7 @@ def _export_composed(
                 promoted_snapshots=promoted_snapshots,
                 shapes=shapes,
                 dynamic_batch=dynamic_batch,
+                selected_pairs=seg_selected,
             )
             seg_entry = {
                 "kind": "forward",
@@ -1638,6 +1853,17 @@ def _export_composed(
             # payload is the ImplicitUpdate leaf.
             impl_model = payload
             assert isinstance(impl_model, ImplicitUpdate)
+            # Local (unknown, given) IFT pairs on a requested dependency path:
+            # the given reachable from a requested master input AND the unknown
+            # reaching a requested master output. Drives both whether to emit the
+            # IFT graph and which per-pair blocks it emits.
+            isys = impl_model.system
+            selected_ift_pairs = {
+                (u, g)
+                for u in isys.unknown_names
+                for g in isys.given_names
+                if _keep_local_pair(u, g)
+            }
             seg = _compile_implicit_segment(
                 impl_model,
                 basename,
@@ -1645,6 +1871,8 @@ def _export_composed(
                 device,
                 shapes=shapes,
                 dynamic_batch=dynamic_batch,
+                emit_ift=bool(selected_ift_pairs),
+                selected_ift_pairs=selected_ift_pairs,
             )
             seg_metas.append({"kind": "implicit", **seg})
 
@@ -1674,6 +1902,7 @@ def export_model_for_aoti(
     promoted: set[str] | list[str] | tuple[str, ...] = (),
     example_batch_shape: dict[str, str] | str | None = None,
     dynamic_batch: bool | None = None,
+    derivatives: Sequence[str] = (),
     pre: Sequence[str] = (),
     additional_args: tuple[str, ...] = (),
 ) -> dict:
@@ -1719,6 +1948,15 @@ def export_model_for_aoti(
         a baked parameter has a rank ≥ 1 shape that would specialize the
         dynamic dim. When ``None`` (default), the HIT setting -- or ``True``
         if unset -- applies.
+    derivatives:
+        Sequence of ``OUT:IN`` derivative specs (the ``-d/--derivative`` CLI
+        surface). Each requests a Jacobian/JVP block for that output-input
+        pair; omitting a side selects all on that side (``stress:`` = all
+        inputs of stress, ``:strain`` = all outputs wrt strain, ``:`` = all
+        pairs). Empty (the default) compiles **no** derivative graphs, and the
+        runtime ``jvp`` / ``jacobian`` raise until recompiled with ``-d``.
+        Resolved against the model's outputs + structural inputs after
+        promotion (see :func:`_resolve_derivative_specs`).
     pre:
         HIT snippets prepended before parsing (same semantics as
         ``nmhit.parse_file``'s ``pre`` arg). Use to bind ``${var}``
@@ -1776,6 +2014,14 @@ def export_model_for_aoti(
     _promote_to_nl_params(model, promoted_names)
     promoted_qnames = set(promoted_names)
 
+    # Resolve -d/--derivative specs into the master (out, in) pair set, against
+    # the post-promotion outputs + structural inputs (promoted parameters never
+    # appear in the Jacobian). Empty => no derivative graphs are compiled.
+    structural_input_names = list(_structural_inputs(model.input_spec, promoted_qnames))
+    master_pairs = _resolve_derivative_specs(
+        derivatives, list(model.output_spec), structural_input_names
+    )
+
     # Freeze any remaining nn.Parameter to a persistent buffer so torch.export
     # bakes it into the graph instead of lifting it as a graph input. Promoted
     # entries are already gone from _parameters so they're skipped naturally.
@@ -1806,6 +2052,7 @@ def export_model_for_aoti(
             promoted_qnames=promoted_qnames,
             shapes=resolved_shapes,
             dynamic_batch=dynamic_batch,
+            derivatives=master_pairs,
         )
     elif _contains_implicit(inner):
         meta = _export_composed(
@@ -1817,6 +2064,7 @@ def export_model_for_aoti(
             promoted_snapshots=promoted_snapshots,
             shapes=resolved_shapes,
             dynamic_batch=dynamic_batch,
+            derivatives=master_pairs,
         )
     else:
         meta = _export_forward(
@@ -1828,6 +2076,7 @@ def export_model_for_aoti(
             promoted_snapshots=promoted_snapshots,
             shapes=resolved_shapes,
             dynamic_batch=dynamic_batch,
+            derivatives=master_pairs,
         )
 
     # v2 top-level additions: device + dtype are baked into the artifact;
@@ -1835,6 +2084,17 @@ def export_model_for_aoti(
     meta["device"] = device
     meta["dtype"] = dtype
     meta["parameters"] = _parameter_infos(promoted_snapshots, origin)
+    # Master (out, in) derivative pairs the artifact supports, in deterministic
+    # (output-order, input-order) order so the runtime iterates rows/cols
+    # consistently. Empty => no derivative graphs (jvp/jacobian raise).
+    out_order = {n: k for k, n in enumerate(model.output_spec)}
+    in_order = {n: k for k, n in enumerate(structural_input_names)}
+    meta["derivatives"] = [
+        [o, i]
+        for (o, i) in sorted(
+            master_pairs, key=lambda p: (out_order.get(p[0], 0), in_order.get(p[1], 0))
+        )
+    ]
 
     _write_meta(output_dir / f"{model_name}_meta.json", meta)
     return meta

--- a/neml2/csrc/aoti/Model.cpp
+++ b/neml2/csrc/aoti/Model.cpp
@@ -102,7 +102,7 @@ Model::Impl::Impl(const std::filesystem::path & meta_path,
   // lack the master base_shape; we fail loudly instead of misinterpreting them.
   // dependencies: aoti.schema_version (NOT auto-managed -- C++ `//` comments are
   // not scanned by scripts/dep_manager.py; keep this literal in sync by hand).
-  static constexpr int kSupportedSchemaVersion = 5;
+  static constexpr int kSupportedSchemaVersion = 6;
   const auto schema_version = meta.value("schema_version", 0);
   _assert(schema_version == kSupportedSchemaVersion,
           "aoti::Model: metadata schema_version=",
@@ -162,6 +162,9 @@ Model::Impl::Impl(const std::filesystem::path & meta_path,
     const auto sz = v["var_size"].get<int>();
     _input_names.push_back(name);
     _input_base_shapes.push_back(v["base_shape"].get<std::vector<int64_t>>());
+    _input_sub_batch_shapes.push_back(v.contains("sub_batch_shape")
+                                          ? v["sub_batch_shape"].get<std::vector<int64_t>>()
+                                          : std::vector<int64_t>{});
     _input_offsets.push_back(_input_total_size);
     _input_sizes.push_back(sz);
     _input_total_size += sz;
@@ -174,6 +177,42 @@ Model::Impl::Impl(const std::filesystem::path & meta_path,
     _output_names.push_back(v["name"].get<std::string>());
     _output_base_shapes.push_back(v["base_shape"].get<std::vector<int64_t>>());
     _output_sizes.push_back(v["var_size"].get<int>());
+  }
+
+  // Master (out, in) derivative pairs the artifact supports (v6+). Absent /
+  // empty => no derivative graphs compiled; jvp() / jacobian() raise. Kept in
+  // the metadata's (output-order, input-order) so the public maps iterate
+  // rows/cols consistently.
+  if (meta.contains("derivatives"))
+    for (const auto & pr : meta["derivatives"])
+    {
+      auto o = pr.at(0).get<std::string>();
+      auto i = pr.at(1).get<std::string>();
+      _deriv_by_out[o].push_back(i);
+      _derivatives.emplace_back(std::move(o), std::move(i));
+    }
+
+  // Narrowed "dense auxiliary B matrix" layout: the distinct requested input
+  // directions, in `_input_names` order, with their column offsets in the
+  // narrowed carrier. The multi-segment dense Jacobian seeds + composes over
+  // only these columns instead of every master input.
+  {
+    std::map<std::string, std::size_t> in_idx;
+    for (std::size_t j = 0; j < _input_names.size(); ++j)
+      in_idx[_input_names[j]] = j;
+    std::vector<char> seen(_input_names.size(), 0);
+    for (const auto & [o, i] : _derivatives)
+    {
+      const auto j = in_idx.at(i);
+      if (!seen[j])
+      {
+        seen[j] = 1;
+        _req_input_offset[i] = _req_total_size;
+        _req_input_size[i] = _input_sizes[j];
+        _req_inputs.push_back(i);
+        _req_total_size += _input_sizes[j];
+      }
+    }
   }
 
   // Promoted parameters (v2; empty in the common fully-baked case).
@@ -272,6 +311,7 @@ Model::Impl::Impl(const std::filesystem::path & meta_path,
             pi.in_base_shape = p["in_base_shape"].get<std::vector<int64_t>>();
           if (p.contains("in_sub_batch_shape"))
             pi.in_sub_batch_shape = p["in_sub_batch_shape"].get<std::vector<int64_t>>();
+          pi.batch_independent = p.value("batch_independent", false);
           seg.jacobian_pairs.push_back(std::move(pi));
         }
       }
@@ -316,30 +356,25 @@ Model::Impl::Impl(const std::filesystem::path & meta_path,
       for (const auto & g : seg_meta["residual_group_infos"])
         seg.residual_groups.push_back(parse_group_info(g));
 
-      // v7 per-(row_group, col_group) IFT cell metadata.
-      // ift_cells[k] corresponds to ift_outs[k] in row-major order.
-      if (seg_meta.contains("ift_cells"))
+      // Per-(unknown, given) IFT Jacobian-pair metadata (v6). The IFT loader
+      // emits one block per pair (via AssembledMatrix.disassemble), in
+      // jacobian_pairs order, so the runtime composes them against dg_dmaster
+      // exactly like a forward segment's per-pair blocks.
+      if (seg_meta.contains("jacobian_pairs"))
       {
-        for (const auto & c : seg_meta["ift_cells"])
+        for (const auto & p : seg_meta["jacobian_pairs"])
         {
-          Segment::CellInfo ci;
-          ci.row_group_idx = c["row_group_idx"].get<int64_t>();
-          ci.col_group_idx = c["col_group_idx"].get<int64_t>();
-          ci.row_structure = c["row_structure"].get<std::string>();
-          ci.col_structure = c["col_structure"].get<std::string>();
-          if (c.contains("sub_batch_shape"))
-            ci.sub_batch_shape = c["sub_batch_shape"].get<std::vector<int64_t>>();
-          if (c.contains("row_vars"))
-          {
-            for (const auto & v : c["row_vars"])
-              ci.row_vars.push_back(parse_var_info(v));
-          }
-          if (c.contains("col_vars"))
-          {
-            for (const auto & v : c["col_vars"])
-              ci.col_vars.push_back(parse_var_info(v));
-          }
-          seg.ift_cells.push_back(std::move(ci));
+          Segment::PairInfo pi;
+          pi.out_var = p["out_var"].get<std::string>();
+          pi.in_var = p["in_var"].get<std::string>();
+          if (p.contains("out_base_shape"))
+            pi.out_base_shape = p["out_base_shape"].get<std::vector<int64_t>>();
+          if (p.contains("in_base_shape"))
+            pi.in_base_shape = p["in_base_shape"].get<std::vector<int64_t>>();
+          if (p.contains("in_sub_batch_shape"))
+            pi.in_sub_batch_shape = p["in_sub_batch_shape"].get<std::vector<int64_t>>();
+          pi.batch_independent = p.value("batch_independent", false);
+          seg.jacobian_pairs.push_back(std::move(pi));
         }
       }
       // Solver convergence / line-search configuration is no longer baked into

--- a/neml2/csrc/aoti/internal.h
+++ b/neml2/csrc/aoti/internal.h
@@ -153,25 +153,6 @@ struct Model::Impl
     std::vector<GroupInfo> given_groups;
     std::vector<GroupInfo> residual_groups;
 
-    /// Per-(row_group, col_group) cell metadata for the IFT loader's
-    /// output tuple. ``ift_cells[k]`` corresponds to ``ift_outs[k]`` --
-    /// row-major (rows outer, cols inner) over ``unknown_groups`` ×
-    /// ``given_groups``. Each cell carries the row/col group indices,
-    /// the per-side structure ("block" / "dense"), the cell's own
-    /// sub_batch_shape (paired or single-side), and the per-(rvar, cvar)
-    /// VarInfo lists for slicing sub-cells out of the cell tensor.
-    struct CellInfo
-    {
-      int64_t row_group_idx = 0;
-      int64_t col_group_idx = 0;
-      std::string row_structure;
-      std::string col_structure;
-      std::vector<int64_t> sub_batch_shape;
-      std::vector<VarInfo> row_vars;
-      std::vector<VarInfo> col_vars;
-    };
-    std::vector<CellInfo> ift_cells;
-
     /// Per-(out_var, in_var) Jacobian-pair metadata for the
     /// forward-segment Jacobian loader output tuple. Ordered row-major
     /// (outputs outer, structural inputs inner). The C++ Jacobian
@@ -185,6 +166,11 @@ struct Model::Impl
       std::vector<int64_t> out_base_shape;
       std::vector<int64_t> in_base_shape;
       std::vector<int64_t> in_sub_batch_shape;
+      /// True when this block does not depend on the dynamic batch (e.g. a
+      /// constant stiffness tensor). The compiled graph emits it with a static
+      /// size-1 leading dynamic-batch axis; the single-forward-segment Jacobian
+      /// path squeezes that axis and returns the block unbatched.
+      bool batch_independent = false;
     };
     std::vector<PairInfo> jacobian_pairs;
 
@@ -259,12 +245,12 @@ struct Model::Impl
 
   /// Compose an implicit segment's IFT into `dstate`: run the IFT loader on
   /// the converged per-group ``u_solved_groups`` + per-group ``g_groups``,
-  /// receive one tensor per ``(row_group, col_group)`` cell of
-  /// ``-du_dg`` (in row-major order matching ``seg.ift_cells``), and
-  /// accumulate per-cell matmul contributions into per-unknown
-  /// ``du_dmaster`` slots. Each cell's matmul kind is dispatched by
-  /// ``(row_structure, col_structure)``; per-grain BLOCK + BLOCK cells
-  /// stay compact throughout, no N² dense materialisation.
+  /// receive one block per ``(unknown, given)`` pair of ``-du_dg`` (in
+  /// ``seg.jacobian_pairs`` order, the disassemble of the IFT matrix), and
+  /// accumulate each block's matmul against ``dstate[given]`` into the
+  /// ``dstate[unknown]`` slot -- the same per-pair Jacobian composition a
+  /// forward segment uses. (BLOCK / per-grain unknowns are rejected with a
+  /// clear "not yet implemented" error pending the sub-batch IFT path.)
   void _run_implicit_segment_jacobian(const Segment & seg,
                                       const std::vector<at::Tensor> & u_solved_groups,
                                       const std::vector<at::Tensor> & g_groups,
@@ -287,12 +273,17 @@ struct Model::Impl
   /// has already passed for this input.
   std::vector<int64_t> _batch_shape_of(std::size_t idx, const at::Tensor & t) const;
 
-  /// Internal flat Jacobian: outputs + the assembled dense `(*B, Σout, Σin)`
-  /// matrix (rows in `_output_names` order, cols in `_input_names` order). The
-  /// public `jacobian()` reshapes this into unflattened variable-pair blocks;
-  /// `jvp()` contracts it directly as `J @ v`.
-  std::pair<std::map<std::string, at::Tensor>, at::Tensor>
-  _jacobian_flat(const std::map<std::string, at::Tensor> & inputs) const;
+  /// Compose the master Jacobian carrier: returns the output values plus the
+  /// per-variable `dstate` map, where `dstate[var]` is `(*common_dyn,
+  /// var_folded, M_req)` -- the variable's sensitivity to the requested input
+  /// columns (`M_req`), its own sub-batch folded into `var_folded`. `jacobian()`
+  /// slices each requested output's block and reshapes to `(*B, *out_base,
+  /// *in_base)`; `jvp()` contracts the requested input columns with the
+  /// tangents. (Returning the map -- not a single catted `(*B, Σout, M_req)` --
+  /// keeps per-output offsets correct when outputs have heterogeneous folded
+  /// sizes, e.g. a per-grain output alongside a global one.)
+  std::pair<std::map<std::string, at::Tensor>, std::map<std::string, at::Tensor>>
+  _jacobian_dstate(const std::map<std::string, at::Tensor> & inputs) const;
 
   // The per-group Newton iteration + line-search reductions now live in
   // newton.{h,cpp} (driven through the NonlinearSystem abstraction);
@@ -313,6 +304,47 @@ struct Model::Impl
   std::vector<std::string> _output_names;
   std::vector<std::vector<int64_t>> _output_base_shapes;
   std::vector<int> _output_sizes;
+
+  // Per-master-input sub-batch shapes (empty when plain-batch). The dense
+  // Jacobian carrier seeds `dstate[var] = (*common_dyn, var_folded, M_req)` --
+  // a shared dynamic batch (NOT the first input's full leading shape) with each
+  // variable's own sub-batch axes folded into the storage dim -- so a
+  // heterogeneous mix of global and per-grain inputs composes correctly.
+  std::vector<std::vector<int64_t>> _input_sub_batch_shapes;
+
+  // Master (out, in) derivative pairs the artifact supports, in the order the
+  // metadata recorded them (output-order, input-order). Empty => no derivative
+  // graphs were compiled; jvp() / jacobian() raise. `_deriv_by_out` is a cache
+  // mapping each covered output to its requested inputs for O(1) assembly.
+  std::vector<std::pair<std::string, std::string>> _derivatives;
+  std::map<std::string, std::vector<std::string>> _deriv_by_out;
+
+  // The "dense auxiliary B matrix" narrowing (multi-segment path): the dense
+  // chain-rule carrier (`dstate`) and flat Jacobian carry columns for only the
+  // *requested* input directions, not every master input. `_req_inputs` is the
+  // distinct requested inputs in `_input_names` order; `_req_input_offset` /
+  // `_req_total_size` are their column offsets / total width in that narrowed
+  // matrix.
+  std::vector<std::string> _req_inputs;
+  std::map<std::string, int64_t> _req_input_offset;
+  std::map<std::string, int64_t> _req_input_size;
+  int64_t _req_total_size = 0;
+
+  /// Single-forward-segment Jacobian fast path: run the segment's jvp loader once
+  /// and return (outputs, per-pair blocks) directly (no dense flat-J), squeezing
+  /// the static size-1 dynamic-batch axis of batch-independent blocks so they
+  /// come back unbatched. Only valid when there is exactly one Forward segment
+  /// with a jvp loader.
+  std::pair<std::map<std::string, at::Tensor>, VariablePairJacobian>
+  _forward_pair_blocks(const std::map<std::string, at::Tensor> & inputs) const;
+
+  /// True iff the artifact is a single forward segment carrying a jvp loader --
+  /// the case the per-pair fast path (unbatched batch-independent return) covers.
+  bool _is_single_forward_jac() const
+  {
+    return _segments.size() == 1 && _segments.front().kind == SegmentKind::Forward &&
+           static_cast<bool>(_segments.front().jvp_loader);
+  }
 
   // Owned state -- only the runtime-flexible (promoted) parameters live here.
   // Baked entries are constants inside the AOTI graphs and have no C++-side

--- a/neml2/csrc/aoti/jacobian.cpp
+++ b/neml2/csrc/aoti/jacobian.cpp
@@ -38,19 +38,102 @@ Model::Impl::_init_dstate(const at::TensorOptions & options,
                           at::IntArrayRef batch_shape,
                           std::map<std::string, at::Tensor> & dstate) const
 {
-  std::vector<int64_t> shape_vec(batch_shape.begin(), batch_shape.end());
+  // Narrowed carrier: columns span only the *requested* input directions
+  // (`_req_total_size`), so the composition's matmuls and the IFT solve's RHS
+  // ("B matrix") are sized to the derivatives the user asked for. An input that
+  // is never on the `in` side of a requested pair gets an all-zero block (it is
+  // never differentiated, so it contributes nothing downstream).
+  //
+  // `batch_shape` is the FIRST input's full leading shape `(*dyn, *sub0)`. Each
+  // dstate block carries the shared dynamic batch `*common_dyn` (with the first
+  // input's own sub-batch axes stripped) and the per-variable folded storage
+  // `sub_total_k * base_k`, so a heterogeneous mix of global and per-grain
+  // inputs each gets the right shape (the first input being per-grain must not
+  // impose its grain axis on a global input's sensitivity).
+  const std::size_t in0_sub =
+      _input_sub_batch_shapes.empty() ? 0 : _input_sub_batch_shapes[0].size();
+  std::vector<int64_t> common_dyn(batch_shape.begin(),
+                                  batch_shape.end() - static_cast<int64_t>(in0_sub));
   for (std::size_t k = 0; k < _input_names.size(); ++k)
   {
-    const auto s_k = _input_sizes[k];
-    const auto c_k = _input_offsets[k];
-    shape_vec.push_back(s_k);
-    shape_vec.push_back(_input_total_size);
+    int64_t sub_total = 1;
+    for (auto s : _input_sub_batch_shapes[k])
+      sub_total *= s;
+    const int64_t folded = sub_total * _input_sizes[k];
+    std::vector<int64_t> shape_vec = common_dyn;
+    shape_vec.push_back(folded);
+    shape_vec.push_back(_req_total_size);
     auto block = at::zeros(shape_vec, options);
-    block.narrow(/*dim=*/-1, /*start=*/c_k, /*length=*/s_k).copy_(at::eye(s_k, options));
-    shape_vec.pop_back();
-    shape_vec.pop_back();
+    auto it = _req_input_offset.find(_input_names[k]);
+    if (it != _req_input_offset.end())
+    {
+      // Requested inputs are plain-batch (the compile-time guard rejects
+      // sub-batched requested pairs), so folded == _req_input_size here.
+      const auto rs = _req_input_size.at(_input_names[k]);
+      block.narrow(/*dim=*/-1, /*start=*/it->second, /*length=*/rs).copy_(at::eye(rs, options));
+    }
     dstate[_input_names[k]] = block;
   }
+}
+
+std::pair<std::map<std::string, at::Tensor>, VariablePairJacobian>
+Model::Impl::_forward_pair_blocks(const std::map<std::string, at::Tensor> & inputs) const
+{
+  const auto & seg = _segments.front();
+
+  // Pack + validate caller inputs into a state map (canonical (*B, *base)).
+  std::map<std::string, at::Tensor> state;
+  for (std::size_t k = 0; k < _input_names.size(); ++k)
+  {
+    const auto & n = _input_names[k];
+    auto it = inputs.find(n);
+    _assert(it != inputs.end(), "aoti::Model::jacobian: missing required input '", n, "'.");
+    _validate_input_shape(k, it->second);
+    state[n] = it->second.contiguous();
+  }
+
+  // Run the jvp loader once: it returns (*outputs, *per-pair blocks) where the
+  // blocks are row-major over seg.jacobian_pairs (the requested pairs).
+  std::vector<at::Tensor> loader_in;
+  loader_in.reserve(seg.fwd_inputs.size() + seg.param_inputs.size());
+  for (const auto & name : seg.fwd_inputs)
+    loader_in.push_back(state.at(name).contiguous());
+  for (auto & p : _gather_params(seg.param_inputs))
+    loader_in.push_back(std::move(p));
+  const auto outs = seg.jvp_loader->run(loader_in);
+
+  const std::size_t n_outs = seg.fwd_outputs.size();
+  const std::size_t n_pairs = seg.jacobian_pairs.size();
+  _assert(outs.size() == n_outs + n_pairs,
+          "aoti::Model::jacobian: jvp loader returned ",
+          outs.size(),
+          " tensors, expected ",
+          n_outs + n_pairs,
+          ".");
+
+  std::map<std::string, at::Tensor> outputs;
+  for (std::size_t i = 0; i < n_outs; ++i)
+    outputs[seg.fwd_outputs[i]] = outs[i];
+
+  VariablePairJacobian jac;
+  for (std::size_t k = 0; k < n_pairs; ++k)
+  {
+    const auto & p = seg.jacobian_pairs[k];
+    auto block = outs[n_outs + k]; // (*dyn, *in_sub, *out_base, *in_base)
+    if (p.batch_independent)
+    {
+      // A batch-independent block traced to a static size-1 dynamic-batch axis;
+      // drop the leading size-1 axes so it is returned unbatched (broadcasts
+      // against any runtime batch). The metadata flag gates this, so a
+      // state-dependent block that happens to run at batch=1 is never squeezed.
+      const int64_t trail = static_cast<int64_t>(p.in_sub_batch_shape.size() +
+                                                 p.out_base_shape.size() + p.in_base_shape.size());
+      while (block.dim() > trail && block.size(0) == 1)
+        block = block.squeeze(0);
+    }
+    jac[p.out_var][p.in_var] = block.contiguous();
+  }
+  return {std::move(outputs), std::move(jac)};
 }
 
 void
@@ -243,9 +326,10 @@ Model::Impl::_run_implicit_segment_jacobian(const Segment & seg,
                                             const std::vector<at::Tensor> & g_groups,
                                             std::map<std::string, at::Tensor> & dstate) const
 {
-  // IFT loader signature: (*u_groups, *g_groups, [params...]) -> *cells.
-  // Each cell is one (row_group, col_group) entry of -du_dg in row-major
-  // order (matches seg.ift_cells).
+  // IFT loader signature: (*u_groups, *g_groups, [params...]) -> *blocks, one
+  // per (unknown, given) pair in seg.jacobian_pairs order (the disassemble of
+  // -du/dg). Compose each block against dstate[given] into dstate[unknown] --
+  // the same per-pair Jacobian path a forward segment uses.
   std::vector<at::Tensor> ift_in;
   ift_in.reserve(u_solved_groups.size() + g_groups.size() + seg.param_inputs.size());
   for (const auto & t : u_solved_groups)
@@ -255,190 +339,73 @@ Model::Impl::_run_implicit_segment_jacobian(const Segment & seg,
   for (auto & p : _gather_params(seg.param_inputs))
     ift_in.push_back(std::move(p));
 
-  const auto ift_outs = seg.ift_loader->run(ift_in);
-  _assert(ift_outs.size() == seg.ift_cells.size(),
+  const auto blocks = seg.ift_loader->run(ift_in);
+  const std::size_t n_pairs = seg.jacobian_pairs.size();
+  _assert(blocks.size() == n_pairs,
           "aoti::Model: IFT loader returned ",
-          ift_outs.size(),
-          " tensors, expected ",
-          seg.ift_cells.size(),
-          " (one per cell).");
+          blocks.size(),
+          " blocks, expected ",
+          n_pairs,
+          " (one per (unknown, given) pair).");
 
-  // Master_ndim from dstate of any given var (all dstate entries share
-  // the trailing M dim).
+  // Master dim M + batch shape from any given's dstate (all share trailing M).
   _assert(!seg.givens.empty(),
           "aoti::Model: implicit-segment IFT has no givens; cannot infer master_ndim.");
-  auto first_dg_it = dstate.find(seg.givens[0].name);
+  auto first_dg_it = dstate.find(seg.givens.front().name);
   _assert(first_dg_it != dstate.end(),
           "aoti::Model: dstate missing given '",
-          seg.givens[0].name,
+          seg.givens.front().name,
           "' at IFT composition time.");
-  const int64_t M = first_dg_it->second.size(-1);
-
-  // Batch shape (leading dims of any cell's tensor, before its sub +
-  // base axes). Pick cell 0 to source it.
-  const auto & cell0 = ift_outs[0];
-  const auto & cinfo0 = seg.ift_cells[0];
-  const int64_t cell0_trail =
-      static_cast<int64_t>(cinfo0.sub_batch_shape.size()) + 2; // sub + 2 base
-  _assert(cell0.dim() >= cell0_trail,
-          "aoti::Model: IFT cell tensor ndim=",
-          cell0.dim(),
-          " < expected trail=",
-          cell0_trail);
-  const int64_t batch_ndim = cell0.dim() - cell0_trail;
+  const auto & dg_ref = first_dg_it->second;
+  const int64_t M = dg_ref.size(-1);
   std::vector<int64_t> batch_shape;
-  batch_shape.reserve(static_cast<std::size_t>(batch_ndim));
-  for (int64_t d = 0; d < batch_ndim; ++d)
-    batch_shape.push_back(cell0.size(d));
+  for (int64_t d = 0; d < dg_ref.dim() - 2; ++d)
+    batch_shape.push_back(dg_ref.size(d));
 
-  // Per-unknown accumulator at the converged-segment shape:
-  // (*B, u.var_size, M). Mirrors what the old flat-matmul produced so
-  // downstream forward composition sees an identical layout.
+  // Per-unknown accumulator (*B, u.var_size, M). Unknowns are not seeded in
+  // _init_dstate (they are produced by composition), so start at zero.
   std::map<std::string, at::Tensor> du_acc;
   for (const auto & u : seg.unknowns)
   {
     std::vector<int64_t> shape = batch_shape;
     shape.push_back(u.var_size);
     shape.push_back(M);
-    du_acc[u.name] = at::zeros(shape, cell0.options());
+    du_acc[u.name] = at::zeros(shape, dg_ref.options());
   }
 
-  // Iterate cells; for each, slice per-(rvar, cvar) sub-cells on the
-  // last 2 dims by base offsets, dispatch matmul kind by
-  // (row_structure, col_structure), accumulate into du_acc[rvar].
-  for (std::size_t k = 0; k < ift_outs.size(); ++k)
+  for (std::size_t k = 0; k < n_pairs; ++k)
   {
-    const auto & cell_t = ift_outs[k];
-    const auto & cinfo = seg.ift_cells[k];
-    const bool row_block = (cinfo.row_structure == "block");
-    const bool col_block = (cinfo.col_structure == "block");
+    const auto & blk = blocks[k];
+    const auto & pinfo = seg.jacobian_pairs[k];
 
-    int64_t r_off = 0;
-    for (const auto & rv : cinfo.row_vars)
-    {
-      int64_t r_base = 1;
-      for (auto s : rv.base_shape)
-        r_base *= s;
-      int64_t r_sub_total = 1;
-      for (auto s : rv.sub_batch_shape)
-        r_sub_total *= s;
+    auto din_it = dstate.find(pinfo.in_var);
+    _assert(din_it != dstate.end(),
+            "aoti::Model: IFT needs dstate['",
+            pinfo.in_var,
+            "'] which is missing.");
+    const auto & din = din_it->second;
 
-      int64_t c_off = 0;
-      for (const auto & cv : cinfo.col_vars)
-      {
-        int64_t c_base = 1;
-        for (auto s : cv.base_shape)
-          c_base *= s;
-        int64_t c_sub_total = 1;
-        for (auto s : cv.sub_batch_shape)
-          c_sub_total *= s;
+    // ``disassemble`` blocks carry exactly two trailing storage axes
+    // ``(*B, [sub], out_storage, in_storage)`` (out_storage == unknown var_size,
+    // in_storage == given var_size). For a plain batch the block is
+    // ``(*B, out_storage, in_storage)`` and ``dstate[given]`` is
+    // ``(*B, in_storage, M)``, so the IFT composition is a direct matmul. A
+    // BLOCK (per-grain) side adds an intermediate sub axis that needs the paired
+    // / cross-grain reduction -- deferred (rejected) until the sub-batch IFT
+    // path lands.
+    _assert(pinfo.in_sub_batch_shape.empty() &&
+                blk.dim() == static_cast<int64_t>(batch_shape.size()) + 2,
+            "aoti::Model: sub-batch (BLOCK) IFT Jacobian for (",
+            pinfo.out_var,
+            ", ",
+            pinfo.in_var,
+            ") is not yet implemented.");
 
-        // Slice sub-cell from cell_t (last-2 dims).
-        auto sub_cell = cell_t.narrow(/*dim=*/-2, /*start=*/r_off, /*length=*/r_base)
-                            .narrow(/*dim=*/-1, /*start=*/c_off, /*length=*/c_base);
-
-        // Pick the matching dg_dmaster view for cv. dstate[cv.name]
-        // has shape (*B, cv.var_size, M). For a BLOCK col group, view
-        // as (*B, *cv.sub, *cv.base_flat, M) but we want (*B, sub, c_base, M)
-        // with sub_total flat across cv's sub axes; for DENSE col, keep
-        // (*B, cv.var_size, M).
-        auto dg_it = dstate.find(cv.name);
-        _assert(dg_it != dstate.end(),
-                "aoti::Model: IFT consumer needs dstate['",
-                cv.name,
-                "'] which is missing.");
-        const auto & dg = dg_it->second;
-
-        // Contribution shape: (*B, *cell_sub_for_row, r_base, M).
-        at::Tensor contribution;
-        if (row_block && col_block)
-        {
-          // PAIRED BLOCK + BLOCK: sub axes on row and col are the same
-          // (single sub axis on cell tensor). dg viewed as
-          // (*B, c_sub_total, c_base, M).
-          std::vector<int64_t> dg_target = batch_shape;
-          for (auto s : cv.sub_batch_shape)
-            dg_target.push_back(s);
-          dg_target.push_back(c_base);
-          dg_target.push_back(M);
-          auto dg_view = dg.reshape(dg_target);
-          // sub_cell shape: (*B, *cell_sub, r_base, c_base); dg_view
-          // (*B, *cv.sub, c_base, M); matmul → (*B, *sub, r_base, M).
-          contribution = at::matmul(sub_cell, dg_view);
-        }
-        else if (row_block && !col_block)
-        {
-          // BLOCK row, DENSE col: sub_cell (*B, *row_sub, r_base,
-          // c_folded). dg (*B, c_folded, M). Broadcast dg with
-          // singleton sub axes.
-          std::vector<int64_t> dg_target = batch_shape;
-          for (std::size_t s = 0; s < cinfo.sub_batch_shape.size(); ++s)
-            dg_target.push_back(1);
-          dg_target.push_back(c_base);
-          dg_target.push_back(M);
-          auto dg_view = dg.reshape(dg_target);
-          contribution = at::matmul(sub_cell, dg_view);
-        }
-        else if (!row_block && col_block)
-        {
-          // DENSE row, BLOCK col: sub_cell (*B, *col_sub, r_folded,
-          // c_base). dg (*B, *cv.sub, c_base, M). matmul → (*B,
-          // *col_sub, r_folded, M); SUM over the col_sub axes (cross-
-          // grain reduction into the global row).
-          std::vector<int64_t> dg_target = batch_shape;
-          for (auto s : cv.sub_batch_shape)
-            dg_target.push_back(s);
-          dg_target.push_back(c_base);
-          dg_target.push_back(M);
-          auto dg_view = dg.reshape(dg_target);
-          auto per_col = at::matmul(sub_cell, dg_view);
-          std::vector<int64_t> sum_dims;
-          const int64_t col_sub_ndim = static_cast<int64_t>(cv.sub_batch_shape.size());
-          for (int64_t d = per_col.dim() - 2 - col_sub_ndim; d < per_col.dim() - 2; ++d)
-            sum_dims.push_back(d);
-          contribution = per_col.sum(sum_dims);
-        }
-        else
-        {
-          // DENSE row, DENSE col: standard matmul.
-          contribution = at::matmul(sub_cell, dg);
-        }
-
-        // Accumulate into du_acc[rv.name] at shape (*B, rv.var_size, M).
-        // For BLOCK row, contribution carries row sub axes; reshape to
-        // (*B, sub_total * r_base, M) so it lays out var-shaped slabs.
-        at::Tensor flat_contribution;
-        if (row_block)
-        {
-          std::vector<int64_t> target = batch_shape;
-          target.push_back(r_sub_total * r_base);
-          target.push_back(M);
-          flat_contribution = contribution.reshape(target);
-          (void)c_sub_total; // not used in this branch
-        }
-        else
-        {
-          flat_contribution = contribution;
-        }
-
-        // r_var_size = (BLOCK row: r_sub_total * r_base; DENSE row:
-        // r_base). du_acc is keyed by rv.name with shape (*B,
-        // rv.var_size, M).
-        int64_t r_var_size = (row_block) ? (r_sub_total * r_base) : r_base;
-        _assert(r_var_size == rv.var_size,
-                "aoti::Model: IFT row-var size mismatch for '",
-                rv.name,
-                "'");
-        du_acc[rv.name] = du_acc[rv.name] + flat_contribution;
-
-        c_off += c_base;
-      }
-      r_off += r_base;
-    }
+    auto contrib = at::matmul(blk, din); // (*B, out_storage, M)
+    du_acc[pinfo.out_var] = du_acc[pinfo.out_var] + contrib;
   }
 
-  // Write final per-unknown du into dstate. Negation: cells carry
-  // -du_dg already (Python side returns -du_dg.tensors[i][j]).
+  // Negation already applied Python-side (IFT emits -du/dg).
   for (const auto & u : seg.unknowns)
     dstate[u.name] = du_acc[u.name].contiguous();
 }

--- a/neml2/csrc/aoti/ops.cpp
+++ b/neml2/csrc/aoti/ops.cpp
@@ -122,8 +122,8 @@ Model::Impl::forward(const std::map<std::string, at::Tensor> & inputs) const
   return outputs;
 }
 
-std::pair<std::map<std::string, at::Tensor>, at::Tensor>
-Model::Impl::_jacobian_flat(const std::map<std::string, at::Tensor> & inputs) const
+std::pair<std::map<std::string, at::Tensor>, std::map<std::string, at::Tensor>>
+Model::Impl::_jacobian_dstate(const std::map<std::string, at::Tensor> & inputs) const
 {
   // Pack state from caller inputs (validating each is canonical (*B, *base)).
   std::map<std::string, at::Tensor> state;
@@ -149,77 +149,100 @@ Model::Impl::_jacobian_flat(const std::map<std::string, at::Tensor> & inputs) co
   std::map<std::string, at::Tensor> dstate;
   _init_dstate(ref.options(), batch_shape, dstate);
 
+  int64_t batch_numel = 1;
+  for (auto s : batch_shape_vec)
+    batch_numel *= s;
   for (const auto & seg : _segments)
   {
     if (seg.kind == SegmentKind::Forward)
     {
-      _assert(static_cast<bool>(seg.jvp_loader),
-              "aoti::Model::jacobian: forward segment is missing its jvp_package loader. "
-              "Re-export via `neml2-compile`.");
-      _run_forward_segment_jacobian(seg, state, dstate);
+      if (seg.jvp_loader)
+        _run_forward_segment_jacobian(seg, state, dstate);
+      else
+      {
+        // Off-path forward segment (pruned by `-d` selection): its outputs are
+        // on no requested derivative path, so advance `state` via the value
+        // graph and zero-fill its outputs' dstate. The zeros are never consumed
+        // by a kept pair -- only discarded in the final per-pair slice.
+        _run_forward_segment(seg, state);
+        for (const auto & oname : seg.fwd_outputs)
+        {
+          const auto & val = state.at(oname);
+          const int64_t osz = batch_numel > 0 ? val.numel() / batch_numel : 0;
+          std::vector<int64_t> shp = batch_shape_vec;
+          shp.push_back(osz);
+          shp.push_back(_req_total_size);
+          dstate[oname] = at::zeros(shp, ref.options());
+        }
+      }
     }
     else
     {
       std::vector<at::Tensor> u_solved_groups;
       std::vector<at::Tensor> g_groups;
       _run_implicit_segment(seg, state, u_solved_groups, g_groups);
-      _assert(static_cast<bool>(seg.ift_loader),
-              "aoti::Model::jacobian: implicit segment is missing its ift_package loader. "
-              "Re-export via `neml2-compile`.");
-      _run_implicit_segment_jacobian(seg, u_solved_groups, g_groups, dstate);
+      if (seg.ift_loader)
+        _run_implicit_segment_jacobian(seg, u_solved_groups, g_groups, dstate);
+      else
+        // Off-path implicit segment: forward solve already advanced `state`;
+        // zero-fill the unknowns' dstate (never consumed by a kept pair).
+        for (const auto & u : seg.unknowns)
+        {
+          std::vector<int64_t> shp = batch_shape_vec;
+          shp.push_back(u.var_size);
+          shp.push_back(_req_total_size);
+          dstate[u.name] = at::zeros(shp, ref.options());
+        }
     }
   }
 
-  // Pack outputs and the assembled flat J of shape (*B, sum(out), sum(in)).
+  // Pack the output values; the caller slices `dstate[out]` per requested pair.
   std::map<std::string, at::Tensor> outputs;
   for (const auto & n : _output_names)
     outputs[n] = state.at(n);
 
-  std::vector<at::Tensor> out_blocks;
-  out_blocks.reserve(_output_names.size());
-  for (const auto & n : _output_names)
-  {
-    auto it = dstate.find(n);
-    _assert(it != dstate.end(),
-            "aoti::Model::jacobian: dstate missing entry for master output '",
-            n,
-            "'.");
-    out_blocks.push_back(it->second);
-  }
-  auto J = at::cat(out_blocks, /*dim=*/-2).contiguous();
-
-  return {std::move(outputs), std::move(J)};
+  return {std::move(outputs), std::move(dstate)};
 }
 
 std::pair<std::map<std::string, at::Tensor>, VariablePairJacobian>
 Model::Impl::jacobian(const std::map<std::string, at::Tensor> & inputs) const
 {
-  auto [outputs, J] = _jacobian_flat(inputs); // J: (*B, Σout, Σin)
+  _assert(!_derivatives.empty(),
+          "aoti::Model::jacobian: this artifact was compiled with no derivative graphs. "
+          "Recompile with `neml2-compile -d OUT:IN` (e.g. `-d :` for all pairs).");
 
-  // The batch shape is everything in J ahead of the trailing (Σout, Σin) axes.
-  std::vector<int64_t> batch(J.sizes().begin(), J.sizes().end() - 2);
+  // Single forward segment: return the compiled per-pair blocks directly (no
+  // dense flat-J round-trip), so a batch-independent block (e.g. a constant
+  // stiffness tensor) is returned unbatched at its natural (*out_base, *in_base).
+  if (_is_single_forward_jac())
+    return _forward_pair_blocks(inputs);
 
-  // Slice the flat J into unflattened variable-pair blocks: row range
-  // [out_offset, +out_var) x col range [in_offset, +in_var), reshaped to
-  // (*B, *out_base, *in_base).
-  VariablePairJacobian jac;
-  int64_t row = 0;
+  auto [outputs, dstate] = _jacobian_dstate(inputs); // dstate[var]: (*B, var_folded, M_req)
+
+  std::map<std::string, std::size_t> out_idx, in_idx;
   for (std::size_t i = 0; i < _output_names.size(); ++i)
+    out_idx[_output_names[i]] = i;
+  for (std::size_t j = 0; j < _input_names.size(); ++j)
+    in_idx[_input_names[j]] = j;
+
+  // Slice each requested output's dstate block directly (no flat cat): take the
+  // input's column band [req_offset, +in_var) and reshape to
+  // (*B, *out_base, *in_base). Per-output slicing keeps offsets correct even
+  // with heterogeneous folded output sizes.
+  VariablePairJacobian jac;
+  for (const auto & [o, i] : _derivatives)
   {
-    const auto out_sz = _output_sizes[i];
-    auto & row_map = jac[_output_names[i]];
-    for (std::size_t j = 0; j < _input_names.size(); ++j)
-    {
-      const auto in_sz = _input_sizes[j];
-      auto block = J.narrow(-2, row, out_sz).narrow(-1, _input_offsets[j], in_sz);
-      std::vector<int64_t> block_shape = batch;
-      block_shape.insert(
-          block_shape.end(), _output_base_shapes[i].begin(), _output_base_shapes[i].end());
-      block_shape.insert(
-          block_shape.end(), _input_base_shapes[j].begin(), _input_base_shapes[j].end());
-      row_map[_input_names[j]] = block.reshape(block_shape).contiguous();
-    }
-    row += out_sz;
+    const auto & blk = dstate.at(o); // (*B, out_folded, M_req)
+    std::vector<int64_t> batch(blk.sizes().begin(), blk.sizes().end() - 2);
+    const auto ji = in_idx.at(i);
+    auto col = blk.narrow(-1, _req_input_offset.at(i), _req_input_size.at(i));
+    std::vector<int64_t> block_shape = batch;
+    block_shape.insert(block_shape.end(),
+                       _output_base_shapes[out_idx.at(o)].begin(),
+                       _output_base_shapes[out_idx.at(o)].end());
+    block_shape.insert(
+        block_shape.end(), _input_base_shapes[ji].begin(), _input_base_shapes[ji].end());
+    jac[o][i] = col.reshape(block_shape).contiguous();
   }
 
   return {std::move(outputs), std::move(jac)};
@@ -229,52 +252,60 @@ std::pair<std::map<std::string, at::Tensor>, std::map<std::string, at::Tensor>>
 Model::Impl::jvp(const std::map<std::string, at::Tensor> & inputs,
                  const std::map<std::string, at::Tensor> & tangents) const
 {
-  // Compose against the internal flat Jacobian: J @ v where v is the canonical
-  // input tangent stacked in declared order. One well-tested path drives both
-  // jacobian() and jvp(); only the final pack differs (here we unflatten the
-  // result to each output's base shape).
-  auto [outputs, J] = _jacobian_flat(inputs); // J: (*B, Σout, Σin)
-  std::vector<int64_t> batch(J.sizes().begin(), J.sizes().end() - 2);
+  _assert(!_derivatives.empty(),
+          "aoti::Model::jvp: this artifact was compiled with no derivative graphs. "
+          "Recompile with `neml2-compile -d OUT:IN` (e.g. `-d :` for all pairs).");
 
-  // Pack the tangent vector v: shape (*B, Σin). Each tangent is canonical
-  // (*B, *in_base) and flattens to its var_size slot; a missing tangent is zero.
-  std::vector<at::Tensor> v_parts;
-  v_parts.reserve(_input_names.size());
-  for (std::size_t k = 0; k < _input_names.size(); ++k)
+  // Per covered output, contract its requested input column bands with the
+  // matching tangents. Outputs in no requested pair are omitted; inputs not
+  // paired with an output contribute nothing (they were not differentiated).
+  auto [outputs, dstate] = _jacobian_dstate(inputs); // dstate[var]: (*B, var_folded, M_req)
+
+  std::map<std::string, std::size_t> out_idx, in_idx;
+  for (std::size_t i = 0; i < _output_names.size(); ++i)
+    out_idx[_output_names[i]] = i;
+  for (std::size_t j = 0; j < _input_names.size(); ++j)
+    in_idx[_input_names[j]] = j;
+
+  // Per-input tangent column (*B, in_var_size, 1) at the given batch; a missing
+  // tangent is zero.
+  auto tangent_col = [&](const std::string & iname,
+                         const std::vector<int64_t> & batch,
+                         const at::TensorOptions & opts) -> at::Tensor
   {
-    const auto & n = _input_names[k];
-    const auto sz = _input_sizes[k];
-    auto it = tangents.find(n);
-    at::Tensor part;
+    const auto ji = in_idx.at(iname);
+    const auto sz = _input_sizes[ji];
+    auto it = tangents.find(iname);
     if (it != tangents.end())
     {
-      _validate_input_shape(k, it->second); // same canonical (*B, *base) contract
-      auto shape = _batch_shape_of(k, it->second);
+      _validate_input_shape(ji, it->second); // canonical (*B, *base) contract
+      auto shape = _batch_shape_of(ji, it->second);
       shape.push_back(sz); // flatten trailing base axes into the var_size slot
-      part = it->second.reshape(shape).to(_dtype);
+      return it->second.reshape(shape).to(_dtype).unsqueeze(-1).contiguous();
     }
-    else
-    {
-      std::vector<int64_t> shape = batch;
-      shape.push_back(sz);
-      part = at::zeros(shape, J.options());
-    }
-    v_parts.push_back(part.contiguous());
-  }
-  auto v = at::cat(v_parts, /*dim=*/-1).unsqueeze(-1); // (*B, Σin, 1)
-  auto Jv = at::matmul(J, v).squeeze(-1);              // (*B, Σout)
-
-  // Split Jv per output and unflatten to the output's natural (*B, *out_base).
-  std::map<std::string, at::Tensor> jvp_outputs;
-  int64_t offset = 0;
-  for (std::size_t i = 0; i < _output_names.size(); ++i)
-  {
-    const auto sz = _output_sizes[i];
-    auto flat = Jv.narrow(-1, offset, sz); // (*B, out_var_size)
     std::vector<int64_t> shape = batch;
-    shape.insert(shape.end(), _output_base_shapes[i].begin(), _output_base_shapes[i].end());
-    jvp_outputs[_output_names[i]] = flat.reshape(shape).contiguous();
-    offset += sz;
+    shape.push_back(sz);
+    shape.push_back(1);
+    return at::zeros(shape, opts);
+  };
+
+  std::map<std::string, at::Tensor> jvp_outputs;
+  for (const auto & [o, ins] : _deriv_by_out)
+  {
+    const auto & blk = dstate.at(o); // (*B, out_folded, M_req)
+    std::vector<int64_t> batch(blk.sizes().begin(), blk.sizes().end() - 2);
+    at::Tensor acc;
+    for (const auto & iname : ins)
+    {
+      auto col = blk.narrow(-1, _req_input_offset.at(iname), _req_input_size.at(iname));
+      auto contrib = at::matmul(col, tangent_col(iname, batch, blk.options())).squeeze(-1);
+      acc = acc.defined() ? acc + contrib : contrib;
+    }
+    std::vector<int64_t> shape = batch;
+    shape.insert(shape.end(),
+                 _output_base_shapes[out_idx.at(o)].begin(),
+                 _output_base_shapes[out_idx.at(o)].end());
+    jvp_outputs[o] = acc.reshape(shape).contiguous();
   }
 
   return {std::move(outputs), std::move(jvp_outputs)};

--- a/neml2/csrc/dispatchers/DispatchedModel.cpp
+++ b/neml2/csrc/dispatchers/DispatchedModel.cpp
@@ -239,7 +239,22 @@ struct DispatchedModel::Impl
       outs.push_back(std::move(c.first));
       jparts.push_back(std::move(c.second));
     }
-    return {cat_batch(outs), cat_batch_nested(jparts)};
+    // Per-pair reassembly is base-shape-aware so a batch-independent block
+    // (returned unbatched by the single-forward fast path) is passed through
+    // rather than concatenated across chunks. Build name -> base-ndim maps from
+    // the active model's declared layout.
+    std::map<std::string, int64_t> out_base_ndim, in_base_ndim;
+    {
+      const auto & onames = _active->output_names();
+      const auto & oshapes = _active->output_base_shapes();
+      for (std::size_t k = 0; k < onames.size(); ++k)
+        out_base_ndim[onames[k]] = static_cast<int64_t>(oshapes[k].size());
+      const auto & inames = _active->input_names();
+      const auto & ishapes = _active->input_base_shapes();
+      for (std::size_t k = 0; k < inames.size(); ++k)
+        in_base_ndim[inames[k]] = static_cast<int64_t>(ishapes[k].size());
+    }
+    return {cat_batch(outs), cat_batch_nested(jparts, out_base_ndim, in_base_ndim)};
   }
 
   void set_solver_config(const SolverConfig & config)

--- a/neml2/csrc/dispatchers/batch_chunk.h
+++ b/neml2/csrc/dispatchers/batch_chunk.h
@@ -171,4 +171,56 @@ cat_batch_nested(
     }
   return out;
 }
+
+/// Concatenate per-chunk nested Jacobians, passing batch-independent blocks
+/// through instead of concatenating them.
+///
+/// A batch-independent block (e.g. a constant stiffness tensor) is returned by
+/// the per-device model unbatched at its natural ``(*out_base, *in_base)`` shape
+/// -- identical across every chunk. Concatenating it along dim 0 would corrupt
+/// it (stacking N identical copies and mislabelling an ``out_base`` axis as
+/// batch). We detect it structurally: a block with exactly
+/// ``out_base_ndim[o] + in_base_ndim[i]`` dims carries no leading batch axis, so
+/// take the first chunk's copy; any block with more dims is batched and is
+/// concatenated as usual.
+inline std::map<std::string, std::map<std::string, at::Tensor>>
+cat_batch_nested(
+    const std::vector<std::map<std::string, std::map<std::string, at::Tensor>>> & chunks,
+    const std::map<std::string, int64_t> & out_base_ndim,
+    const std::map<std::string, int64_t> & in_base_ndim)
+{
+  _assert(!chunks.empty(), "cat_batch_nested: no chunks to concatenate.");
+  if (chunks.size() == 1)
+    return chunks.front();
+
+  std::map<std::string, std::map<std::string, at::Tensor>> out;
+  for (const auto & [o, row] : chunks.front())
+    for (const auto & [i, first] : row)
+    {
+      const int64_t trail = out_base_ndim.at(o) + in_base_ndim.at(i);
+      if (first.dim() == trail)
+      {
+        // Batch-independent: identical across chunks, take the first.
+        out[o].emplace(i, first);
+        continue;
+      }
+      std::vector<at::Tensor> parts;
+      parts.reserve(chunks.size());
+      for (const auto & c : chunks)
+      {
+        auto oit = c.find(o);
+        _assert(oit != c.end(), "cat_batch_nested: output '", o, "' missing from a chunk.");
+        auto iit = oit->second.find(i);
+        _assert(iit != oit->second.end(),
+                "cat_batch_nested: block ('",
+                o,
+                "', '",
+                i,
+                "') missing from a chunk.");
+        parts.push_back(iit->second);
+      }
+      out[o].emplace(i, at::cat(parts, /*dim=*/0));
+    }
+  return out;
+}
 } // namespace neml2::aoti

--- a/neml2/csrc/dispatchers/batch_chunk.h
+++ b/neml2/csrc/dispatchers/batch_chunk.h
@@ -136,42 +136,6 @@ to_device_nested(const std::map<std::string, std::map<std::string, at::Tensor>> 
   return out;
 }
 
-/// Concatenate per-chunk nested variable-pair Jacobians block by block along
-/// dim 0. Keyed by the first chunk's (out, in) structure; every chunk must
-/// carry the same blocks.
-inline std::map<std::string, std::map<std::string, at::Tensor>>
-cat_batch_nested(
-    const std::vector<std::map<std::string, std::map<std::string, at::Tensor>>> & chunks)
-{
-  _assert(!chunks.empty(), "cat_batch_nested: no chunks to concatenate.");
-  if (chunks.size() == 1)
-    return chunks.front();
-
-  std::map<std::string, std::map<std::string, at::Tensor>> out;
-  for (const auto & [o, row] : chunks.front())
-    for (const auto & [i, first] : row)
-    {
-      (void)first;
-      std::vector<at::Tensor> parts;
-      parts.reserve(chunks.size());
-      for (const auto & c : chunks)
-      {
-        auto oit = c.find(o);
-        _assert(oit != c.end(), "cat_batch_nested: output '", o, "' missing from a chunk.");
-        auto iit = oit->second.find(i);
-        _assert(iit != oit->second.end(),
-                "cat_batch_nested: block ('",
-                o,
-                "', '",
-                i,
-                "') missing from a chunk.");
-        parts.push_back(iit->second);
-      }
-      out[o].emplace(i, at::cat(parts, /*dim=*/0));
-    }
-  return out;
-}
-
 /// Concatenate per-chunk nested Jacobians, passing batch-independent blocks
 /// through instead of concatenating them.
 ///

--- a/neml2/es/implicit.py
+++ b/neml2/es/implicit.py
@@ -32,12 +32,12 @@ Three ``nn.Module`` graphs, one per piece of the Newton orchestration:
 - :class:`NewtonStep` -- ``(*u_groups, *g_groups) -> (*du_groups, *b_groups)``
                          (Newton step direction + residual at the current
                          iterate).
-- :class:`IFT`        -- ``(*u_groups, *g_groups) -> *cells`` (implicit
+- :class:`IFT`        -- ``(*u_groups, *g_groups) -> *blocks`` (implicit
                          function theorem Jacobian at the converged state,
-                         emitted as one typed cell per (row_group,
-                         col_group) entry of the AssembledMatrix; the
-                         C++ runtime consumes cells with per-cell matmul
-                         accumulation against ``dg_dmaster``).
+                         emitted as one block per ``(unknown, given)`` pair
+                         via ``AssembledMatrix.disassemble``; the C++ runtime
+                         composes each block against ``dg_dmaster`` with the
+                         same per-pair path a forward segment uses).
 
 All three segments take and return per-group raw tensors at the natural
 ``AssembledVector`` / ``AssembledMatrix`` group shape -- BLOCK groups
@@ -69,7 +69,7 @@ def enumerate_group_var_names(layout: AxisLayout) -> tuple[tuple[str, ...], ...]
 
     Single source of truth for the order in which group tensors are
     enumerated in segment forward signatures and in metadata
-    emission. See :func:`~neml2.cli.aoti_export._enumerate_groups_and_cells`
+    emission. See :func:`~neml2.cli.aoti_export._enumerate_group_infos`
     for the matching emitter side.
     """
     return tuple(tuple(g) for g in layout.groups)
@@ -227,21 +227,6 @@ def _vector_to_per_group_raws(vec: AssembledVector) -> tuple[torch.Tensor, ...]:
     return tuple(t.data for t in vec.tensors)  # noqa: data-ok AOTI
 
 
-def _matrix_to_per_cell_raws(mat: AssembledMatrix) -> tuple[torch.Tensor, ...]:
-    """Extract per-(row_group, col_group) raw tensors from an AssembledMatrix.
-
-    Row-major order (rows outer, cols inner). Matches
-    :func:`~neml2.cli.aoti_export._enumerate_groups_and_cells` on the
-    metadata side -- both must use the same nested loop or the schema
-    cells will desync from the loader output positions.
-    """
-    cells: list[torch.Tensor] = []
-    for i in range(mat.row_layout.ngroup):
-        for j in range(mat.col_layout.ngroup):
-            cells.append(mat.tensors[i][j].data)  # noqa: data-ok AOTI
-    return tuple(cells)
-
-
 class RHS(_SystemModule):
     """Exportable residual graph.
 
@@ -288,23 +273,42 @@ class IFT(_SystemModule):
     """Exportable IFT Jacobian $du/dg = -A^{-1} B$ for a converged
     :class:`ImplicitUpdate`.
 
-    Contract: ``(*u_groups, *g_groups) -> *cells`` where each cell is one
-    ``(row_group_i, col_group_j)`` entry of ``-du_dg`` in row-major
-    order (matches
-    :func:`~neml2.cli.aoti_export._enumerate_groups_and_cells`). Each
-    cell stays at its natural per-(row_structure, col_structure) shape;
-    no fold to dense.
+    Contract: ``(*u_groups, *g_groups) -> *blocks`` where each block is one
+    per-variable-pair ``(unknown, given)`` entry of ``-du_dg``, emitted in
+    ``unknown_names`` (outer) × ``given_names`` (inner) order -- matching the
+    ``jacobian_pairs`` metadata in
+    :func:`~neml2.cli.aoti_export._compile_implicit_segment`.
 
-    The C++ runtime consumes the cells via per-cell matmul against the
-    matching ``dg_dmaster`` segment, accumulating into per-unknown
-    ``du_dmaster`` slots. Per-grain BLOCK + BLOCK cells stay
-    block-diagonal-compact throughout -- the runtime never materialises
-    the N² dense block.
+    The equation system assembles the dense ``A`` / ``B`` (via the model's
+    per-variable chain rule), applies the IFT solve, then ``disassemble()``\\ s
+    the resulting :class:`~neml2.es.assembled.AssembledMatrix` into
+    per-(unknown, given) blocks. Each block keeps its natural per-structure
+    shape (``"dense"`` -> ``(*B, u_storage, g_storage)``; a BLOCK side stays
+    block-diagonal-compact, no N² fold). The C++ runtime then composes these
+    blocks against ``dg_dmaster`` exactly like a forward segment's per-pair
+    Jacobian blocks -- one uniform per-pair path for forward and implicit.
     """
 
-    def __init__(self, system: ModelNonlinearSystem, linear_solver) -> None:
+    def __init__(
+        self,
+        system: ModelNonlinearSystem,
+        linear_solver,
+        selected_pairs: set[tuple[str, str]] | None = None,
+    ) -> None:
         super().__init__(system)
         self._linear_solver = linear_solver
+        # Local (unknown, given) pairs to emit; ``None`` = all. Emitted in
+        # unknown x given order to match the metadata.
+        self._selected_pairs = selected_pairs
+
+    def emitted_pairs(self) -> list[tuple[str, str]]:
+        """The (unknown, given) pairs this graph emits, in emission order."""
+        return [
+            (u, g)
+            for u in self.unknown_names
+            for g in self.given_names
+            if self._selected_pairs is None or (u, g) in self._selected_pairs
+        ]
 
     def forward(self, *args: torch.Tensor) -> tuple[torch.Tensor, ...]:
         state = self._state_from_per_group_args(args)
@@ -313,7 +317,13 @@ class IFT(_SystemModule):
         A = self._assembled_matrix(self.ulayout, v_out, output_state)
         B = self._assembled_matrix(self.glayout, v_out, output_state)
         du_dg = self._linear_solver.solve(A, B)
-        return _matrix_to_per_cell_raws(-du_dg)
+        cells = (-du_dg).disassemble().cells
+        # Emit per-(unknown, given) raw blocks in the canonical order. The
+        # ``.data`` reads are the legitimate AOTI segment-output boundary.
+        return tuple(
+            cells[u][g].data  # noqa: data-ok AOTI
+            for (u, g) in self.emitted_pairs()
+        )
 
 
 __all__ = ["RHS", "NewtonStep", "IFT", "enumerate_group_var_names"]

--- a/scripts/cpp_coverage.sh
+++ b/scripts/cpp_coverage.sh
@@ -53,30 +53,40 @@ ctest --test-dir "$BUILD_DIR" -L 'dispatcher|eager' --output-on-failure
 # reach the implicit / sub-batch / derivative-selection paths in
 # csrc/aoti/{ops,jacobian,Model}.cpp. The Python AOTI suite (tests/aoti) DOES --
 # it compiles real models and calls forward/jvp/jacobian through the pybind
-# binding, which loads libneml2. Point that load at the *instrumented* library so
-# those runs contribute to the same coverage profile.
+# binding, which loads libneml2. Make the binding load the *instrumented* library
+# so those runs contribute to the same coverage profile; the per-process .profraw
+# land in $RAW alongside the ctest ones and merge below.
 #
-# The binding's DT_NEEDED is `libneml2.so`, but a non-Release build names the
-# library `libneml2_<config>.so` with a matching SONAME (see CMakeLists OUTPUT_NAME),
-# so a plain LD_PRELOAD would not satisfy the NEEDED entry. Stage a copy with the
-# SONAME rewritten to `libneml2.so` and preload that; its per-process .profraw land
-# in $RAW alongside the ctest ones and merge below. Opt out with NEML2_CPP_COV_PYTEST=0.
-if [ "${NEML2_CPP_COV_PYTEST:-1}" = "1" ] && python -c "import neml2.aoti" 2>/dev/null; then
+# We must NOT use LD_PRELOAD: it would also be inherited by the g++ subprocess
+# Inductor spawns to build each .pt2 kernel, which then fails to start
+# ("InductorError: InvalidCxxCompiler"). Instead swap the instrumented library in
+# place of the one the binding resolves through its rpath, so only the in-process
+# binding picks it up and the compiler subprocess is untouched. The build names
+# the library `libneml2_<config>.so` with a matching SONAME (CMakeLists
+# OUTPUT_NAME), so rewrite the staged copy's SONAME to `libneml2.so` (the
+# binding's DT_NEEDED) before swapping, and restore the original afterwards. Opt
+# out with NEML2_CPP_COV_PYTEST=0.
+if [ "${NEML2_CPP_COV_PYTEST:-1}" = "1" ] && command -v patchelf >/dev/null 2>&1 \
+   && python -c "import neml2.aoti._aoti" 2>/dev/null; then
   NEML2_LIB="$(find "$BUILD_DIR" -maxdepth 1 -name 'libneml2*.so' ! -name '*eager*' | head -1)"
-  if [ -n "$NEML2_LIB" ] && command -v patchelf >/dev/null 2>&1; then
-    PRELOAD_DIR="$OUT_DIR/preload"
-    mkdir -p "$PRELOAD_DIR"
-    cp "$NEML2_LIB" "$PRELOAD_DIR/libneml2.so"
-    patchelf --set-soname libneml2.so "$PRELOAD_DIR/libneml2.so"
-    echo "cpp_coverage: driving tests/aoti through the instrumented runtime (LD_PRELOAD $NEML2_LIB)"
+  AOTI_SO="$(python -c 'import neml2.aoti._aoti as m; print(m.__file__)' 2>/dev/null || true)"
+  TARGET_LIB="$(ldd "$AOTI_SO" 2>/dev/null | sed -n 's/.*libneml2\.so => \([^ ]*\).*/\1/p' | head -1)"
+  if [ -n "$NEML2_LIB" ] && [ -n "$TARGET_LIB" ] && [ -w "$TARGET_LIB" ]; then
+    STAGED="$OUT_DIR/instrumented_libneml2.so"
+    cp "$NEML2_LIB" "$STAGED"
+    patchelf --set-soname libneml2.so "$STAGED"
+    cp "$TARGET_LIB" "$TARGET_LIB.covbak"   # back up the binding's library
+    cp "$STAGED" "$TARGET_LIB"              # swap in the instrumented one
+    echo "cpp_coverage: driving tests/aoti through the instrumented runtime (swapped $TARGET_LIB)"
     # Keep pyproject's addopts (--import-mode=importlib is load-bearing: it makes
     # `import neml2` resolve to the installed package + its pybind `_aoti.so`).
     # %p in LLVM_PROFILE_FILE gives every xdist worker its own profile.
-    LD_PRELOAD="$PRELOAD_DIR/libneml2.so" LLVM_PROFILE_FILE="$RAW/py-%p.profraw" \
+    LLVM_PROFILE_FILE="$RAW/py-%p.profraw" \
       python -m pytest "$SRC/tests/aoti" -n auto -q -p no:cacheprovider \
       || echo "cpp_coverage: WARNING tests/aoti exited non-zero (coverage still merged)" >&2
+    mv -f "$TARGET_LIB.covbak" "$TARGET_LIB"  # restore the original library
   else
-    echo "cpp_coverage: skipping Python coverage (need patchelf + a built libneml2 under $BUILD_DIR)" >&2
+    echo "cpp_coverage: skipping Python coverage (need patchelf + a writable binding libneml2)" >&2
   fi
 fi
 

--- a/scripts/cpp_coverage.sh
+++ b/scripts/cpp_coverage.sh
@@ -48,6 +48,38 @@ export LLVM_PROFILE_FILE="$RAW/%p.profraw"
 # -- both label groups instrument neml2/csrc sources, so cover them together.
 ctest --test-dir "$BUILD_DIR" -L 'dispatcher|eager' --output-on-failure
 
+# --- Python-driven coverage of the AOTI runtime -----------------------------
+# The C++ ctests only drive a forward leaf (the dispatch fixture); they never
+# reach the implicit / sub-batch / derivative-selection paths in
+# csrc/aoti/{ops,jacobian,Model}.cpp. The Python AOTI suite (tests/aoti) DOES --
+# it compiles real models and calls forward/jvp/jacobian through the pybind
+# binding, which loads libneml2. Point that load at the *instrumented* library so
+# those runs contribute to the same coverage profile.
+#
+# The binding's DT_NEEDED is `libneml2.so`, but a non-Release build names the
+# library `libneml2_<config>.so` with a matching SONAME (see CMakeLists OUTPUT_NAME),
+# so a plain LD_PRELOAD would not satisfy the NEEDED entry. Stage a copy with the
+# SONAME rewritten to `libneml2.so` and preload that; its per-process .profraw land
+# in $RAW alongside the ctest ones and merge below. Opt out with NEML2_CPP_COV_PYTEST=0.
+if [ "${NEML2_CPP_COV_PYTEST:-1}" = "1" ] && python -c "import neml2.aoti" 2>/dev/null; then
+  NEML2_LIB="$(find "$BUILD_DIR" -maxdepth 1 -name 'libneml2*.so' ! -name '*eager*' | head -1)"
+  if [ -n "$NEML2_LIB" ] && command -v patchelf >/dev/null 2>&1; then
+    PRELOAD_DIR="$OUT_DIR/preload"
+    mkdir -p "$PRELOAD_DIR"
+    cp "$NEML2_LIB" "$PRELOAD_DIR/libneml2.so"
+    patchelf --set-soname libneml2.so "$PRELOAD_DIR/libneml2.so"
+    echo "cpp_coverage: driving tests/aoti through the instrumented runtime (LD_PRELOAD $NEML2_LIB)"
+    # Keep pyproject's addopts (--import-mode=importlib is load-bearing: it makes
+    # `import neml2` resolve to the installed package + its pybind `_aoti.so`).
+    # %p in LLVM_PROFILE_FILE gives every xdist worker its own profile.
+    LD_PRELOAD="$PRELOAD_DIR/libneml2.so" LLVM_PROFILE_FILE="$RAW/py-%p.profraw" \
+      python -m pytest "$SRC/tests/aoti" -n auto -q -p no:cacheprovider \
+      || echo "cpp_coverage: WARNING tests/aoti exited non-zero (coverage still merged)" >&2
+  else
+    echo "cpp_coverage: skipping Python coverage (need patchelf + a built libneml2 under $BUILD_DIR)" >&2
+  fi
+fi
+
 # Instrumented objects: the shared library (carries the neml2/csrc mapping) plus
 # every test executable (carries the header-only template instantiations --
 # batch_chunk.h, the _guarded / _assert helpers, ...). llvm-cov merges per-source

--- a/scripts/dependencies.yaml
+++ b/scripts/dependencies.yaml
@@ -105,7 +105,7 @@ neml2:
 # ``doc/content/tutorials/models/compiled_models/`` are regenerated at
 # tutorial-rebuild time and so are not tracked here.
 aoti:
-  schema_version: "5"
+  schema_version: "6"
   files:
     - neml2/cli/aoti_export.py
     - neml2/csrc/aoti/Model.cpp

--- a/tests/aoti/derivative_prune/prune.i
+++ b/tests/aoti/derivative_prune/prune.i
@@ -1,0 +1,75 @@
+# Two INDEPENDENT pipelines composed into one model, used to exercise the
+# `-d` reachability prune at runtime (the off-path forward / implicit segment
+# branches in csrc/aoti/ops.cpp):
+#
+#   * a pure-forward pipeline   strain -> stress -> mandel_stress   (forward seg)
+#   * a forward+implicit pipeline   x -> y_rate -> y                (implicit seg)
+#
+# The two share no variables, so requesting a derivative of one pipeline's
+# output prunes the *other* pipeline's whole segment:
+#   -d mandel_stress:strain  keeps the forward seg, prunes the implicit seg
+#   -d y:x                   keeps the implicit seg, prunes the forward seg
+
+[Models]
+  [elasticity]
+    type = LinearIsotropicElasticity
+    strain = 'strain'
+    stress = 'stress'
+    coefficients = '100 0.3'
+    coefficient_types = 'YOUNGS_MODULUS POISSONS_RATIO'
+  []
+  [mandel]
+    type = IsotropicMandelStress
+    cauchy_stress = 'stress'
+    mandel_stress = 'mandel_stress'
+  []
+  [rate]
+    type = MacaulaySplit
+    from = 'x'
+    to_positive = 'y_rate'
+    to_negative = 'y_neg_unused'
+  []
+  [integrate]
+    type = ScalarBackwardEulerTimeIntegration
+    variable = 'y'
+    time = 't'
+  []
+  [implicit_rate]
+    type = ComposedModel
+    models = 'rate integrate'
+  []
+[]
+
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'implicit_rate'
+    unknowns = 'y'
+    residuals = 'y_residual'
+  []
+[]
+
+[Solvers]
+  [newton]
+    type = Newton
+    abs_tol = 1e-10
+    rel_tol = 1e-08
+    max_its = 25
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+
+[Models]
+  [implicit_solve]
+    type = ImplicitUpdate
+    equation_system = 'eq_sys'
+    solver = 'newton'
+  []
+  [model]
+    type = ComposedModel
+    models = 'elasticity mandel implicit_solve'
+  []
+[]

--- a/tests/aoti/test_derivative_selection.py
+++ b/tests/aoti/test_derivative_selection.py
@@ -43,6 +43,9 @@ import neml2  # noqa: F401 — registers models
 _TESTS_ROOT = Path(__file__).resolve().parents[1]
 _ELASTICITY_I = _TESTS_ROOT / "models/solid_mechanics/elasticity/LinearIsotropicElasticity.i"
 _COMPOSED_I = _TESTS_ROOT / "aoti/forward_implicit/model.i"
+# Two independent pipelines (forward strain->mandel_stress; implicit x->y) in one
+# model: requesting one pipeline's pair prunes the OTHER pipeline's whole segment.
+_PRUNE_I = _TESTS_ROOT / "aoti/derivative_prune/prune.i"
 # A sub-batched (per-grain) implicit model: unknowns u_per (per-grain) / u_glob
 # (global); givens g_per / g_glob / coupling.
 _SUBBATCH_IMPLICIT_I = _TESTS_ROOT / "aoti/implicit_grain_global_cross/model.i"
@@ -162,6 +165,34 @@ def test_composed_reachability_partial_matches_eager(tmp_path):
     _, Jc = m.jacobian(ins)
     assert list(Jc) == [o] and list(Jc[o]) == [i]
     assert _broadcast_equal(Jc[o][i], Je[o][i])
+
+
+@pytest.mark.parametrize(
+    "pair",
+    [
+        # Forward-pipeline pair: keeps the forward segment, prunes the implicit one.
+        "mandel_stress:strain",
+        # Implicit-pipeline pair: keeps the implicit segment, prunes the forward one(s).
+        "y:x",
+    ],
+)
+def test_offpath_segment_pruned_jacobian_matches_eager(tmp_path, pair):
+    """A composed model of two INDEPENDENT pipelines: requesting one pipeline's
+    pair prunes the other pipeline's whole segment (no jvp/ift graph). At runtime
+    that segment is advanced value-only and its dstate zero-filled; the requested
+    block must still equal the eager chain-rule block (the off-path zeros are
+    never folded into a kept pair)."""
+    from neml2.eager import _EagerModel
+
+    out, inp = (s.strip() for s in pair.split(":"))
+    m = _compile(tmp_path, _PRUNE_I, "model", derivatives=[pair])
+    eager = _EagerModel(str(_PRUNE_I), "model")
+    ins = _rand_inputs(eager, B=4)
+
+    _, Jc = m.jacobian(ins)
+    _, Je = eager.jacobian(ins)
+    assert list(Jc) == [out] and list(Jc[out]) == [inp]
+    assert _broadcast_equal(Jc[out][inp], Je[out][inp])
 
 
 def test_subbatch_implicit_global_global_compiles_and_matches_fd(tmp_path):

--- a/tests/aoti/test_derivative_selection.py
+++ b/tests/aoti/test_derivative_selection.py
@@ -109,6 +109,19 @@ def test_selected_pair_returns_only_that_pair_and_matches_eager(tmp_path):
     assert torch.allclose(jv["stress"], jve["stress"], rtol=1e-6, atol=1e-8)
 
 
+def test_jvp_missing_tangent_contributes_zero(tmp_path):
+    """A tangent dict missing an input key contributes nothing: the runtime
+    packs an absent tangent as zeros, so jvp along an empty tangent is zero."""
+    from neml2.eager import _EagerModel
+
+    m = _compile(tmp_path, _ELASTICITY_I, "model", derivatives=["stress:strain"])
+    eager = _EagerModel(str(_ELASTICITY_I), "model")
+    ins = _rand_inputs(eager)
+
+    _, jv = m.jvp(ins, {})  # no tangents -> zero directional derivative
+    assert torch.allclose(jv["stress"], torch.zeros_like(jv["stress"]))
+
+
 def test_constant_jacobian_block_returned_unbatched(tmp_path):
     """Linear elasticity's d(stress)/d(strain) is the constant stiffness tensor:
     the metadata flags it ``batch_independent`` and the single-forward-segment

--- a/tests/aoti/test_derivative_selection.py
+++ b/tests/aoti/test_derivative_selection.py
@@ -1,0 +1,224 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""End-to-end tests for selectable derivative pairs (``neml2-compile -d``).
+
+These compile real artifacts and drive ``neml2.aoti.Model`` (the C++ binding),
+checking the runtime contract against the eager chain rule
+(:class:`neml2.eager._EagerModel`): default-off raises, a selected pair returns
+only that pair and matches eager, batch-independent blocks come back unbatched,
+and the composed-model reachability prune stays numerically correct.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+import neml2  # noqa: F401 — registers models
+
+_TESTS_ROOT = Path(__file__).resolve().parents[1]
+_ELASTICITY_I = _TESTS_ROOT / "models/solid_mechanics/elasticity/LinearIsotropicElasticity.i"
+_COMPOSED_I = _TESTS_ROOT / "aoti/forward_implicit/model.i"
+# A sub-batched (per-grain) implicit model: unknowns u_per (per-grain) / u_glob
+# (global); givens g_per / g_glob / coupling.
+_SUBBATCH_IMPLICIT_I = _TESTS_ROOT / "aoti/implicit_grain_global_cross/model.i"
+
+
+def _broadcast_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """True if *a* equals *b* after broadcasting (a batch-independent block is
+    returned unbatched, so it must broadcast-match the eager batched block)."""
+    a = a.expand_as(b) if a.shape != b.shape else a
+    return torch.allclose(a, b, rtol=1e-6, atol=1e-8)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _f64():
+    prev = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
+    yield
+    torch.set_default_dtype(prev)
+
+
+def _compile(tmp_path: Path, hit: Path, name: str, derivatives):
+    from neml2.aoti import Model
+    from neml2.cli.aoti_export import export_model_for_aoti
+
+    out = tmp_path / "art"
+    export_model_for_aoti(hit, name, out, derivatives=derivatives)
+    return Model(str(out / f"{name}_meta.json"))
+
+
+def _rand_inputs(eager, B=5):
+    g = torch.Generator().manual_seed(0)
+    return {
+        n: torch.randn(B, *eager.input_spec[n].BASE_SHAPE, generator=g, dtype=torch.float64) * 1e-3
+        for n in eager.input_names
+    }
+
+
+def test_default_off_jvp_jacobian_raise(tmp_path):
+    """No ``-d`` flags -> no derivative graphs -> jvp/jacobian raise, pointing
+    the user at ``-d``."""
+    m = _compile(tmp_path, _ELASTICITY_I, "model", derivatives=())
+    strain = torch.randn(5, 6, dtype=torch.float64) * 1e-2
+    with pytest.raises(Exception, match="-d"):
+        m.jacobian({"strain": strain})
+    with pytest.raises(Exception, match="-d"):
+        m.jvp({"strain": strain}, {"strain": strain})
+
+
+def test_selected_pair_returns_only_that_pair_and_matches_eager(tmp_path):
+    from neml2.eager import _EagerModel
+
+    m = _compile(tmp_path, _ELASTICITY_I, "model", derivatives=["stress:strain"])
+    eager = _EagerModel(str(_ELASTICITY_I), "model")
+    ins = _rand_inputs(eager)
+
+    _, Jc = m.jacobian(ins)
+    _, Je = eager.jacobian(ins)
+    assert list(Jc) == ["stress"] and list(Jc["stress"]) == ["strain"]
+    assert _broadcast_equal(Jc["stress"]["strain"], Je["stress"]["strain"])
+
+    _, jv = m.jvp(ins, ins)
+    _, jve = eager.jvp(ins, ins)
+    assert list(jv) == ["stress"]
+    assert torch.allclose(jv["stress"], jve["stress"], rtol=1e-6, atol=1e-8)
+
+
+def test_constant_jacobian_block_returned_unbatched(tmp_path):
+    """Linear elasticity's d(stress)/d(strain) is the constant stiffness tensor:
+    the metadata flags it ``batch_independent`` and the single-forward-segment
+    Jacobian path returns it **unbatched** at its natural ``(6, 6)`` (no leading
+    batch axis), regardless of the runtime batch size."""
+    import json
+
+    from neml2.aoti import Model
+    from neml2.cli.aoti_export import export_model_for_aoti
+
+    out = tmp_path / "art"
+    meta = export_model_for_aoti(_ELASTICITY_I, "model", out, derivatives=["stress:strain"])
+    on_disk = json.loads((out / "model_meta.json").read_text())
+    assert meta["derivatives"] == [["stress", "strain"]]
+    pair = on_disk["segments"][0]["jacobian_pairs"][0]
+    assert (pair["out_var"], pair["in_var"]) == ("stress", "strain")
+    assert pair["batch_independent"] is True
+
+    m = Model(str(out / "model_meta.json"))
+    for B in (1, 7):
+        _, J = m.jacobian({"strain": torch.randn(B, 6, dtype=torch.float64) * 1e-2})
+        # Unbatched: natural (6, 6), no leading batch axis, independent of B.
+        assert tuple(J["stress"]["strain"].shape) == (6, 6)
+
+
+def test_composed_reachability_partial_matches_eager(tmp_path):
+    """A composed forward+implicit model with a single requested master pair:
+    the reachability prune drops off-path local pairs but the returned block is
+    still numerically identical to the eager all-pairs result."""
+    from neml2.eager import _EagerModel
+
+    eager = _EagerModel(str(_COMPOSED_I), "model")
+    ins = _rand_inputs(eager, B=4)
+    _, Je = eager.jacobian(ins)
+    o, i = next((o, i) for o in Je for i in Je[o])
+
+    m = _compile(tmp_path, _COMPOSED_I, "model", derivatives=[f"{o}:{i}"])
+    _, Jc = m.jacobian(ins)
+    assert list(Jc) == [o] and list(Jc[o]) == [i]
+    assert _broadcast_equal(Jc[o][i], Je[o][i])
+
+
+def test_subbatch_implicit_global_global_compiles_and_matches_fd(tmp_path):
+    """A sub-batched (crystal-plasticity-style) implicit model supports compiled
+    Jacobian for a **non-sub-batched output w.r.t. non-sub-batched input**
+    (``u_glob:g_glob``): the IFT solve handles the internal per-grain coupling and
+    the returned global-to-global block has no grain axis. Validated by finite
+    differences on the (sub-batch-capable) compiled forward."""
+    from neml2.aoti import Model
+    from neml2.cli.aoti_export import export_model_for_aoti
+
+    out = tmp_path / "art"
+    meta = export_model_for_aoti(_SUBBATCH_IMPLICIT_I, "model", out, derivatives=["u_glob:g_glob"])
+    assert meta["derivatives"] == [["u_glob", "g_glob"]]
+    info = {v["name"]: v for v in meta["inputs"]}
+    m = Model(str(out / "model_meta.json"))
+
+    B = 4
+    g = torch.Generator().manual_seed(0)
+    ins = {
+        n: torch.randn(
+            B,
+            *info[n].get("sub_batch_shape", []),
+            *info[n]["base_shape"],
+            generator=g,
+            dtype=torch.float64,
+        )
+        * 0.1
+        + 0.5
+        for n in m.input_names
+    }
+    _, J = m.jacobian(ins)
+    block = J["u_glob"]["g_glob"]
+
+    # Finite-difference reference on the compiled forward.
+    gsz = max(1, int(torch.tensor(info["g_glob"]["base_shape"]).prod()))
+    eps = 1e-6
+    out0 = m.forward(ins)["u_glob"]
+    cols = []
+    for k in range(gsz):
+        bumped = {n: t.clone() for n, t in ins.items()}
+        flat = bumped["g_glob"].reshape(B, -1)
+        flat[:, k] += eps
+        bumped["g_glob"] = flat.reshape(ins["g_glob"].shape)
+        cols.append(((m.forward(bumped)["u_glob"] - out0) / eps).reshape(B, -1))
+    fd = torch.stack(cols, dim=-1)
+    assert torch.allclose(block.reshape(fd.shape), fd, rtol=1e-3, atol=1e-5)
+
+
+def test_subbatch_implicit_per_grain_pair_errors_at_compile(tmp_path):
+    """Requesting a derivative that touches a sub-batched (per-grain) implicit
+    variable fails fast at ``neml2-compile`` with a clear message (the per-pair
+    IFT consumer is plain-batch only)."""
+    from neml2.cli.aoti_export import export_model_for_aoti
+
+    with pytest.raises(NotImplementedError, match="sub-batched"):
+        export_model_for_aoti(_SUBBATCH_IMPLICIT_I, "model", tmp_path / "a", derivatives=[":"])
+
+
+def test_all_pairs_parity_with_eager_composed(tmp_path):
+    """``-d :`` on a composed model reproduces the full eager Jacobian."""
+    from neml2.eager import _EagerModel
+
+    eager = _EagerModel(str(_COMPOSED_I), "model")
+    ins = _rand_inputs(eager, B=4)
+    _, Je = eager.jacobian(ins)
+
+    m = _compile(tmp_path, _COMPOSED_I, "model", derivatives=[":"])
+    _, Jc = m.jacobian(ins)
+    for o in Je:
+        for i in Je[o]:
+            assert i in Jc.get(o, {}), f"missing pair ({o}, {i})"
+            assert _broadcast_equal(Jc[o][i], Je[o][i]), f"mismatch ({o}, {i})"

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 add_test(
       NAME dispatcher_fixture_compile
       COMMAND ${Python3_EXECUTABLE} -m neml2.cli.aoti_compile ${_fixture_input}
-              --model model --device ${_fixture_devices} -p E -p nu
+              --model model --device ${_fixture_devices} -p E -p nu -d :
               --output-dir ${_fixture_dir}
       WORKING_DIRECTORY ${NEML2_SOURCE_DIR}
 )

--- a/tests/cpp/test_batch_chunk.cpp
+++ b/tests/cpp/test_batch_chunk.cpp
@@ -110,5 +110,46 @@ main()
     NEML2_CHECK(at::equal(cat.narrow(0, 4, 6), b));
   }
 
+  // cat_batch_nested (base-shape-aware): per-(out,in) blocks, where a batched
+  // block (dim > out_base_ndim + in_base_ndim) is concatenated along dim 0 while
+  // a batch-independent block (dim == that trail) is identical across chunks and
+  // passed through unchanged. Out var "o" has base ndim 1; inputs "i"/"c" too.
+  {
+    const std::map<std::string, int64_t> out_nd{{"o", 1}};
+    const std::map<std::string, int64_t> in_nd{{"i", 1}, {"c", 1}};
+    auto a = at::randn({4, 2, 3}, dbl); // batched (o,i) block, chunk 0
+    auto b = at::randn({6, 2, 3}, dbl); // batched (o,i) block, chunk 1
+    auto bi = at::randn({2, 3}, dbl);   // batch-independent (o,c) block
+
+    std::map<std::string, std::map<std::string, at::Tensor>> c0, c1;
+    c0["o"]["i"] = a;
+    c0["o"]["c"] = bi;
+    c1["o"]["i"] = b;
+    c1["o"]["c"] = bi; // identical across chunks (batch-independent)
+
+    auto cat = cat_batch_nested({c0, c1}, out_nd, in_nd);
+    // Batched pair: concatenated to the full batch.
+    NEML2_CHECK(cat.at("o").at("i").size(0) == 10);
+    NEML2_CHECK(at::equal(cat.at("o").at("i").narrow(0, 0, 4), a));
+    NEML2_CHECK(at::equal(cat.at("o").at("i").narrow(0, 4, 6), b));
+    // Batch-independent pair: passed through at its natural (2, 3), not stacked.
+    NEML2_CHECK(cat.at("o").at("c").dim() == 2);
+    NEML2_CHECK(at::equal(cat.at("o").at("c"), bi));
+
+    // Single-chunk fast path: returned verbatim.
+    auto one = cat_batch_nested({c0}, out_nd, in_nd);
+    NEML2_CHECK(at::equal(one.at("o").at("i"), a));
+    NEML2_CHECK(at::equal(one.at("o").at("c"), bi));
+  }
+
+  // to_device_nested: a cpu->cpu move is a no-op that preserves every block.
+  {
+    std::map<std::string, std::map<std::string, at::Tensor>> j;
+    auto blk = at::randn({3, 2, 3}, dbl);
+    j["o"]["i"] = blk;
+    auto moved = to_device_nested(j, at::kCPU);
+    NEML2_CHECK(at::equal(moved.at("o").at("i"), blk));
+  }
+
   return 0;
 }

--- a/tests/cpp/test_dispatcher.cpp
+++ b/tests/cpp/test_dispatcher.cpp
@@ -111,7 +111,12 @@ main(int argc, char ** argv)
       NEML2_CHECK(at::allclose(jout.at(o), std::get<0>(ref_jac).at(o), 1e-8, 1e-10));
       for (const auto & i : ref.input_names())
       {
-        NEML2_CHECK(j.at(o).at(i).size(0) == b);
+        // The dispatched block must reassemble to the same shape the
+        // single-device reference returns: a batched block is concatenated back
+        // to leading dim `b`, while a batch-independent block (this model's
+        // constant stiffness Jacobian) is passed through unbatched. Comparing to
+        // the reference covers both without hard-coding the batch axis.
+        NEML2_CHECK(j.at(o).at(i).sizes() == std::get<1>(ref_jac).at(o).at(i).sizes());
         NEML2_CHECK(at::allclose(j.at(o).at(i), std::get<1>(ref_jac).at(o).at(i), 1e-8, 1e-10));
       }
     }

--- a/tests/unit/test_aoti_export.py
+++ b/tests/unit/test_aoti_export.py
@@ -73,6 +73,17 @@ def forward_export(tmp_path_factory):
     from neml2.cli.aoti_export import export_model_for_aoti
 
     out_dir = tmp_path_factory.mktemp("aoti_forward")
+    # Derivative graphs are opt-in (schema v6); request all pairs so the
+    # jvp/jacobian assertions below have a graph to exercise.
+    meta = export_model_for_aoti(_ELASTICITY_I, "model", out_dir, derivatives=[":"])
+    return meta, out_dir
+
+
+@pytest.fixture(scope="session")
+def forward_export_no_deriv(tmp_path_factory):
+    from neml2.cli.aoti_export import export_model_for_aoti
+
+    out_dir = tmp_path_factory.mktemp("aoti_forward_no_deriv")
     meta = export_model_for_aoti(_ELASTICITY_I, "model", out_dir)
     return meta, out_dir
 
@@ -82,7 +93,7 @@ def implicit_export(tmp_path_factory):
     from neml2.cli.aoti_export import export_model_for_aoti
 
     out_dir = tmp_path_factory.mktemp("aoti_implicit")
-    meta = export_model_for_aoti(_J2_NATIVE_I, "return_map", out_dir)
+    meta = export_model_for_aoti(_J2_NATIVE_I, "return_map", out_dir, derivatives=[":"])
     return meta, out_dir
 
 
@@ -113,6 +124,9 @@ def test_export_forward_model_metadata(forward_export):
     assert meta["outputs"] == [
         {"name": "stress", "var_size": 6, "var_type": "SR2", "base_shape": [6]}
     ]
+    # Schema v6: top-level `derivatives` lists the requested master pairs.
+    assert meta["schema_version"] == 6
+    assert meta["derivatives"] == [["stress", "strain"]]
     seg = meta["segments"][0]
     assert seg["kind"] == "forward"
     # Forward-segment per-variable metadata is name-only (v4 schema). The
@@ -123,6 +137,23 @@ def test_export_forward_model_metadata(forward_export):
     # Forward segments carry a `jvp_package` next to the value package.
     assert seg["jvp_package"] == "model_jvp.pt2"
     assert (out_dir / "model_jvp.pt2").exists()
+    # Each pair carries a batch_independent flag; elasticity's Jacobian is the
+    # constant stiffness tensor -> batch-independent.
+    pair = seg["jacobian_pairs"][0]
+    assert (pair["out_var"], pair["in_var"]) == ("stress", "strain")
+    assert pair["batch_independent"] is True
+
+
+def test_export_forward_default_off_no_derivatives(forward_export_no_deriv):
+    """With no -d flags, NO derivative graph is compiled: empty top-level
+    `derivatives`, no segment `jvp_package`, no `*_jvp.pt2` on disk."""
+    meta, out_dir = forward_export_no_deriv
+    assert meta["schema_version"] == 6
+    assert meta["derivatives"] == []
+    seg = meta["segments"][0]
+    assert "jvp_package" not in seg
+    assert "jacobian_pairs" not in seg
+    assert not (out_dir / "model_jvp.pt2").exists()
 
 
 def test_export_forward_jvp_matches_finite_difference(forward_export):
@@ -256,10 +287,33 @@ def test_export_implicit_ift_satisfies_IFT_identity(implicit_export):
     A = A_assembled.tensors[0][0].data
     B = B_assembled.tensors[0][0].data
 
-    J = ift_pkg(u, g)
-    if isinstance(J, tuple):
-        J = J[0]
-    # IFT identity: A J + B = 0.
+    # The IFT graph now emits one block per (unknown, given) pair (the
+    # disassemble of -du/dg), in unknown x given order. Reassemble them into the
+    # full -du/dg matrix and check the IFT identity A J + B = 0.
+    blocks = ift_pkg(u, g)
+    if not isinstance(blocks, tuple):
+        blocks = (blocks,)
+    u_off = {
+        n: sum(system.ulayout.var_size(m) for m in system.unknown_names[:i])
+        for i, n in enumerate(system.unknown_names)
+    }
+    g_off = {
+        n: sum(system.glayout.var_size(m) for m in system.given_names[:i])
+        for i, n in enumerate(system.given_names)
+    }
+    J = torch.zeros(
+        u.shape[0],
+        system.ulayout.storage_size(),
+        system.glayout.storage_size(),
+        dtype=torch.float64,
+    )
+    k = 0
+    for un in system.unknown_names:
+        rs = system.ulayout.var_size(un)
+        for gn in system.given_names:
+            cs = system.glayout.var_size(gn)
+            J[:, u_off[un] : u_off[un] + rs, g_off[gn] : g_off[gn] + cs] = blocks[k]
+            k += 1
     residual = A @ J + B
     assert torch.allclose(residual, torch.zeros_like(residual), atol=1e-10)
 

--- a/tests/unit/test_aoti_export.py
+++ b/tests/unit/test_aoti_export.py
@@ -68,6 +68,58 @@ def test_parse_example_batch_shape_rejects_label_suffix():
         _parse_example_batch_shape("(2; 3:grain)")
 
 
+def test_resolve_derivative_specs_grammar_and_errors():
+    """``-d/--derivative OUT:IN`` resolution: explicit pairs, the omission
+    grammar (either/both sides empty = 'all'), the empty-specs default, and the
+    error branches (no colon, unknown output, unknown/promoted input)."""
+    from neml2.cli.aoti_export import _resolve_derivative_specs
+
+    outs = ["stress", "energy"]
+    ins = ["strain", "temperature"]
+
+    # No specs -> no pairs (derivative graphs are opt-in).
+    assert _resolve_derivative_specs([], outs, ins) == set()
+
+    # One explicit pair.
+    assert _resolve_derivative_specs(["stress:strain"], outs, ins) == {("stress", "strain")}
+
+    # Omit the output side -> every output w.r.t. that input.
+    assert _resolve_derivative_specs([":strain"], outs, ins) == {
+        ("stress", "strain"),
+        ("energy", "strain"),
+    }
+
+    # Omit the input side -> that output w.r.t. every input.
+    assert _resolve_derivative_specs(["stress:"], outs, ins) == {
+        ("stress", "strain"),
+        ("stress", "temperature"),
+    }
+
+    # Both sides omitted -> all pairs; whitespace around names is tolerated.
+    assert _resolve_derivative_specs([":"], outs, ins) == {(o, i) for o in outs for i in ins}
+    assert _resolve_derivative_specs([" stress : strain "], outs, ins) == {("stress", "strain")}
+
+    # Multiple specs union (and dedupe).
+    assert _resolve_derivative_specs(["stress:strain", "stress:strain", "energy:"], outs, ins) == {
+        ("stress", "strain"),
+        ("energy", "strain"),
+        ("energy", "temperature"),
+    }
+
+    # Missing colon.
+    with pytest.raises(ValueError, match="expected OUT:IN"):
+        _resolve_derivative_specs(["stress"], outs, ins)
+
+    # Unknown output.
+    with pytest.raises(ValueError, match="unknown output 'nope'"):
+        _resolve_derivative_specs(["nope:strain"], outs, ins)
+
+    # Unknown input (a promoted-parameter name is rejected here too: it is not a
+    # structural input and never appears in the Jacobian).
+    with pytest.raises(ValueError, match="unknown input 'E'"):
+        _resolve_derivative_specs(["stress:E"], outs, ins)
+
+
 @pytest.fixture(scope="session")
 def forward_export(tmp_path_factory):
     from neml2.cli.aoti_export import export_model_for_aoti

--- a/tests/unit/test_sub_batch_aoti_meta.py
+++ b/tests/unit/test_sub_batch_aoti_meta.py
@@ -47,16 +47,17 @@ from neml2.types import Scalar
 # ---------- schema_version constant ----------
 
 
-def test_schema_version_constant_is_int_five():
-    """v5 makes the runtime variable-native: the master ``inputs``/``outputs``
-    metadata now carries each variable's ``base_shape`` so the C++ side reports
-    ``input_base_shapes()``/``output_base_shapes()``, validates canonical
-    ``(*B, *base)`` inputs, and returns unflattened jvp / variable-pair jacobian
-    blocks. (v4 had de-baked the solver config into the stub's ``[Solvers]``
-    block.) The C++ loader mirrors this constant and refuses any other value, so
-    a stale cache surfaces immediately with a clear ``regenerate via
-    neml2-compile`` message instead of a cryptic missing-field error."""
-    assert AOTI_META_SCHEMA_VERSION == 5
+def test_schema_version_constant_is_int_six():
+    """v6 makes derivative graphs opt-in: a top-level ``derivatives`` array lists
+    the master ``[out, in]`` pairs the artifact supports (empty => jvp/jacobian
+    raise), forward ``jvp_package`` / implicit ``ift_package`` are emitted only
+    when requested, and each ``jacobian_pairs`` entry gains a ``batch_independent``
+    flag. (v5 carried per-variable ``base_shape`` for the variable-native runtime;
+    v4 de-baked the solver config.) The C++ loader mirrors this constant and
+    refuses any other value, so a stale cache surfaces immediately with a clear
+    ``regenerate via neml2-compile`` message instead of a cryptic missing-field
+    error."""
+    assert AOTI_META_SCHEMA_VERSION == 6
 
 
 # ---------- _var_infos default behaviour (no sub-batch) ----------


### PR DESCRIPTION
## Summary

Reworks the compiled `jvp` / `jacobian` surface to be **selectable**, **opt-in**,
and **per-variable-pair end to end**.

- **Selectable + opt-in compilation.** `neml2-compile` now defaults to emitting
  **no** derivative graphs. Request pairs with `-d/--derivative OUT:IN`
  (repeatable). Omit either side of `:` to mean "all" on that side; a bare `:`
  means all pairs. Calling `jacobian()`/`jvp()` on an artifact compiled without
  the needed pair raises a `FatalError` pointing back at `-d`.
- **Per-variable-pair representation.** The dense flat-Jacobian runtime
  representation is gone. `jacobian()`/`jvp()` no longer densify→reslice; the
  internal carrier is a per-`(out, in)` block map mirroring the eager
  `ChainRuleDict` and the public per-pair API.
- **Batch-independent unbatched blocks.** A homogeneous model's constant block
  (e.g. an elasticity tensor) is detected at trace time and carried at its
  natural unbatched shape all the way to the public return; the dispatcher
  passes it through instead of cat-duplicating across chunks.
- **Crystal-plasticity global→global.** A compiled derivative of a
  non-sub-batched output w.r.t. a non-sub-batched input on a sub-batched
  implicit model (e.g. `-d u_glob:g_glob`) now works, validated by finite
  differences. A requested pair touching a *per-grain* variable fails fast at
  `neml2-compile` with a clear message — tracked in #381.
- **Schema `5 → 6`**, moved in lockstep across the Python constant, C++
  `kSupportedSchemaVersion`, `dependencies.yaml` (`aoti.schema_version`), and the
  doc literal.

## Parity

All six evaluation routes keep the same `forward` / `jvp` / `jacobian` surface.
Eager routes (`py-eager`, `cpp-eager`) are unchanged and still return all pairs;
selection / opt-in applies to the compiled routes (`py-aoti`, `cpp-aoti`,
`cpp-dispatch`).

## Performance (no drift)

The forward solve path (`solve.cpp`, `newton.cpp`, the value/rhs/step graphs,
`Model::Impl::forward`) is **byte-identical** — the carrier change is confined to
`jacobian.cpp` and is only exercised by the public `jacobian()`/`jvp()`, never by
a forward run. (Proof: the benchmark artifacts compile default-off, so any
`jacobian()` call would raise — yet every cell ran to completion.)

CUDA benchmark (`radret` / `chaboche6` / `scpdecoup` at batch 8 and 4096),
same-machine **same-day** baseline commit vs. this branch:

| scenario | batch | baseline (today) | this branch | Δ |
| --- | --- | --- | --- | --- |
| chaboche6 | 4096 (compute-bound) | 4233.8 ms* | 4251.1 ms | +0.4% |
| scpdecoup | 4096 (compute-bound) | 922.5 ms* | 937.4 ms | +1.6% |
| radret | 8 (host-bound) | 82.99 ms | 85.06 ms | +2.5% |

Compute-bound large-batch is flat; the host-bound small-batch difference is
within run-to-run noise for an ~80 ms host-launch-dominated run. The larger gap
against the **committed June-10** baseline (radret@8: 74.4 ms) was machine-state
drift, not code — re-running the baseline commit today on the same machine gave
82.99 ms (+11.6% over its own recorded number).

<sub>*compute-bound rows compare against the committed June-10 numbers; the
same-day re-measurement was stopped once the host-bound radret result settled the
question.</sub>

## Tests

- New `tests/aoti/test_derivative_selection.py`: default-off raises; selected
  pair matches eager; batch-independent block returned unbatched; composed
  reachability prune; crystal-plasticity global→global FD-validated; per-grain
  compile error.
- Updated `tests/unit/test_aoti_export.py` (fixtures use `-d :`, default-off
  test, per-pair IFT identity, `batch_independent` metadata),
  `tests/unit/test_sub_batch_aoti_meta.py` (schema 6), and the C++ dispatcher
  fixture/test.
- Docs updated: `aoti_packages.md`, `cli.md`, `cpp_aoti.md`, `cpp_dispatch.md`,
  `py_aoti.md`, and the compiled-models tutorial.

## Follow-up

- #381 — compiled **per-grain** (sub-batched) `jvp`/`jacobian` pairs (the
  block-preserving BLOCK/DENSE contraction). Pre-existing gap, now a clear
  compile-time error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
