### PR TITLE
Allow model reuse in implicit composition; fix leading-K Jacobian seed

### DIFF
--- a/benchmark/radret/model.i
+++ b/benchmark/radret/model.i
@@ -66,21 +66,14 @@
   [trial_elastic_strain]
     type = SR2LinearCombination
     from = 'strain plastic_strain~1'
-    to = 'trial_elastic_strain'
+    to = 'elastic_strain'
     weights = '1 -1'
   []
-  [trial_cauchy_stress]
-    type = LinearIsotropicElasticity
-    coefficients = '1e5 0.3'
-    coefficient_types = 'YOUNGS_MODULUS POISSONS_RATIO'
-    strain = 'trial_elastic_strain'
-    stress = 'trial_stress'
-  []
-  [trial_mandel_stress]
-    type = IsotropicMandelStress
-    cauchy_stress = 'trial_stress'
-    mandel_stress = 'trial_mandel_stress'
-  []
+  # The elastic response (cauchy_stress + mandel_stress) is reused from the
+  # single instances defined below for the actual return map. Each ComposedModel
+  # scope binds 'elastic_strain' to its own value (trial here, current in
+  # 'surface'), so the same elasticity instance -- and its parameters -- serves
+  # both, rather than duplicating the model.
   [trial_isoharden]
     type = LinearIsotropicHardening
     equivalent_plastic_strain = 'equivalent_plastic_strain~1'
@@ -95,7 +88,7 @@
   []
   [trial_overstress]
     type = SR2LinearCombination
-    from = 'trial_mandel_stress trial_backstress'
+    from = 'mandel_stress trial_backstress'
     to = 'trial_overstress'
     weights = '1 -1'
   []
@@ -120,12 +113,12 @@
     type = Normality
     model = 'trial_flow'
     function = 'trial_yield_function'
-    from = 'trial_mandel_stress trial_isoharden trial_backstress'
+    from = 'mandel_stress trial_isoharden trial_backstress'
     to = 'NM Nk NX'
   []
   [trial_state]
     type = ComposedModel
-    models = 'trial_elastic_strain trial_cauchy_stress trial_mandel_stress
+    models = 'trial_elastic_strain cauchy_stress mandel_stress
               trial_isoharden trial_kinharden trial_normality'
   []
   ###############################################################################

--- a/neml2/cli/aoti_export.py
+++ b/neml2/cli/aoti_export.py
@@ -209,7 +209,14 @@ def _leading_k_identity_seed(
     mid = (1,) * len(batch_shape)
     eye = eye.reshape(n, *mid, *type_cls.BASE_SHAPE)
     data = eye.expand(n, *tuple(batch_shape), *type_cls.BASE_SHAPE).contiguous()
-    return type_cls(data)
+    # Declare the leading axis as a K region (one "full" seed axis of size n)
+    # rather than folding it into the batch. Derivative-leaf models (e.g.
+    # Normality) emit tangents with k_ndim=1; if the seed leaves K folded
+    # (k_ndim=0), the two conventions collide in align_k when both feed the
+    # same downstream sum (e.g. a frozen flow_direction passed as a given to an
+    # ImplicitUpdate solve). Establishing the K region at the seed keeps the
+    # whole chain rule consistent.
+    return type_cls(data, k_ndim=1, k_state=("full",), k_pairing=(None,))
 
 
 def _leading_k_block_to_trailing_k(block: torch.Tensor | TensorWrapper) -> torch.Tensor:

--- a/neml2/models/common/ComposedModel.py
+++ b/neml2/models/common/ComposedModel.py
@@ -141,71 +141,9 @@ def _walk_nl_params(m: Model) -> dict[str, NLParam]:
     return dict(getattr(m, "_nl_params", {}))
 
 
-def _internal_models(m: Model) -> dict[int, Model]:
-    """Object-id → model map for every model transitively evaluated by m.
-
-    Empty for a leaf. For a ``ComposedModel``, the union of every plan
-    submodule plus its own internals, recursively.
-    """
-    if not hasattr(m, "_plan"):
-        return {}
-    inner: dict[int, Model] = {}
-    for attr, *_ in m._plan:  # type: ignore[attr-defined]
-        sub = getattr(m, attr)
-        inner[id(sub)] = sub
-        inner.update(_internal_models(sub))
-    return inner
-
-
 # v2-parity: EdgeInfo / per-label composition machinery removed. The chain
 # rule no longer dispatches on labels -- it uses positional K_pairing
 # metadata. The composed map is just inherited reachability now.
-
-
-def _check_no_redundant_nl_param_provider(ordered: list[Model]) -> None:
-    """Refuse compositions where the same nl-param provider would be
-    evaluated more than once per outer call.
-
-    The case caught: an outer ``ComposedModel`` lists provider ``P`` as a
-    direct child (explicitly or via auto-include) AND one of its other
-    children is itself a ``ComposedModel`` that also evaluates ``P``
-    internally (via *its* own auto-include of ``P`` from one of its
-    grandchildren's nl-params). The outer would then call ``P`` once as a
-    direct step and a second time through the inner -- silently wasted
-    work, and a sign that the composition wants restructuring (typically:
-    drop the explicit listing, or split ``P`` out so it's owned by exactly
-    one ancestor).
-
-    Detected by id() equality so a model that's deliberately registered as
-    a child of multiple ComposedModels (a legitimate sharing pattern when
-    each ComposedModel runs in isolation) is *not* flagged -- the check
-    only fires when the same instance appears at two different levels of
-    the SAME outer's evaluation tree.
-    """
-    direct_ids = {id(m): m for m in ordered}
-    for child in ordered:
-        inner_ids = _internal_models(child)
-        # Don't flag the child against itself.
-        inner_ids.pop(id(child), None)
-        overlap = set(direct_ids) & set(inner_ids)
-        if not overlap:
-            continue
-        dup_models = [direct_ids[i] for i in overlap]
-
-        def _name(m: Model) -> str:
-            hit = getattr(m, "_hit_name", None)
-            return repr(hit) if hit else type(m).__name__
-
-        dup_str = ", ".join(_name(m) for m in dup_models)
-        raise ValueError(
-            f"Redundant nl-param provider in ComposedModel: "
-            f"{dup_str} appears both as a direct child AND inside "
-            f"the child {_name(child)}. The provider would be evaluated "
-            "more than once per outer call. Resolve by either (a) removing "
-            "the explicit listing -- the inner composition's auto-include "
-            "already provides it -- or (b) restructuring so the provider "
-            "lives in exactly one ancestor."
-        )
 
 
 if TYPE_CHECKING:
@@ -294,8 +232,6 @@ class ComposedModel(Model):
                 ordered.append(nlp.provider)
                 seen_ids.add(id(nlp.provider))
                 queue.append(nlp.provider)
-
-        _check_no_redundant_nl_param_provider(ordered)
 
         ao_node = node.find("additional_outputs")
         additional_outputs = node.param_list_str("additional_outputs") if ao_node else None

--- a/neml2/models/common/ImplicitUpdate.py
+++ b/neml2/models/common/ImplicitUpdate.py
@@ -119,8 +119,17 @@ def _matrix_pushforward(
     # leading (K, *dynamic_batch) axes. ``tangent.dynamic_batch_shape``
     # already includes the chain-rule K dim, so it is the full leading
     # axis count for the flat tensor.
-    dyn_ndim = len(tangent.dynamic_batch_shape)
     type_t = type(tangent)
+    # Leading axes to preserve when flattening the tangent's trailing
+    # (sub_batch + base) axes into a single DOF axis. A chain-rule tangent's
+    # layout is [K | dynamic_batch | sub_batch | base] (see neml2.types._base):
+    # the leading region is the K (seed-direction) axes PLUS the dynamic batch
+    # axes. The earlier code used len(dynamic_batch_shape), which by definition
+    # excludes the K region (dynamic_batch_shape starts after k_ndim), so for a
+    # tangent carrying k_ndim > 0 it dropped the K axis -- e.g. an SR2 tangent
+    # (K=6, batch=8, base=6) was flattened as if its leading shape were just
+    # (8,) and reshaped to (6, 6), failing on size 288.
+    dyn_ndim = tangent.k_ndim + len(tangent.dynamic_batch_shape)
     sub_total = 1
     for s in tangent.sub_batch_shape:
         sub_total *= int(s)
@@ -139,9 +148,18 @@ def _matrix_pushforward(
     else:
         # Scalar output with no sub-batch: drop the trailing length-1.
         contribution = contribution_t.data.squeeze(-1)
+    # The generic Tensor matmul above is K-unaware (it folds the leading K axes
+    # into batch), so re-declare the K region on the output: the contribution's
+    # leading axes are [K | dynamic_batch], and downstream chain-rule ops + the
+    # final Jacobian assembly need k_ndim to map the K directions back onto the
+    # seeded input's base. Carry the tangent's K metadata through unchanged --
+    # the contraction touches only the trailing DOF axis, leaving K intact.
     return output_type(
         contribution,
         sub_batch_ndim=len(output_sub_batch_shape),
+        k_ndim=tangent.k_ndim,
+        k_state=tangent.k_state,
+        k_pairing=tangent.k_pairing,
     )
 
 

--- a/tests/regression/solid_mechanics/rate_independent_plasticity/radial_return/model.i
+++ b/tests/regression/solid_mechanics/rate_independent_plasticity/radial_return/model.i
@@ -49,21 +49,14 @@
   [trial_elastic_strain]
     type = SR2LinearCombination
     from = 'E plastic_strain~1'
-    to = 'Ee_trial'
+    to = 'elastic_strain'
     weights = '1 -1'
   []
-  [trial_cauchy_stress]
-    type = LinearIsotropicElasticity
-    coefficients = '1e5 0.3'
-    coefficient_types = 'YOUNGS_MODULUS POISSONS_RATIO'
-    strain = 'Ee_trial'
-    stress = 'S_trial'
-  []
-  [trial_mandel_stress]
-    type = IsotropicMandelStress
-    cauchy_stress = 'S_trial'
-    mandel_stress = 'M_trial'
-  []
+  # The elastic response (cauchy_stress + mandel_stress) is reused from the
+  # single instances defined below for the actual return map. Each ComposedModel
+  # scope binds 'elastic_strain' to its own value (trial here, current in
+  # 'surface'), so the same elasticity instance -- and its parameters -- serves
+  # both, rather than duplicating the model.
   [trial_isoharden]
     type = LinearIsotropicHardening
     equivalent_plastic_strain = 'equivalent_plastic_strain~1'
@@ -79,7 +72,7 @@
   [trial_overstress]
     type = SR2LinearCombination
     to = 'O_trial'
-    from = 'M_trial X_trial'
+    from = 'mandel_stress X_trial'
     weights = '1 -1'
   []
   [trial_vonmises]
@@ -103,12 +96,12 @@
     type = Normality
     model = 'trial_flow'
     function = 'fp_trial'
-    from = 'M_trial k_trial X_trial'
+    from = 'mandel_stress k_trial X_trial'
     to = 'NM Nk NX'
   []
   [trial_state]
     type = ComposedModel
-    models = 'trial_elastic_strain trial_cauchy_stress trial_mandel_stress
+    models = 'trial_elastic_strain cauchy_stress mandel_stress
               trial_isoharden trial_kinharden trial_normality'
   []
   ###############################################################################

--- a/tests/regression/solid_mechanics/viscoplasticity/radial_return/model.i
+++ b/tests/regression/solid_mechanics/viscoplasticity/radial_return/model.i
@@ -49,21 +49,14 @@
   [trial_elastic_strain]
     type = SR2LinearCombination
     from = 'E plastic_strain~1'
-    to = 'Ee_trial'
+    to = 'elastic_strain'
     weights = '1 -1'
   []
-  [trial_cauchy_stress]
-    type = LinearIsotropicElasticity
-    coefficients = '1e5 0.3'
-    coefficient_types = 'YOUNGS_MODULUS POISSONS_RATIO'
-    strain = 'Ee_trial'
-    stress = 'S_trial'
-  []
-  [trial_mandel_stress]
-    type = IsotropicMandelStress
-    cauchy_stress = 'S_trial'
-    mandel_stress = 'M_trial'
-  []
+  # The elastic response (cauchy_stress + mandel_stress) is reused from the
+  # single instances defined below for the actual return map. Each ComposedModel
+  # scope binds 'elastic_strain' to its own value (trial here, current in
+  # 'surface'), so the same elasticity instance -- and its parameters -- serves
+  # both, rather than duplicating the model.
   [trial_isoharden]
     type = LinearIsotropicHardening
     equivalent_plastic_strain = 'equivalent_plastic_strain~1'
@@ -79,7 +72,7 @@
   [trial_overstress]
     type = SR2LinearCombination
     to = 'O_trial'
-    from = 'M_trial X_trial'
+    from = 'mandel_stress X_trial'
     weights = '1 -1'
   []
   [trial_vonmises]
@@ -103,12 +96,12 @@
     type = Normality
     model = 'trial_flow'
     function = 'fp_trial'
-    from = 'M_trial k_trial X_trial'
+    from = 'mandel_stress k_trial X_trial'
     to = 'NM Nk NX'
   []
   [trial_state]
     type = ComposedModel
-    models = 'trial_elastic_strain trial_cauchy_stress trial_mandel_stress trial_isoharden trial_kinharden trial_normality'
+    models = 'trial_elastic_strain cauchy_stress mandel_stress trial_isoharden trial_kinharden trial_normality'
   []
   ###############################################################################
   # The actual radial return:

--- a/tests/unit/test_eager.py
+++ b/tests/unit/test_eager.py
@@ -260,6 +260,75 @@ def test_jvp_jacobian_composed_multi_output():
         assert torch.allclose(jvp_out[o_name], expect, atol=1e-10)
 
 
+# --- implicit-model Jacobian vs finite differences ----------------------------
+# Regression for the leading-K (``k_ndim``) seed-region convention. The Jacobian
+# seed declares its identity directions as a K region, and derivative-leaf models
+# (e.g. ``Normality``) emit tangents carrying that region. When such a leaf
+# output is frozen and passed as a *given* to an ``ImplicitUpdate`` solve (radial
+# return), its tangent is summed -- in ``_output_sensitivities`` -- with the
+# direct input tangent for the same seed. If the seed left K folded into the
+# batch (``k_ndim=0``) while the leaf used ``k_ndim=1``, ``align_k`` could not
+# reconcile the two and produced a malformed block. These composed models
+# exercise that path through the ``d(output)/d(E)`` column (``E`` feeds both the
+# frozen ``flow_direction`` and the implicit residual directly). Implicit-model
+# Jacobians were previously covered only for forward values, so this was latent.
+
+_SM_REGRESSION = _REPO / "tests" / "regression" / "solid_mechanics"
+_IMPLICIT_JAC_MODELS = [
+    _SM_REGRESSION / "viscoplasticity" / "radial_return" / "model.i",
+    _SM_REGRESSION / "viscoplasticity" / "isoharden" / "model.i",
+    _SM_REGRESSION / "viscoplasticity" / "chaboche" / "model.i",
+    _SM_REGRESSION / "rate_independent_plasticity" / "perfect" / "model.i",
+    _SM_REGRESSION / "rate_independent_plasticity" / "radial_return" / "model.i",
+]
+
+
+def _fd_strain_column(m, inputs, o_name, h=1e-7):
+    """Central-difference ``d(o_name)/d(E)`` -> ``(*batch, *out_base, 6)``."""
+    base = inputs["E"]
+    cols = []
+    for k in range(6):
+        e = torch.zeros_like(base)
+        e[..., k] = h
+        fp = m.forward({**inputs, "E": base + e})[o_name]
+        fm = m.forward({**inputs, "E": base - e})[o_name]
+        cols.append((fp - fm) / (2 * h))
+    return torch.stack(cols, dim=-1)
+
+
+@pytest.mark.parametrize(
+    "path", _IMPLICIT_JAC_MODELS, ids=lambda p: f"{p.parents[1].name}-{p.parent.name}"
+)
+def test_implicit_jacobian_strain_column_matches_fd(path):
+    m = _EagerModel(str(path), "model")
+    b = 4
+    # Uniaxial strain well into the plastic regime (yield strain ~1e-3), with all
+    # lagged states left at the fresh-start zero and t = 1 (dt = 1). Perturbing
+    # only E avoids predictor-only inputs (e.g. gamma~1), whose converged-solution
+    # sensitivity is a structural zero the central difference cannot resolve.
+    inputs = {}
+    for name, base_shape in zip(m.input_names, m.input_base_shapes, strict=True):
+        if name == "t":
+            inputs[name] = torch.ones(b, *base_shape, dtype=m.dtype, device=m.device)
+        elif name == "E":
+            strain = torch.zeros(b, *base_shape, dtype=m.dtype, device=m.device)
+            strain[..., 0] = 5e-3
+            strain[..., 1] = strain[..., 2] = -0.3 * 5e-3
+            inputs[name] = strain
+        else:
+            inputs[name] = torch.zeros(b, *base_shape, dtype=m.dtype, device=m.device)
+
+    _, jac = m.jacobian(inputs)
+    for o_name, o_base in zip(m.output_names, m.output_base_shapes, strict=True):
+        block = jac[o_name]["E"]
+        assert tuple(block.shape) == (b, *o_base, 6)
+        ref = _fd_strain_column(m, inputs, o_name)
+        scale = ref.abs().max().item() + 1e-30
+        assert (block - ref).abs().max().item() / scale < 1e-5, (
+            f"{path.parent.name}: d({o_name})/dE disagrees with finite differences"
+        )
+
+
 # --- #2 plain-batch guard: reject sub-batch (crystal-plasticity) models -------
 
 


### PR DESCRIPTION
## Summary

Lets a single model instance (e.g. `elasticity`) be reused across a trial state and the implicit return-map surface, as in radial return. This matters for **parameter calibration**, where the trial and regular elasticity must share parameters rather than being two independent copies.

Two framework changes were required to make reuse work, plus a deduplication of the example/benchmark inputs that now rely on it.

## Changes

### 1. Allow reuse — drop the redundant-provider guard (`ComposedModel.py`)
Removed the `_check_no_redundant_nl_param_provider` guard (and the `_internal_models` helper it used) that forbade the same nl-param provider from appearing both as a direct child and inside a sub-model. The same instance may now appear both directly and inside a sub-model of the same outer `ComposedModel`.

### 2. Fix the leading-K (`k_ndim`) Jacobian seed (`aoti_export.py`, `ImplicitUpdate.py`)
`_leading_k_identity_seed` previously folded its K axis into the batch (`k_ndim=0`), while derivative-leaf models (e.g. `Normality`) emit tangents with `k_ndim=1`. When a frozen `Normality` output is passed as a *given* to an `ImplicitUpdate` solve, the two conventions collided in `align_k` during `_output_sensitivities`, producing a malformed Jacobian block.

- The seed now declares its K region explicitly: `k_ndim=1, k_state=("full",), k_pairing=(None,)`.
- `ImplicitUpdate._matrix_pushforward` now counts K in its dynamic-batch ndim (`tangent.k_ndim + len(tangent.dynamic_batch_shape)`) and carries the K metadata onto its output. The earlier `len(dynamic_batch_shape)` excluded the K region, so an `SR2` tangent (K=6, batch=8, base=6) was flattened as if its leading shape were just `(8,)` and reshaped to `(6, 6)`, failing on size 288.

The seed's K region is over base DOFs (genuinely full) and is orthogonal to the sub-batch broadcast region, so crystal-plasticity cross-sub-batch compactness is unaffected — verified identical tangent storage with/without the change and exact autograd match.

### 3. Deduplicate elasticity in the radial-return examples
Now that an instance can be reused across `ComposedModel` scopes, the trial state and the return-map surface share a single `elasticity` + `mandel_stress` instance instead of duplicating them (`trial_cauchy_stress` / `trial_mandel_stress` removed). Each scope binds its own `elastic_strain`, mirroring the MOOSE `radial_return_neml2.i` pattern. Touches `benchmark/radret/model.i` and the two regression `model.i` files.

Gold results unchanged for both regression examples; `benchmark/radret` output byte-identical.

## Tests

Adds `test_implicit_jacobian_strain_column_matches_fd` (`tests/unit/test_eager.py`), FD-checking `d(out)/d(E)` for five composed implicit models. Implicit-model Jacobians were previously covered only for forward values, so the leading-K bug was latent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)