### PR TITLE
Add `neml2-compile --interactive` wizard (Questionary)

### DIFF
--- a/doc/content/deployment/cli.md
+++ b/doc/content/deployment/cli.md
@@ -167,6 +167,24 @@ artifact from Python, parameter promotion (`-p <name>`), and the
 trade-offs against eager mode — lives in
 [](tutorials-models-compiled).
 
+### Interactive mode (`-i` / `--interactive`)
+
+`neml2-compile`'s flag surface is wide and interdependent: the promotable
+parameter names (`-p`) and the valid `OUT:IN` derivative pairs (`-d`) only exist
+once the model is loaded and introspected. Pass `-i` / `--interactive` to be
+guided through the options with prompts populated from the model, ending on a
+review you can run, edit, or copy as a plain `neml2-compile` command:
+
+```bash
+neml2-compile -i input.i
+```
+
+The input file is required (give it on the command line so the shell completes
+the path); `--load` extensions are honored. Interactive mode is powered by
+[Questionary](https://questionary.readthedocs.io/), a lightweight dependency
+carried in the `dev` extra rather than the core install — if it is missing the
+flag prints a `pip install questionary` hint and exits.
+
 ## `neml2-stub`
 
 Regenerates `.pyi` type stubs for every pybind11 extension module in the

--- a/neml2/cli/_compile_interactive.py
+++ b/neml2/cli/_compile_interactive.py
@@ -1,0 +1,232 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Framework-free core for ``neml2-compile --interactive``.
+
+The interactive (``-i`` / ``--interactive``) mode of ``neml2-compile`` walks the
+user through the tool's wide, interdependent flag surface as a sequence of
+prompts, introspecting the chosen model to offer its promotable parameters and
+derivative variables. This module holds the **pure** pieces of that flow -- the
+state dataclasses, the ``neml2-compile`` argv builder, and the introspection /
+validation / block-listing helpers -- with no dependency on ``questionary``, so
+they are unit-testable on their own. The interactive prompt loop that consumes
+them lives in :mod:`neml2.cli._compile_wizard`.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class FormState:
+    """A snapshot of the wizard's answers, sufficient to build the compile argv.
+
+    Pure data -- the wizard collects answers into one of these and every
+    command-building / validation helper consumes it, so the non-interactive
+    logic is testable in isolation.
+    """
+
+    input_file: str = ""
+    target: str = "model"  # "model" | "driver"
+    name: str = ""
+    devices: tuple[str, ...] = ("cpu",)
+    dtype: str = "float64"
+    output_dir: str = "./aoti"
+    promoted: tuple[str, ...] = ()
+    derivatives: tuple[str, ...] = ()  # "OUT:IN" specs
+    example_shape: tuple[str, ...] = ()  # raw --example-batch-shape entries
+    dynamic_batch: bool | None = None  # None => emit neither flag
+    load: tuple[str, ...] = ()  # --load extension modules
+
+
+@dataclass(frozen=True)
+class IntrospectionForm:
+    """The model facts the wizard needs, reduced from :func:`inspect._model_to_dict`.
+
+    ``promotable`` are the dotted names ``-p`` accepts (parameters + buffers);
+    ``outputs`` / ``inputs`` are the variable names that populate the derivative
+    ``OUT`` / ``IN`` choices; ``input_types`` maps each input name to its tensor
+    type (e.g. ``"SR2"``) for display in the example-batch-shape hint.
+    """
+
+    promotable: list[str] = field(default_factory=list)
+    outputs: list[str] = field(default_factory=list)
+    inputs: list[str] = field(default_factory=list)
+    input_types: dict[str, str] = field(default_factory=dict)
+
+
+def _dedupe(items: tuple[str, ...] | list[str]) -> list[str]:
+    """Order-preserving de-duplication (mirrors ``neml2-compile``'s device handling)."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def build_compile_argv(state: FormState) -> list[str]:
+    """Build the ``neml2-compile`` argv (sans program name) from *state*.
+
+    The argument order mirrors :func:`neml2.cli.aoti_compile._build_arg_parser`
+    so the previewed command is exactly what the real CLI parses. The same argv
+    drives both the preview (:func:`preview_command`) and the actual run -- a
+    single builder guarantees "what you preview is what runs".
+    """
+    argv: list[str] = []
+
+    # Positional input first -- keeps argparse from folding it into the
+    # nargs="+" --device list below.
+    if state.input_file:
+        argv.append(state.input_file)
+
+    # Exactly one of --model / --driver (the CLI's mutually-exclusive group).
+    flag = "--driver" if state.target == "driver" else "--model"
+    if state.name:
+        argv += [flag, state.name]
+
+    if state.output_dir:
+        argv += ["--output-dir", state.output_dir]
+
+    devices = _dedupe(state.devices)
+    if devices:
+        # Single nargs="+" flag: `--device cpu cuda`. Safe because every token
+        # that follows starts with `-`, so argparse stops consuming here.
+        argv += ["--device", *devices]
+
+    if state.dtype:
+        argv += ["--dtype", state.dtype]
+
+    for name in state.promoted:
+        argv += ["-p", name]
+
+    for spec in state.derivatives:
+        argv += ["-d", spec]
+
+    for spec in state.example_shape:
+        argv += ["--example-batch-shape", spec]
+
+    if state.dynamic_batch is True:
+        argv.append("--dynamic-batch")
+    elif state.dynamic_batch is False:
+        argv.append("--no-dynamic-batch")
+
+    for path in state.load:
+        argv += ["--load", path]
+
+    return argv
+
+
+def preview_command(state: FormState) -> str:
+    """Render the shell command the wizard would run, with shell-safe quoting.
+
+    ``shlex.join`` quotes specs containing ``;`` / ``(`` / spaces (e.g.
+    ``strain=(2;100)``) so the previewed line is copy-pasteable into a shell.
+    """
+    return "neml2-compile " + shlex.join(build_compile_argv(state))
+
+
+def introspection_to_form(data: dict[str, Any]) -> IntrospectionForm:
+    """Reduce :func:`neml2.cli.inspect._model_to_dict` output to wizard choices.
+
+    Promotable names are parameters followed by buffers (both are valid ``-p``
+    targets, per :func:`neml2.cli.aoti_export._validate_promoted`); the
+    derivative choices draw from the output / (structural) input variable names.
+    """
+    promotable = [p["name"] for p in data.get("parameters", [])]
+    promotable += [b["name"] for b in data.get("buffers", [])]
+    outputs = [o["name"] for o in data.get("outputs", [])]
+    inputs = [i["name"] for i in data.get("inputs", [])]
+    input_types = {i["name"]: i.get("type", "") for i in data.get("inputs", [])}
+    return IntrospectionForm(
+        promotable=promotable, outputs=outputs, inputs=inputs, input_types=input_types
+    )
+
+
+def validate_state(state: FormState) -> list[str]:
+    """Return human-readable problems that block a compile (empty == ready)."""
+    problems: list[str] = []
+    if not state.input_file.strip():
+        problems.append("Input file is required.")
+    elif not Path(state.input_file).expanduser().exists():
+        problems.append(f"Input file not found: {state.input_file}")
+    if not state.name.strip():
+        problems.append(f"A {state.target} name is required.")
+    if not state.devices:
+        problems.append("Select at least one device.")
+    return problems
+
+
+def list_section_entries(path: str | Path, section: str) -> list[tuple[str, str]]:
+    """List ``(name, type)`` for every block under top-level ``[section]``.
+
+    ``type`` is the block's ``type = ...`` field (e.g. ``"LinearIsotropicElasticity"``
+    for a model, ``"TransientDriver"`` for a driver), or ``""`` if absent. Parses
+    with ``nmhit`` only -- no model/driver is instantiated, so this works even
+    when a block's ``type`` is a user extension that has not been imported.
+    Mirrors the walk in :func:`neml2.cli.aoti_compile.driver_target_model`.
+    """
+    import nmhit  # noqa: PLC0415
+
+    root = nmhit.parse_file(str(path), [], [])
+    entries: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for top in root.children(nmhit.NodeType.Section):
+        if top.path() != section:
+            continue
+        for child in top.children(nmhit.NodeType.Section):
+            name = child.path()
+            if name in seen:
+                continue
+            seen.add(name)
+            entries.append((name, child.param_optional_str("type", "")))
+    return entries
+
+
+def list_model_names(path: str | Path) -> list[str]:
+    """Names of the ``[Models]`` blocks in *path* (no instantiation)."""
+    return [name for name, _ in list_section_entries(path, "Models")]
+
+
+def list_driver_names(path: str | Path) -> list[str]:
+    """Names of the ``[Drivers]`` blocks in *path* (no instantiation)."""
+    return [name for name, _ in list_section_entries(path, "Drivers")]
+
+
+__all__ = [
+    "FormState",
+    "IntrospectionForm",
+    "build_compile_argv",
+    "preview_command",
+    "introspection_to_form",
+    "validate_state",
+    "list_section_entries",
+    "list_model_names",
+    "list_driver_names",
+]

--- a/neml2/cli/_compile_wizard.py
+++ b/neml2/cli/_compile_wizard.py
@@ -1,0 +1,568 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""The interactive Questionary flow behind ``neml2-compile --interactive``.
+
+Imported lazily by :func:`neml2.cli.aoti_compile.main` only after the
+``questionary`` dependency is confirmed present, so ``neml2-compile``'s normal
+(non-interactive) path never imports it. The framework-free core it builds on
+lives in :mod:`neml2.cli._compile_interactive`.
+
+The flow has two parts: a guided linear pass that asks each option in turn
+(target, name, parameters, derivatives, devices, dtype, output dir, batch
+shape), then a **review screen** that shows every answer plus the equivalent
+``neml2-compile`` command and lets the user jump back to *any* field to change it
+before running. Questionary has no built-in "go back", so this review/edit loop
+is how earlier answers are revisited. On confirmation it runs the *exact*
+previewed command as a subprocess that inherits this terminal, so the tool itself
+does no log capture -- ``neml2-compile``'s own output streams straight to the
+user.
+
+Every prompt returns ``None`` when the user cancels (Ctrl-C / Esc); during the
+linear pass that aborts the wizard, while in the review/edit loop it just returns
+to the review.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import questionary
+
+from ._compile_interactive import (
+    FormState,
+    IntrospectionForm,
+    build_compile_argv,
+    introspection_to_form,
+    list_section_entries,
+    preview_command,
+    validate_state,
+)
+
+# (state key, human label) for every editable field, in the order the linear
+# pass asks them and the order the edit menu lists them.
+_FIELDS: list[tuple[str, str]] = [
+    ("target", "Target"),
+    ("name", "Name"),
+    ("promoted", "Parameters"),
+    ("derivatives", "Derivatives"),
+    ("devices", "Devices"),
+    ("dtype", "dtype"),
+    ("output_dir", "Output dir"),
+    ("example_shape", "Example batch shape"),
+    ("dynamic_batch", "Dynamic batch"),
+]
+
+# Distinct sentinel for the edit menu's "back" choice. A questionary ``Choice``
+# substitutes the *title* for a ``None`` value, so ``None`` cannot be used to
+# mean "no field" -- it would arrive as the string "↩ back".
+_BACK = object()
+
+# One-line explanation per field, printed as a muted line just above its prompt.
+# (Questionary's high-level API has no persistent bottom toolbar, and its
+# ``instruction=`` argument is not uniformly usable -- ``path`` rejects it and
+# ``confirm`` lets it clobber the ``[y/N]`` hint -- so help is printed instead.)
+_HELP: dict[str, str] = {
+    "target": "Compile a [Models] block directly, or the model a [Drivers] block runs.",
+    "name": "The block to compile (its type is shown in parentheses).",
+    "promoted": "Checked params become runtime-settable graph inputs instead of baked "
+    "constants; space toggles, enter confirms.",
+    "derivatives": "Also compile Jacobian/JVP graphs for chosen output:input pairs "
+    "(needed for jvp()/jacobian() at runtime).",
+    "devices": "Target device(s), baked at export; one artifact is emitted per device.",
+    "dtype": "Floating-point precision baked into the artifact.",
+    "output_dir": "Directory for the .pt2 artifacts and the runnable HIT stub.",
+    "example_shape": "Trace-time shape per input; '(dyn;sub)' splits dynamic from "
+    "sub-batch axes, e.g. (2;100). Blank = default.",
+    "dynamic_batch": "Let the leading batch dimension vary at runtime (vs. pinned to "
+    "the example shape).",
+}
+
+
+def run_wizard(*, input_file: str, initial_load: tuple[str, ...] = ()) -> int:
+    """Drive the interactive compile wizard for *input_file*. Returns an exit code.
+
+    *input_file* is taken from the ``neml2-compile`` command line (a required
+    positional) rather than prompted for -- the shell's own path completion beats
+    an in-prompt one, and an input file is needed to begin with.
+    """
+    input_file = input_file.strip()
+    if not input_file or not Path(input_file).expanduser().exists():
+        print(f"Error: input file not found: {input_file!r}", file=sys.stderr)
+        return 1
+    questionary.print(f"Input file: {input_file}", style="bold")
+
+    # User extensions must register before we list / load anything.
+    if initial_load:
+        from ._extensions import load_user_extensions  # noqa: PLC0415
+
+        try:
+            load_user_extensions(list(initial_load))
+        except ImportError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+
+    state = _default_state()
+    cache: dict[tuple[str, str], IntrospectionForm | None] = {}
+
+    # Guided linear pass -- cancelling any prompt aborts the wizard.
+    for field, _label in _FIELDS:
+        if not _ask_field(field, input_file, state, cache):
+            return _aborted()
+
+    # Review / edit loop -- the "go back to a previous question" surface.
+    while True:
+        fs = _form_state(input_file, state, initial_load)
+        _print_review(fs)
+        action = questionary.select(
+            "What would you like to do?",
+            choices=[
+                questionary.Choice("Run the compile", "run"),
+                questionary.Choice("Edit a field", "edit"),
+                questionary.Choice("Quit without compiling", "quit"),
+            ],
+        ).ask()
+        if action is None:
+            return _aborted()
+        if action == "quit":
+            questionary.print("Quit. Copy the command above to run it later.", style="italic")
+            return 0
+        if action == "run":
+            problems = validate_state(fs)
+            if problems:
+                for problem in problems:
+                    questionary.print(f"  - {problem}", style="fg:ansired")
+                continue
+            return run_compile(build_compile_argv(fs))
+        # action == "edit": pick a field and re-ask just that one.
+        field = questionary.select(
+            "Edit which field?",
+            choices=[questionary.Choice(label, key) for key, label in _FIELDS]
+            + [questionary.Choice("↩ back", _BACK)],
+        ).ask()
+        if field is None or field is _BACK:
+            continue
+        _ask_field(field, input_file, state, cache)
+        # Changing the target invalidates the name (different section), so re-pick.
+        if field == "target":
+            _ask_field("name", input_file, state, cache)
+
+
+def _default_state() -> dict:
+    return {
+        "target": "model",
+        "name": "",
+        "promoted": (),
+        "derivatives": (),
+        "devices": ("cpu",),
+        "dtype": "float64",
+        "output_dir": "./aoti",
+        "example_shape": (),  # tuple of raw `--example-batch-shape` entries
+        "dynamic_batch": True,
+    }
+
+
+def _ask_field(field: str, input_file: str, state: dict, cache: dict) -> bool:
+    """Prompt for one field, updating *state*. Returns False if the user cancels."""
+    # Show the field's explanation as a muted line above the prompt. (Questionary's
+    # `instruction=` is not uniformly safe -- `path` rejects it and `confirm`
+    # replaces its [y/N] hint with it -- so help goes here instead.)
+    help_text = _HELP.get(field)
+    if help_text:
+        questionary.print(help_text, style="italic fg:ansibrightblack")
+
+    if field == "target":
+        v = questionary.select(
+            "Target:", choices=["model", "driver"], default=state["target"]
+        ).ask()
+        if v is None:
+            return False
+        if v != state["target"]:
+            state["target"] = v
+            state["name"] = ""  # name belongs to the old section
+            _reset_model_dependent(state)
+        return True
+
+    if field == "name":
+        section = "Models" if state["target"] == "model" else "Drivers"
+        entries = list_section_entries(input_file, section)
+        label = f"{state['target'].capitalize()} name:"
+        if entries:
+            choices = [questionary.Choice(f"{n}  ({t})" if t else n, n) for n, t in entries]
+            default = state["name"] if any(n == state["name"] for n, _ in entries) else None
+            v = questionary.select(label, choices=choices, default=default).ask()
+        else:
+            v = questionary.text(label, default=state["name"]).ask()
+        if v is None:
+            return False
+        v = v.strip()
+        if not v:
+            questionary.print("A name is required.", style="fg:ansired")
+            return False
+        if v != state["name"]:
+            state["name"] = v
+            _reset_model_dependent(state)
+        _ensure_intro(input_file, state, cache)
+        return True
+
+    if field == "promoted":
+        intro = _ensure_intro(input_file, state, cache)
+        if not intro or not intro.promotable:
+            state["promoted"] = ()
+            questionary.print("(model has no promotable parameters)", style="italic")
+            return True
+        v = questionary.checkbox(
+            "Promote parameters to runtime inputs:",
+            choices=[
+                questionary.Choice(p, p, checked=(p in state["promoted"])) for p in intro.promotable
+            ],
+        ).ask()
+        if v is None:
+            return False
+        state["promoted"] = tuple(v)
+        return True
+
+    if field == "derivatives":
+        intro = _ensure_intro(input_file, state, cache)
+        specs = _ask_derivatives(intro, tuple(state["promoted"]), tuple(state["derivatives"]))
+        if specs is None:
+            return False
+        state["derivatives"] = tuple(specs)
+        return True
+
+    if field == "devices":
+        v = questionary.checkbox(
+            "Devices:",
+            choices=[
+                questionary.Choice("cpu", "cpu", checked="cpu" in state["devices"]),
+                questionary.Choice("cuda", "cuda", checked="cuda" in state["devices"]),
+            ],
+        ).ask()
+        if v is None:
+            return False
+        state["devices"] = tuple(v)
+        return True
+
+    if field == "dtype":
+        v = questionary.select(
+            "dtype:", choices=["float64", "float32"], default=state["dtype"]
+        ).ask()
+        if v is None:
+            return False
+        state["dtype"] = v
+        return True
+
+    if field == "output_dir":
+        v = questionary.path(
+            "Output dir:", default=state["output_dir"], only_directories=True
+        ).ask()
+        if v is None:
+            return False
+        state["output_dir"] = v.strip()
+        return True
+
+    if field == "example_shape":
+        return _ask_example_shape(input_file, state, cache)
+
+    if field == "dynamic_batch":
+        v = questionary.confirm("Dynamic batch?", default=bool(state["dynamic_batch"])).ask()
+        if v is None:
+            return False
+        state["dynamic_batch"] = bool(v)
+        return True
+
+    raise ValueError(f"unknown field {field!r}")  # pragma: no cover -- defensive
+
+
+def _ask_example_shape(input_file: str, state: dict, cache: dict) -> bool:
+    """Ask the example batch shape: a uniform shape for all inputs, or a custom
+    shape for a chosen subset of inputs.
+
+    First ask whether to apply one uniform shape; if so, prompt that single value.
+    Otherwise let the user pick which inputs to customize and prompt only those.
+    Non-blank per-input answers become ``name=spec`` ``--example-batch-shape``
+    entries; a non-blank uniform answer is a single bare entry. When introspection
+    is unavailable, fall back to one free-text prompt.
+    """
+    intro = _ensure_intro(input_file, state, cache)
+    entries = tuple(state["example_shape"])
+    # Split existing entries into a uniform value vs. per-variable specs (defaults).
+    current_per_var = {
+        k.strip(): v.strip()
+        for entry in entries
+        if "=" in entry and not entry.lstrip().startswith("(")
+        for k, _, v in [entry.partition("=")]
+    }
+    current_uniform = entries[0] if len(entries) == 1 and "=" not in entries[0] else ""
+
+    if not intro or not intro.inputs:
+        prev = entries[0] if entries else ""
+        v = questionary.text(
+            "Example batch shape (optional, e.g. (2,) or strain=(2;100)):", default=prev
+        ).ask()
+        if v is None:
+            return False
+        v = v.strip()
+        state["example_shape"] = (v,) if v else ()
+        return True
+
+    uniform = questionary.confirm(
+        "Apply a uniform example batch shape to all inputs?", default=bool(current_uniform)
+    ).ask()
+    if uniform is None:
+        return False
+    if uniform:
+        v = questionary.text(
+            "Uniform example batch shape (e.g. (2,) or (2;100); blank = default):",
+            default=current_uniform,
+        ).ask()
+        if v is None:
+            return False
+        v = v.strip()
+        state["example_shape"] = (v,) if v else ()
+        return True
+
+    # Customize: pick which inputs to set, then prompt only those.
+    which = questionary.checkbox(
+        "Customize the example shape for which inputs? (none = use defaults)",
+        choices=[
+            questionary.Choice(
+                f"{n} ({intro.input_types.get(n) or '?'})", n, checked=(n in current_per_var)
+            )
+            for n in intro.inputs
+        ],
+    ).ask()
+    if which is None:
+        return False
+    specs: dict[str, str] = {}
+    for name in which:
+        typ = intro.input_types.get(name) or "?"
+        v = questionary.text(f"  {name} ({typ}):", default=current_per_var.get(name, "")).ask()
+        if v is None:
+            return False
+        v = v.strip()
+        if v:
+            specs[name] = v
+    state["example_shape"] = tuple(f"{k}={v}" for k, v in specs.items())
+    return True
+
+
+def _reset_model_dependent(state: dict) -> None:
+    """Drop parameter / derivative selections that belong to the previous model."""
+    if state["promoted"] or state["derivatives"]:
+        questionary.print(
+            "(cleared parameter / derivative selections for the new model)", style="italic"
+        )
+    state["promoted"] = ()
+    state["derivatives"] = ()
+
+
+def _ensure_intro(input_file: str, state: dict, cache: dict) -> IntrospectionForm | None:
+    """Introspect the current (target, name), cached. ``None`` if it can't load."""
+    name = state["name"]
+    if not name:
+        return None
+    key = (state["target"], name)
+    if key in cache:
+        return cache[key]
+    try:
+        questionary.print(f"Loading model {name!r} ...", style="italic")
+        intro: IntrospectionForm | None = _introspect(input_file, state["target"], name)
+    except Exception as exc:  # noqa: BLE001
+        questionary.print(f"Could not introspect model: {exc}", style="fg:ansired")
+        intro = None
+    cache[key] = intro
+    return intro
+
+
+def _form_state(input_file: str, state: dict, initial_load: tuple[str, ...]) -> FormState:
+    return FormState(
+        input_file=input_file,
+        target=state["target"],
+        name=state["name"],
+        devices=tuple(state["devices"]),
+        dtype=state["dtype"],
+        output_dir=state["output_dir"],
+        promoted=tuple(state["promoted"]),
+        derivatives=tuple(state["derivatives"]),
+        example_shape=tuple(state["example_shape"]),
+        dynamic_batch=state["dynamic_batch"],
+        load=tuple(initial_load),
+    )
+
+
+def _print_review(fs: FormState) -> None:
+    questionary.print("\nReview:", style="bold")
+    rows = [
+        ("Target", f"{fs.target}: {fs.name or '(unset)'}"),
+        ("Parameters", ", ".join(fs.promoted) or "(none)"),
+        ("Derivatives", ", ".join(fs.derivatives) or "(none)"),
+        ("Devices", ", ".join(fs.devices) or "(none)"),
+        ("dtype", fs.dtype),
+        ("Output dir", fs.output_dir),
+        ("Example shape", ", ".join(fs.example_shape) or "(none)"),
+        ("Dynamic batch", "yes" if fs.dynamic_batch else "no"),
+    ]
+    for label, value in rows:
+        questionary.print(f"  {label:<14} {value}")
+    questionary.print("\nCommand:", style="bold")
+    questionary.print("  " + preview_command(fs))
+
+
+def _aborted() -> int:
+    print("Aborted.", file=sys.stderr)
+    return 1
+
+
+def _introspect(input_file: str, target: str, name: str) -> IntrospectionForm:
+    """Load + introspect the chosen model (resolving a driver to its model)."""
+    from ..factory import load_input  # noqa: PLC0415
+    from .aoti_compile import driver_target_model  # noqa: PLC0415
+    from .inspect import _model_to_dict  # noqa: PLC2701, PLC0415
+
+    model_name = driver_target_model(Path(input_file), name) if target == "driver" else name
+    model = load_input(input_file).get_model(model_name)
+    return introspection_to_form(_model_to_dict(model))
+
+
+def _ask_derivatives(
+    intro: IntrospectionForm | None, promoted: tuple[str, ...], current: tuple[str, ...]
+) -> list[str] | None:
+    """Select which ``OUT:IN`` derivative pairs to compile.
+
+    Returns the new list of ``out:in`` specs (``[]`` = no derivatives) or ``None``
+    if the user cancelled. With nothing selected yet it gates on a confirm then
+    runs one bulk round (two toggle-able lists -- outputs, then w.r.t.
+    inputs/params -- whose cross-product is the pair set). It then loops on a
+    round menu: add another bulk selection (hiding pairs already chosen), edit the
+    current pairs as a flat toggle list, clear, or finish.
+    """
+    if intro is None:
+        return list(current)  # can't introspect -> leave the selection unchanged
+    outputs = intro.outputs
+    # Structural inputs plus any promoted parameter (parameter derivatives).
+    inputs = list(intro.inputs) + [p for p in promoted if p not in intro.inputs]
+    if not outputs or not inputs:
+        return []
+
+    pairs = list(current)
+    if not pairs:
+        # Gate the no-derivatives case, then run one initial bulk round.
+        want = questionary.confirm("Compile derivative (Jacobian) graphs?", default=False).ask()
+        if want is None:
+            return None
+        if not want:
+            return []
+        new = _bulk_select_pairs(outputs, inputs, pairs)
+        if new is None:
+            return None
+        pairs = list(dict.fromkeys([*pairs, *new]))
+
+    # Round menu -- add more / edit / clear / finish.
+    while True:
+        if pairs:
+            questionary.print(f"Selected derivatives ({len(pairs)}):", style="bold")
+            for pair in pairs:
+                questionary.print(f"  - {pair}")
+        else:
+            questionary.print("No derivatives selected yet.", style="italic")
+        action = questionary.select(
+            "Derivatives -- what next?",
+            choices=[
+                questionary.Choice("Add a selection", "add"),
+                questionary.Choice("Edit existing selections", "edit"),
+                questionary.Choice("Clear all", "clear"),
+                questionary.Choice("Done (continue)", "done"),
+            ],
+            default="done",
+        ).ask()
+        if action is None:
+            return None
+        if action == "done":
+            return pairs
+        if action == "clear":
+            pairs = []
+        elif action == "edit":
+            kept = questionary.checkbox(
+                "Keep which derivative pairs? (uncheck to remove)",
+                choices=[questionary.Choice(p, p, checked=True) for p in pairs],
+            ).ask()
+            if kept is not None:
+                pairs = list(kept)
+        else:  # "add" -- new pairs are unioned with the (hidden) existing ones.
+            new = _bulk_select_pairs(outputs, inputs, pairs)
+            if new is not None:
+                pairs = list(dict.fromkeys([*pairs, *new]))
+
+
+def _bulk_select_pairs(
+    outputs: list[str], inputs: list[str], existing: list[str]
+) -> list[str] | None:
+    """Two toggle-able lists (outputs x w.r.t. inputs); return their cross-product
+    as ``out:in`` specs, excluding any already in *existing*. ``None`` if
+    cancelled, ``[]`` if a side is empty or everything is already selected.
+
+    Items already fully covered by *existing* are hidden: an output paired with
+    every input, then an input paired with every selected output.
+    """
+    taken = set(existing)
+    avail_out = [o for o in outputs if any(f"{o}:{i}" not in taken for i in inputs)]
+    if not avail_out:
+        questionary.print("(all output:input pairs are already selected)", style="italic")
+        return []
+    outs = questionary.checkbox(
+        "Differentiate which outputs?",
+        choices=[questionary.Choice(o, o) for o in avail_out],
+    ).ask()
+    if outs is None:
+        return None
+    if not outs:
+        return []
+    avail_in = [i for i in inputs if any(f"{o}:{i}" not in taken for o in outs)]
+    if not avail_in:
+        questionary.print("(all pairs for those outputs are already selected)", style="italic")
+        return []
+    ins = questionary.checkbox(
+        "With respect to which inputs / parameters?",
+        choices=[questionary.Choice(i, i) for i in avail_in],
+    ).ask()
+    if ins is None:
+        return None
+    if not ins:
+        return []
+    return [f"{o}:{i}" for o in outs for i in ins if f"{o}:{i}" not in taken]
+
+
+def run_compile(argv: list[str]) -> int:
+    """Run ``neml2-compile`` with *argv*, inheriting stdio so its output shows live."""
+    questionary.print(f"\n$ neml2-compile {' '.join(argv)}\n", style="bold")
+    try:
+        return subprocess.call([sys.executable, "-m", "neml2.cli.aoti_compile", *argv])
+    except KeyboardInterrupt:
+        return 130
+
+
+__all__ = ["run_wizard", "run_compile"]

--- a/neml2/cli/aoti_compile.py
+++ b/neml2/cli/aoti_compile.py
@@ -64,8 +64,23 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "metadata JSON) and emit a runnable HIT stub."
         ),
     )
+    # `input` is always required (with --interactive too: the user picks the
+    # file via shell completion, and the wizard takes it from there). Exactly one
+    # of --model/--driver is required only for a normal compile -- the wizard
+    # asks -- so the group is left optional here and enforced in main().
     parser.add_argument("input", metavar="INPUT.i", type=Path, help="HIT input file path.")
-    target = parser.add_mutually_exclusive_group(required=True)
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help=(
+            "Launch an interactive wizard that introspects INPUT.i and walks you "
+            "through the options (model/driver, promotable parameters, derivative "
+            "pairs, devices, ...), then runs the resulting compile. Requires the "
+            "'questionary' package."
+        ),
+    )
+    target = parser.add_mutually_exclusive_group(required=False)
     target.add_argument(
         "--model",
         metavar="NAME",
@@ -508,6 +523,29 @@ def main(argv: list[str] | None = None) -> int:
     # other neml2-* CLIs use.
     args, additional_args = parser.parse_known_args(argv)
 
+    # Interactive mode: hand off to the wizard, which collects the remaining
+    # options (model/driver, parameters, derivatives, ...) for the given INPUT.i
+    # and then re-runs this command with the assembled argv. `questionary` is
+    # imported lazily so the normal compile path never depends on it.
+    if args.interactive:
+        try:
+            import questionary  # noqa: F401, PLC0415
+        except ImportError:
+            print(
+                "neml2-compile --interactive needs the 'questionary' package.\n"
+                "Install it with:  pip install questionary",
+                file=sys.stderr,
+            )
+            return 1
+        from ._compile_wizard import run_wizard  # noqa: PLC0415
+
+        return run_wizard(input_file=str(args.input), initial_load=tuple(args.load))
+
+    # Non-interactive: exactly one of --model/--driver is required (argparse
+    # leaves the group optional so --interactive can omit it).
+    if (args.model is None) == (args.driver is None):
+        parser.error("exactly one of --model / --driver is required (or use --interactive)")
+
     input_path: Path = args.input.resolve()
     if not input_path.exists():
         print(f"Error: input file not found: {input_path}", file=sys.stderr)
@@ -520,7 +558,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     # Resolve the (model_name, keep_driver) pair from --model vs --driver.
-    # argparse mutual exclusion already guarantees exactly one is set.
+    # argparse mutual exclusion already guarantees at most one is set.
     if args.driver is not None:
         try:
             model_name = driver_target_model(input_path, args.driver)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,11 @@ dev = [
   # CI's typecheck workflow + scripts/repair_wheel.py both call it.
   # dependencies: pybind11_stubgen.version_min
   "pybind11-stubgen>=2.5.5",
+  # Powers `neml2-compile --interactive`. Lightweight, so it lives in dev
+  # rather than as a separate optional extra; the flag guards the import and
+  # prints a `pip install questionary` hint when it is absent.
+  # dependencies: questionary.version_min
+  "questionary>=2.1.1",
   # git
   "pre-commit",
 ]

--- a/scripts/dependencies.yaml
+++ b/scripts/dependencies.yaml
@@ -59,6 +59,11 @@ pybind11_stubgen:
   files:
     - pyproject.toml
 
+questionary:
+  version_min: "2.1.1"
+  files:
+    - pyproject.toml
+
 jupytext:
   version: "v1.19.1"
   files:

--- a/tests/unit/test_compile_interactive.py
+++ b/tests/unit/test_compile_interactive.py
@@ -585,3 +585,218 @@ def test_compile_interactive_delegates_to_wizard(monkeypatch):
 
     assert aoti_compile.main(["-i", str(_FIXTURE), "--load", "ext.py"]) == 0
     assert captured == {"input_file": str(_FIXTURE), "initial_load": ("ext.py",)}
+
+
+def test_compile_interactive_missing_questionary_hint(monkeypatch, capsys):
+    """`-i` with questionary absent prints an install hint and returns 1."""
+    import builtins  # noqa: PLC0415
+
+    from neml2.cli import aoti_compile  # noqa: PLC0415
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "questionary" or name.startswith("questionary."):
+            raise ImportError("blocked")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    assert aoti_compile.main(["-i", str(_FIXTURE)]) == 1
+    assert "pip install questionary" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# Wizard coverage: early exits, cancels, review/edit loop, helpers            #
+# --------------------------------------------------------------------------- #
+
+# A model with a promotable param + one output/input, so the linear prompt
+# sequence is deterministic for the scripted flows below.
+_WIZ_INTRO = IntrospectionForm(promotable=["E"], outputs=["stress"], inputs=["strain"])
+# Linear-pass answers (one per prompt) for that intro, with a uniform example
+# shape: target, name, promote, derivatives?, devices, dtype, output, uniform?,
+# uniform value, dynamic batch.
+_LINEAR_OK = ["model", "elasticity", ["E"], False, ["cpu"], "float64", "./aoti", True, "", True]
+
+
+def _patch_intro(monkeypatch, wiz, intro=_WIZ_INTRO):
+    monkeypatch.setattr(wiz, "_introspect", lambda *a, **k: intro)
+
+
+def test_run_wizard_bad_input_file(monkeypatch, tmp_path):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([]))
+    assert wiz.run_wizard(input_file=str(tmp_path / "missing.i")) == 1
+
+
+def test_run_wizard_extension_load_error(monkeypatch):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([]))
+    rc = wiz.run_wizard(input_file=str(_FIXTURE), initial_load=("nonexistent_module_zzz_999",))
+    assert rc == 1
+
+
+@pytest.mark.parametrize("cancel_at", range(len(_LINEAR_OK)))
+def test_run_wizard_cancel_at_any_prompt_aborts(monkeypatch, cancel_at):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary(_LINEAR_OK[:cancel_at] + [None]))
+    _patch_intro(monkeypatch, wiz)
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 1
+
+
+def test_run_wizard_name_empty_aborts(monkeypatch):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary(["model", "  "]))
+    _patch_intro(monkeypatch, wiz)
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 1
+
+
+def test_run_wizard_review_quit(monkeypatch):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([*_LINEAR_OK, "quit"]))
+    _patch_intro(monkeypatch, wiz)
+    monkeypatch.setattr(wiz, "run_compile", lambda argv: 0)
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 0
+
+
+def test_run_wizard_review_cancel_aborts(monkeypatch):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([*_LINEAR_OK, None]))
+    _patch_intro(monkeypatch, wiz)
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 1
+
+
+def test_run_wizard_review_validate_problem_then_quit(monkeypatch):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    # devices = [] -> validate_state flags it -> "run" loops back -> "quit".
+    answers = ["model", "elasticity", ["E"], False, [], "float64", "./aoti", True, "", True]
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([*answers, "run", "quit"]))
+    _patch_intro(monkeypatch, wiz)
+    monkeypatch.setattr(wiz, "run_compile", lambda argv: 0)  # must NOT be called
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 0
+
+
+def test_run_wizard_review_edit_target_reasks_name(monkeypatch):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    # review -> edit -> field "target" -> target "model" -> name re-ask "elasticity" -> run.
+    answers = [*_LINEAR_OK, "edit", "target", "model", "elasticity", "run"]
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary(answers))
+    _patch_intro(monkeypatch, wiz)
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setattr(wiz, "run_compile", lambda argv: captured.update(argv=argv) or 0)
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 0
+    assert captured["argv"][:3] == [str(_FIXTURE), "--model", "elasticity"]
+
+
+def test_run_wizard_introspection_failure_fallback(monkeypatch):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    def _boom(*a, **k):
+        raise RuntimeError("cannot load")
+
+    monkeypatch.setattr(wiz, "_introspect", _boom)
+    # No promote/derivative prompts (intro is None); example uses the free-text
+    # fallback. target, name, devices, dtype, output, example-fallback, dynamic, quit.
+    answers = ["model", "m", ["cpu"], "float64", "./aoti", "(2,)", True, "quit"]
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary(answers))
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 0
+
+
+def test_ask_example_shape_cancel_paths(monkeypatch):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    _patch_intro(monkeypatch, wiz, IntrospectionForm(outputs=["stress"], inputs=["strain"]))
+
+    def _state():
+        s = wiz._default_state()
+        s["name"] = "m"
+        return s
+
+    # Decline uniform, then cancel the "which inputs" checkbox.
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([False, None]))
+    assert wiz._ask_example_shape(str(_FIXTURE), _state(), {}) is False
+    # Decline uniform, pick strain, then cancel its per-variable text.
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([False, ["strain"], None]))
+    assert wiz._ask_example_shape(str(_FIXTURE), _state(), {}) is False
+
+
+def test_bulk_select_pairs_paths(monkeypatch):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    def q(answers):
+        monkeypatch.setattr(wiz, "questionary", _FakeQuestionary(answers))
+
+    # avail_out empty -> nothing left to add.
+    q([])
+    assert wiz._bulk_select_pairs(["a"], ["x"], ["a:x"]) == []
+    # outputs cancelled / empty.
+    q([None])
+    assert wiz._bulk_select_pairs(["a"], ["x"], []) is None
+    q([[]])
+    assert wiz._bulk_select_pairs(["a"], ["x"], []) == []
+    # avail_in empty (the one selected output is already fully paired).
+    q([["a"]])
+    assert wiz._bulk_select_pairs(["a", "b"], ["x"], ["a:x"]) == []
+    # inputs cancelled / empty.
+    q([["a"], None])
+    assert wiz._bulk_select_pairs(["a"], ["x", "y"], []) is None
+    q([["a"], []])
+    assert wiz._bulk_select_pairs(["a"], ["x", "y"], []) == []
+    # normal: cross-product, excluding the already-selected pair.
+    q([["a"], ["x", "y"]])
+    assert wiz._bulk_select_pairs(["a"], ["x", "y"], ["a:x"]) == ["a:y"]
+
+
+def test_run_compile_invokes_subprocess(monkeypatch):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([]))
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setattr(wiz.subprocess, "call", lambda cmd: captured.update(cmd=cmd) or 0)
+    assert wiz.run_compile(["in.i", "--model", "m"]) == 0
+    assert captured["cmd"][1:3] == ["-m", "neml2.cli.aoti_compile"]
+    assert captured["cmd"][-3:] == ["in.i", "--model", "m"]
+
+    def _interrupt(cmd):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(wiz.subprocess, "call", _interrupt)
+    assert wiz.run_compile(["x"]) == 130
+
+
+def test_introspect_real_model_and_driver():
+    """Exercise the real introspection body (model + driver-resolution branch)."""
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    by_model = wiz._introspect(str(_FIXTURE), "model", "elasticity")
+    assert by_model.outputs and by_model.inputs
+    by_driver = wiz._introspect(str(_FIXTURE), "driver", "driver")
+    assert by_driver.outputs == by_model.outputs  # driver resolves to the same model
+
+
+def test_argv_builder_empty_optionals():
+    """All-empty optionals exercise the skip branches in build_compile_argv."""
+    argv = build_compile_argv(
+        FormState(input_file="", name="", output_dir="", devices=(), dtype="")
+    )
+    assert argv == []

--- a/tests/unit/test_compile_interactive.py
+++ b/tests/unit/test_compile_interactive.py
@@ -1,0 +1,587 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Tests for ``neml2-compile --interactive``.
+
+The bulk of the coverage targets the framework-free pure helpers in
+:mod:`neml2.cli._compile_interactive` -- importing that module never requires
+``questionary``. The end-to-end flow test (with a scripted, fake ``questionary``)
+and the ``neml2-compile -i`` argument-handling tests are guarded by
+``importorskip("questionary")``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from neml2.cli._compile_interactive import (
+    FormState,
+    IntrospectionForm,
+    _dedupe,
+    build_compile_argv,
+    introspection_to_form,
+    list_driver_names,
+    list_model_names,
+    preview_command,
+    validate_state,
+)
+
+# The shared CLI worked-example input: a `LinearIsotropicElasticity` model named
+# `elasticity` driven by a `TransientDriver` named `driver`.
+_FIXTURE = Path(__file__).resolve().parents[2] / "doc" / "content" / "deployment" / "input.i"
+
+
+# --------------------------------------------------------------------------- #
+# build_compile_argv + the parse-back round-trip                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_argv_minimal_model():
+    state = FormState(input_file="input.i", target="model", name="elasticity", devices=("cpu",))
+    assert build_compile_argv(state) == [
+        "input.i",
+        "--model",
+        "elasticity",
+        "--output-dir",
+        "./aoti",
+        "--device",
+        "cpu",
+        "--dtype",
+        "float64",
+    ]
+
+
+def test_argv_driver_target():
+    state = FormState(input_file="input.i", target="driver", name="driver", devices=("cpu",))
+    assert build_compile_argv(state)[:3] == ["input.i", "--driver", "driver"]
+
+
+def test_argv_multidevice_dedup_single_flag():
+    state = FormState(name="m", devices=("cpu", "cuda", "cpu"))
+    argv = build_compile_argv(state)
+    i = argv.index("--device")
+    # Single nargs="+" flag, de-duped, order preserved.
+    assert argv[i : i + 3] == ["--device", "cpu", "cuda"]
+    assert "--device" not in argv[i + 1 :]
+
+
+def test_argv_promoted_and_derivatives_repeat():
+    state = FormState(
+        name="m",
+        devices=("cpu",),
+        promoted=("E", "nu"),
+        derivatives=("stress:strain", ":"),
+    )
+    argv = build_compile_argv(state)
+    assert [argv[k + 1] for k, t in enumerate(argv) if t == "-p"] == ["E", "nu"]
+    assert [argv[k + 1] for k, t in enumerate(argv) if t == "-d"] == ["stress:strain", ":"]
+
+
+def test_argv_example_shape_and_dynamic_batch_tristate():
+    def mk(dynamic_batch: bool | None) -> FormState:
+        return FormState(
+            name="m",
+            devices=("cpu",),
+            example_shape=("strain=(2;100)",),
+            dynamic_batch=dynamic_batch,
+        )
+
+    assert "--example-batch-shape" in build_compile_argv(mk(None))
+    assert "--dynamic-batch" in build_compile_argv(mk(True))
+    assert "--no-dynamic-batch" in build_compile_argv(mk(False))
+    none_argv = build_compile_argv(mk(None))
+    assert "--dynamic-batch" not in none_argv and "--no-dynamic-batch" not in none_argv
+
+
+def test_argv_load_repeat_and_empty_output_dir_omitted():
+    state = FormState(name="m", devices=("cpu",), output_dir="", load=("a.py", "b.py"))
+    argv = build_compile_argv(state)
+    assert "--output-dir" not in argv
+    assert [argv[k + 1] for k, t in enumerate(argv) if t == "--load"] == ["a.py", "b.py"]
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        FormState(input_file="input.i", target="model", name="elasticity", devices=("cpu",)),
+        FormState(
+            input_file="in.i",
+            target="driver",
+            name="driver",
+            devices=("cpu", "cuda"),
+            dtype="float32",
+            output_dir="out",
+            promoted=("E", "nu"),
+            derivatives=("stress:strain",),
+            example_shape=("strain=(2;100)",),
+            dynamic_batch=False,
+            load=("ext.py",),
+        ),
+    ],
+)
+def test_argv_round_trips_through_real_parser(state):
+    """The built argv must parse cleanly with neml2-compile's own parser, with no
+    leftover tokens -- this is the guarantee that the preview == what the CLI runs."""
+    from neml2.cli.aoti_compile import _build_arg_parser  # noqa: PLC2701, PLC0415
+
+    argv = build_compile_argv(state)
+    args, extra = _build_arg_parser().parse_known_args(argv)
+    assert extra == []
+    assert (args.model, args.driver)[state.target == "driver"] == state.name
+    assert args.device == list(_dedupe(state.devices))
+    assert args.dtype == state.dtype
+    assert args.parameter == list(state.promoted)
+    assert args.derivative == list(state.derivatives)
+    assert args.example_batch_shape == list(state.example_shape)
+    assert args.dynamic_batch is state.dynamic_batch
+    assert args.load == list(state.load)
+
+
+def test_preview_quotes_shell_metacharacters():
+    state = FormState(input_file="input.i", name="m", example_shape=("strain=(2;100)",))
+    preview = preview_command(state)
+    assert preview.startswith("neml2-compile ")
+    # The semicolon would otherwise be a shell statement separator.
+    assert "'strain=(2;100)'" in preview
+
+
+# --------------------------------------------------------------------------- #
+# validate_state                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_validate_flags_missing_fields():
+    problems = validate_state(FormState(input_file="", name="", devices=()))
+    assert any("Input file" in p for p in problems)
+    assert any("name" in p for p in problems)
+    assert any("device" in p for p in problems)
+
+
+def test_validate_flags_nonexistent_input(tmp_path):
+    problems = validate_state(
+        FormState(input_file=str(tmp_path / "nope.i"), name="m", devices=("cpu",))
+    )
+    assert any("not found" in p for p in problems)
+
+
+def test_validate_ok_for_real_file():
+    assert (
+        validate_state(FormState(input_file=str(_FIXTURE), name="elasticity", devices=("cpu",)))
+        == []
+    )
+
+
+# --------------------------------------------------------------------------- #
+# introspection_to_form                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_introspection_to_form_reduces_model_dict():
+    data = {
+        "name": "Foo",
+        "inputs": [{"name": "strain", "type": "SR2"}],
+        "outputs": [{"name": "stress", "type": "SR2"}],
+        "parameters": [{"name": "E"}, {"name": "nu"}],
+        "buffers": [{"name": "buf0"}],
+    }
+    form = introspection_to_form(data)
+    assert form.promotable == ["E", "nu", "buf0"]  # parameters then buffers
+    assert form.inputs == ["strain"]
+    assert form.outputs == ["stress"]
+    assert form.input_types == {"strain": "SR2"}  # used for the example-shape hint
+
+
+def test_introspection_to_form_empty():
+    assert introspection_to_form({}) == IntrospectionForm()
+
+
+def test_dedupe_preserves_order():
+    assert _dedupe(["a", "b", "a", "c", "b"]) == ["a", "b", "c"]
+
+
+# --------------------------------------------------------------------------- #
+# HIT block listing (nmhit-only, no model instantiation)                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_list_model_and_driver_names():
+    assert list_model_names(_FIXTURE) == ["elasticity"]
+    assert list_driver_names(_FIXTURE) == ["driver"]
+
+
+def test_list_section_entries_includes_type():
+    from neml2.cli._compile_interactive import list_section_entries  # noqa: PLC2701, PLC0415
+
+    assert list_section_entries(_FIXTURE, "Models") == [("elasticity", "LinearIsotropicElasticity")]
+    assert list_section_entries(_FIXTURE, "Drivers") == [("driver", "TransientDriver")]
+
+
+# --------------------------------------------------------------------------- #
+# Model-backed introspection + the real validators                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_introspection_matches_inspect_dict():
+    from neml2.cli.inspect import _model_to_dict  # noqa: PLC2701, PLC0415
+    from neml2.factory import load_model  # noqa: PLC0415
+
+    data = _model_to_dict(load_model(str(_FIXTURE), "elasticity"))
+    form = introspection_to_form(data)
+    assert form.outputs == [o["name"] for o in data["outputs"]]
+    assert form.inputs == [i["name"] for i in data["inputs"]]
+    assert form.promotable == [p["name"] for p in data["parameters"]] + [
+        b["name"] for b in data["buffers"]
+    ]
+    # A non-trivial model has at least one output and one structural input.
+    assert form.outputs and form.inputs
+
+
+def test_builder_derivative_specs_accepted_by_real_resolver():
+    """A derivative spec the form would emit must satisfy neml2-compile's own
+    OUT:IN resolver; a bogus one must be rejected."""
+    from neml2.cli.aoti_export import _resolve_derivative_specs  # noqa: PLC2701, PLC0415
+    from neml2.factory import load_model  # noqa: PLC0415
+
+    model = load_model(str(_FIXTURE), "elasticity")
+    out = next(iter(model.output_spec))
+    in_ = next(iter(model.input_spec))
+
+    state = FormState(name="elasticity", devices=("cpu",), derivatives=(f"{out}:{in_}",))
+    # Pull the -d spec straight out of the argv the form produced.
+    argv = build_compile_argv(state)
+    d_specs = [argv[k + 1] for k, t in enumerate(argv) if t == "-d"]
+    struct, _ = _resolve_derivative_specs(d_specs, list(model.output_spec), list(model.input_spec))
+    assert (out, in_) in struct
+
+    with pytest.raises(ValueError):
+        _resolve_derivative_specs(["stress:bogus_input_xyz"], list(model.output_spec), [in_])
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end wizard flow (scripted fake questionary)                          #
+# --------------------------------------------------------------------------- #
+
+
+class _ScriptedPrompt:
+    """Stand-in for a questionary prompt object: ``.ask()`` pops the next answer."""
+
+    def __init__(self, answers):
+        self._answers = answers
+
+    def ask(self):
+        return next(self._answers)
+
+
+class _FakeQuestionary:
+    """A fake ``questionary`` module that answers every prompt from a script, in
+    call order, so the wizard flow can be driven without a TTY."""
+
+    def __init__(self, answers):
+        self._answers = iter(answers)
+
+    @staticmethod
+    def Choice(title, value=None, checked=False):  # noqa: N802 (mirror questionary API)
+        return value if value is not None else title
+
+    def print(self, *args, **kwargs):
+        pass
+
+    def _prompt(self, *args, **kwargs):
+        return _ScriptedPrompt(self._answers)
+
+    text = path = select = checkbox = confirm = _prompt
+
+
+def test_wizard_flow_builds_and_runs_expected_argv(monkeypatch):
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    # Prompt answers in flow order (input file comes from the CLI, not a prompt):
+    # target, name, promote, derivatives?, devices, dtype, output dir, uniform
+    # example shape?, uniform value, dynamic batch, then the review menu's action.
+    fake = _FakeQuestionary(
+        [
+            "model",
+            "elasticity",
+            ["E"],
+            False,
+            ["cpu", "cuda"],
+            "float32",
+            "out",
+            True,  # uniform example shape?
+            "",  # uniform value (blank -> none)
+            True,  # dynamic batch
+            "run",  # review menu -> Run the compile
+        ]
+    )
+    monkeypatch.setattr(wiz, "questionary", fake)
+    # Skip the slow torch model load -- inject a synthetic introspection result.
+    monkeypatch.setattr(
+        wiz,
+        "_introspect",
+        lambda *a, **k: IntrospectionForm(
+            promotable=["E", "nu"], outputs=["stress"], inputs=["strain"]
+        ),
+    )
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setattr(wiz, "run_compile", lambda argv: captured.update(argv=argv) or 0)
+
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 0
+    argv = captured["argv"]
+    assert argv[:3] == [str(_FIXTURE), "--model", "elasticity"]
+    i = argv.index("--device")
+    assert argv[i : i + 3] == ["--device", "cpu", "cuda"]
+    assert argv[argv.index("-p") + 1] == "E"
+    assert argv[argv.index("--dtype") + 1] == "float32"
+    assert "--dynamic-batch" in argv
+    assert "-d" not in argv  # derivatives declined
+
+
+def test_wizard_example_shape_customize_per_variable(monkeypatch):
+    """Decline uniform -> pick which inputs to customize -> prompt only those;
+    non-blank answers become ``name=spec`` --example-batch-shape entries."""
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    # target, name, derivatives?, devices, dtype, output, uniform?(No),
+    # customize-which, strain=, temperature=, dynamic, review -> run.
+    # (No "promote" prompt: promotable is empty.)
+    fake = _FakeQuestionary(
+        [
+            "model",
+            "m",
+            False,
+            ["cpu"],
+            "float64",
+            "./aoti",
+            False,  # uniform? -> customize
+            ["strain", "temperature"],  # which inputs to customize
+            "(2;100)",  # strain
+            "",  # temperature (blank -> omitted)
+            True,
+            "run",
+        ]
+    )
+    monkeypatch.setattr(wiz, "questionary", fake)
+    monkeypatch.setattr(
+        wiz,
+        "_introspect",
+        lambda *a, **k: IntrospectionForm(
+            promotable=[],
+            outputs=["stress"],
+            inputs=["strain", "temperature"],
+            input_types={"strain": "SR2", "temperature": "Scalar"},
+        ),
+    )
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setattr(wiz, "run_compile", lambda argv: captured.update(argv=argv) or 0)
+
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 0
+    ebs = [
+        captured["argv"][k + 1]
+        for k, t in enumerate(captured["argv"])
+        if t == "--example-batch-shape"
+    ]
+    assert ebs == ["strain=(2;100)"]  # temperature left blank -> omitted
+
+
+def test_wizard_example_shape_uniform(monkeypatch):
+    """Uniform -> one bare entry applied to all inputs."""
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    fake = _FakeQuestionary(
+        ["model", "m", False, ["cpu"], "float64", "./aoti", True, "(4,)", True, "run"]
+    )
+    monkeypatch.setattr(wiz, "questionary", fake)
+    monkeypatch.setattr(
+        wiz,
+        "_introspect",
+        lambda *a, **k: IntrospectionForm(promotable=[], outputs=["stress"], inputs=["strain"]),
+    )
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setattr(wiz, "run_compile", lambda argv: captured.update(argv=argv) or 0)
+
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 0
+    argv = captured["argv"]
+    assert argv[argv.index("--example-batch-shape") + 1] == "(4,)"
+
+
+def test_wizard_derivatives_cross_product(monkeypatch):
+    """The two toggle lists yield the cross-product of selected outputs x inputs
+    (a promoted parameter is offered as a w.r.t. input)."""
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    # target, name, promote, derivatives? -> yes, outputs, inputs, round-menu ->
+    # done, devices, dtype, output, uniform?(yes), uniform "", dynamic, review -> run.
+    fake = _FakeQuestionary(
+        [
+            "model",
+            "m",
+            ["E"],  # promote E
+            True,  # compile derivatives?
+            ["stress"],  # outputs
+            ["strain", "E"],  # w.r.t. inputs (incl. promoted param)
+            "done",  # round menu -> finish
+            ["cpu"],
+            "float64",
+            "./aoti",
+            True,
+            "",
+            True,
+            "run",
+        ]
+    )
+    monkeypatch.setattr(wiz, "questionary", fake)
+    monkeypatch.setattr(
+        wiz,
+        "_introspect",
+        lambda *a, **k: IntrospectionForm(promotable=["E"], outputs=["stress"], inputs=["strain"]),
+    )
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setattr(wiz, "run_compile", lambda argv: captured.update(argv=argv) or 0)
+
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 0
+    argv = captured["argv"]
+    dpairs = [argv[k + 1] for k, t in enumerate(argv) if t == "-d"]
+    assert dpairs == ["stress:strain", "stress:E"]
+
+
+def test_ask_derivatives_edit_add_clear(monkeypatch):
+    """With existing selections the round menu runs: 'edit' toggles a flat list,
+    'add' unions a new cross-product (hiding already-selected pairs), 'clear'
+    empties. Each path ends with 'done'."""
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    intro = IntrospectionForm(promotable=[], outputs=["stress"], inputs=["strain", "temperature"])
+    existing = ("stress:strain", "stress:temperature")
+
+    # edit: menu -> "edit", flat checkbox keeps only stress:strain, menu -> "done".
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary(["edit", ["stress:strain"], "done"]))
+    assert wiz._ask_derivatives(intro, (), existing) == ["stress:strain"]
+
+    # add: menu -> "add", outputs [stress], inputs [temperature] (strain hidden:
+    # stress:strain already exists), unioned with existing, menu -> "done".
+    monkeypatch.setattr(
+        wiz, "questionary", _FakeQuestionary(["add", ["stress"], ["temperature"], "done"])
+    )
+    assert wiz._ask_derivatives(intro, (), ("stress:strain",)) == [
+        "stress:strain",
+        "stress:temperature",
+    ]
+
+    # clear: menu -> "clear", menu -> "done".
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary(["clear", "done"]))
+    assert wiz._ask_derivatives(intro, (), existing) == []
+
+
+def test_wizard_edit_back_does_not_crash(monkeypatch):
+    """Selecting the edit menu's '↩ back' returns to the review cleanly (regression:
+    a None-valued Choice arrives as its title, so a distinct sentinel is used)."""
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    # ... linear (uniform example) ..., review -> edit, edit-field -> back, review -> run.
+    fake = _FakeQuestionary(
+        [
+            "model",
+            "m",
+            False,
+            ["cpu"],
+            "float64",
+            "./aoti",
+            True,
+            "",
+            True,
+            "edit",
+            wiz._BACK,
+            "run",
+        ]
+    )
+    monkeypatch.setattr(wiz, "questionary", fake)
+    monkeypatch.setattr(
+        wiz,
+        "_introspect",
+        lambda *a, **k: IntrospectionForm(promotable=[], outputs=["stress"], inputs=["strain"]),
+    )
+    ran: dict[str, bool] = {}
+    monkeypatch.setattr(wiz, "run_compile", lambda argv: ran.update(ok=True) or 0)
+
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 0
+    assert ran.get("ok") is True
+
+
+# --------------------------------------------------------------------------- #
+# neml2-compile --interactive argument handling                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_compile_interactive_keeps_input_required_but_target_optional():
+    """`-i` still requires INPUT.i (so shell path completion applies) but lets the
+    model/driver be omitted (the wizard asks)."""
+    from neml2.cli.aoti_compile import _build_arg_parser  # noqa: PLC2701, PLC0415
+
+    args, _ = _build_arg_parser().parse_known_args(["-i", "in.i"])
+    assert args.interactive is True
+    assert str(args.input) == "in.i"
+    assert args.model is None and args.driver is None
+    # `-i` with no input file is an error (argparse-required positional).
+    with pytest.raises(SystemExit):
+        _build_arg_parser().parse_known_args(["-i"])
+
+
+def test_compile_noninteractive_requires_input_and_target():
+    """Without `-i`, omitting input or model/driver must still error (SystemExit),
+    preserving the original required behavior."""
+    from neml2.cli.aoti_compile import main  # noqa: PLC0415
+
+    with pytest.raises(SystemExit):
+        main([])  # no input
+    with pytest.raises(SystemExit):
+        main([str(_FIXTURE)])  # input but no --model/--driver
+
+
+def test_compile_interactive_delegates_to_wizard(monkeypatch):
+    """`neml2-compile -i input.i` hands the input file off to the wizard."""
+    pytest.importorskip("questionary")
+    from neml2.cli import aoti_compile  # noqa: PLC0415
+
+    captured: dict[str, object] = {}
+
+    def _fake_wizard(*, input_file, initial_load):
+        captured["input_file"] = input_file
+        captured["initial_load"] = initial_load
+        return 0
+
+    # The wizard module is imported lazily inside main(); patch its symbol.
+    import neml2.cli._compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "run_wizard", _fake_wizard)
+
+    assert aoti_compile.main(["-i", str(_FIXTURE), "--load", "ext.py"]) == 0
+    assert captured == {"input_file": str(_FIXTURE), "initial_load": ("ext.py",)}


### PR DESCRIPTION
## Summary

Adds an interactive mode to `neml2-compile` that introspects the model and guides the user through the compile options via prompts, then runs the assembled command.

- `neml2-compile -i INPUT.i` launches a [Questionary](https://questionary.readthedocs.io/) wizard:
  - lists the `[Models]` / `[Drivers]` blocks with their types;
  - introspects the chosen model to offer its promotable parameters (`-p`) and derivative variables (`-d`);
  - asks devices, dtype, output dir, and example batch shape (uniform-for-all or customized per chosen input);
  - ends on a **review** screen to **Run** / **Edit a field** / **Quit** — the mechanism for revisiting earlier answers (Questionary has no built-in "go back").
- Derivatives are chosen as two toggle-able lists (outputs × w.r.t. inputs/params) with a round menu (**Add / Edit / Clear / Done**) that shows the current selection and hides already-selected pairs when adding.
- The previewed command is exactly what runs — a single builder feeds both the preview and the subprocess (which inherits the terminal, so `neml2-compile`'s own output streams live).
- Each prompt is preceded by a muted one-line explanation.

`questionary` is a lightweight **dev** dependency (not core); the `-i` flag guards the import and prints a `pip install questionary` hint if it is absent, so plain installs are unaffected.

## Layout

- `neml2/cli/_compile_interactive.py` — framework-free helpers (state, argv builder, introspection / validation / block-listing), unit-testable without `questionary`.
- `neml2/cli/_compile_wizard.py` — the prompt flow, imported lazily after the `questionary` probe.
- `neml2/cli/aoti_compile.py` — adds `-i` / `--interactive`; `INPUT.i` stays required (so the shell completes the path), with model/driver optional in interactive mode.

## Test plan

- `pytest tests/unit/test_compile_interactive.py` — 28 tests: argv builder + round-trip through the real `neml2-compile` parser, introspection reduction, block listing, the wizard flow (scripted fake `questionary`), the derivatives cross-product / edit-add-clear menu, the example uniform vs. customize paths, and `-i` argument handling.
- `ruff` + `ruff format` + `pyright` clean; `pre-commit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)