### PR TITLE
Fix AOTI binding failing to import under cpu-only torch

### DIFF
--- a/.github/workflows/compat.yaml
+++ b/.github/workflows/compat.yaml
@@ -122,7 +122,14 @@ jobs:
         # pip's resolver from upgrading torch on us: pyproject.toml has no
         # torch version constraint, so the pinned version sticks.
         run: |
-          if [ "${{ runner.os }}" = "Linux" ]; then
+          if [ "${{ matrix.channel }}" = "cuda" ]; then
+            # cuda-runtime row (Linux only): install the default-index CUDA build.
+            # The wheel was built against CPU torch; this asserts it still imports
+            # and cpu-tests cleanly under a cuda torch -- the ABI / DT_NEEDED check
+            # that the cpu-only AOTI-import bug would have failed. GPU kernels are
+            # NOT exercised (GitHub runners have no GPU).
+            pip install torch==${{ matrix.torch }}
+          elif [ "${{ runner.os }}" = "Linux" ]; then
             # --extra-index-url keeps PyPI as a fallback so torch deps the PyTorch
             # CPU index doesn't mirror (mpmath, fsspec, ...) still resolve.
             pip install torch==${{ matrix.torch }} --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple
@@ -135,11 +142,17 @@ jobs:
         # dependencies: pyzag.version
         run: pip install pytest "pyzag==1.1.3"
       - name: Confirm import + torch version under test
+        # `import neml2` deliberately SWALLOWS a failed AOTI-binding import (it is
+        # optional), so it alone would stay green even when libneml2 cannot load
+        # against this torch. Explicitly import the binding to assert it loaded --
+        # this is the line that catches the cpu-only / cross-channel ABI bug.
         run: |
           python - <<'EOF'
           import torch, neml2
+          from neml2.aoti import Model  # must NOT raise: the AOTI binding loaded
           print(f"torch: {torch.__version__}")
           print(f"neml2: {neml2.__file__}")
+          print(f"aoti : {Model.__module__}.{Model.__name__}")
           EOF
       - name: Run pytest
         run: pytest -v --junitxml=pytest.xml tests
@@ -154,4 +167,5 @@ jobs:
             echo "| torch   | ${{ matrix.torch }} |"
             echo "| python  | ${{ matrix.python }} |"
             echo "| os      | ${{ matrix.os }} |"
+            echo "| channel | ${{ matrix.channel }} |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/compat.yaml
+++ b/.github/workflows/compat.yaml
@@ -142,10 +142,14 @@ jobs:
         # dependencies: pyzag.version
         run: pip install pytest "pyzag==1.1.3"
       - name: Confirm import + torch version under test
-        # `import neml2` deliberately SWALLOWS a failed AOTI-binding import (it is
-        # optional), so it alone would stay green even when libneml2 cannot load
-        # against this torch. Explicitly import the binding to assert it loaded --
-        # this is the line that catches the cpu-only / cross-channel ABI bug.
+        # Run from a neutral dir, NOT the repo root: the checked-out source tree
+        # has a `neml2/` package with no compiled `_aoti` extension, and CWD on
+        # sys.path would shadow the installed wheel we mean to test. `import neml2`
+        # deliberately SWALLOWS a failed AOTI-binding import (it is optional), so
+        # it alone would stay green even when libneml2 cannot load against this
+        # torch -- explicitly import the binding to assert it loaded. This is the
+        # line that catches the cpu-only / cross-channel ABI bug.
+        working-directory: ${{ runner.temp }}
         run: |
           python - <<'EOF'
           import torch, neml2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,8 +246,9 @@ find_package(nmhit MODULE REQUIRED)
 # ----------------------------------------------------------------------------
 # libneml2 — the only C++ artifact NEML2 ships (aoti runtime + dispatchers)
 # ----------------------------------------------------------------------------
-# Free-standing: links only against torch::core (+ torch::cuda when available)
-# and nlohmann_json. Wraps torch::inductor::AOTIModelPackageLoader so the
+# Free-standing: links only against torch::core (never torch::cuda -- see the
+# target_link_libraries below) and nlohmann_json. Wraps
+# torch::inductor::AOTIModelPackageLoader so the
 # Python side can execute .pt2 artifacts produced by torch._inductor.aoti_compile_and_package
 # from C++. Source tree lives at neml2/csrc/aoti/, intentionally co-located with
 # the Python package so the C++ and Python sides of NEML2 stay in one tree.
@@ -327,9 +328,15 @@ target_link_libraries(aoti PRIVATE nmhit::nmhit)
 # The async dispatch pool (StaticHybridScheduler path) spawns std::thread workers.
 find_package(Threads REQUIRED)
 target_link_libraries(aoti PRIVATE Threads::Threads)
-if(TARGET torch::cuda)
-      target_link_libraries(aoti PUBLIC torch::cuda)
-endif()
+# Deliberately NOT linked against torch::cuda. neml2's C++ references zero cuda
+# symbols -- it reaches the GPU only through torch's device-generic dispatch,
+# which loads libtorch_cuda at runtime when a cuda tensor appears. Linking
+# torch::cuda only manufactures a hard DT_NEEDED on libc10_cuda.so that buys
+# nothing and makes `import neml2` fail for anyone on a cpu-only torch (the
+# library was previously linked whenever built against a cuda torch, so the
+# published wheel -- built against the default-index cuda torch -- could not
+# load under a cpu torch). The cpu-side torch ABI is identical across the cuda
+# and cpu builds, so one cuda-free libneml2 runs under both.
 
 # MPI scheduler: link MPI and define NEML2_MPI for the aoti TUs only. The public
 # headers are MPI-type-free, so consumers need neither the flag nor mpi.h; the
@@ -442,9 +449,9 @@ target_compile_options(eager PRIVATE -Wall -Wextra -pedantic)
 target_link_libraries(eager PUBLIC aoti torch::core)
 target_link_libraries(eager PRIVATE torch::python Python3::Module)
 target_compile_definitions(eager PRIVATE "PYBIND11_DETAILED_ERROR_MESSAGES")
-if(TARGET torch::cuda)
-      target_link_libraries(eager PUBLIC torch::cuda)
-endif()
+# No torch::cuda here either, for the same reason as the aoti target above: zero
+# cuda symbol references, so linking it would only add an unsatisfiable
+# libc10_cuda.so DT_NEEDED on cpu-only torch.
 
 # rpath:
 #  - ${INSTALL_REL_PATH} (the lib's OWN dir): libneml2_eager.so links the sibling

--- a/neml2/__init__.py
+++ b/neml2/__init__.py
@@ -50,14 +50,35 @@ from .models.chain_rule import ChainRuleAction, ChainRuleDict, TangentAction
 # builtin anywhere else.
 from .models.compile import compile  # noqa: A004
 
-# AOTI subpackage is gated on the optional NEML2_AOTI build (the pybind
-# _aoti.so isn't present otherwise). Import for side effects so the HIT shim
-# registers "AOTIModel" with the factory; silently skip when the binding
-# wasn't built.
+# AOTI subpackage is gated on the optional NEML2_AOTI build. Import for side
+# effects so the HIT shim registers "AOTIModel" with the factory. Two failure
+# modes, treated differently:
+#   * the binding was never built (no _aoti extension on disk) -- an intentional
+#     lean build; stay silent.
+#   * the binding is on disk but fails to import -- warn, because otherwise every
+#     AOTI route goes silently missing and the only symptom is a baffling "Type
+#     'AOTIModel' is not registered" KeyError when load_model later hits a
+#     neml2-compile stub. The swallowed exception is the real diagnostic, so
+#     surface it.
 try:
     from . import aoti as _aoti_module  # noqa: F401 (registers AOTIModel)
-except ImportError:
-    pass
+except ImportError as _aoti_err:
+    from glob import glob as _glob
+
+    # Probe the filesystem (not an import) to tell "never built" from "unloadable".
+    if _glob(str(Path(__file__).parent / "aoti" / "_aoti*.so")):
+        import warnings as _warnings
+
+        _warnings.warn(
+            "NEML2's AOTI runtime binding is installed but failed to import:\n"
+            f"    {type(_aoti_err).__name__}: {_aoti_err}\n"
+            "The 'AOTIModel' HIT type is therefore not registered. Compiled "
+            "(.pt2) models will not load -- neml2.load_model on a neml2-compile "
+            "stub fails with \"Type 'AOTIModel' is not registered\", and the "
+            "neml2.aoti runtime is unavailable. The exception above is the "
+            "underlying cause.",
+            stacklevel=2,
+        )
 # Eagerly expose ``neml2.pyzag`` as an attribute so notebooks / tests
 # can write ``neml2.pyzag.NEML2PyzagModel(...)`` without an explicit
 # import. Safe to place anywhere in this file -- ``pyzag.interface``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,6 +300,18 @@ test-requires = "pytest torch pyzag==1.1.3"
 test-command = "pytest -v {project}/tests"
 
 [tool.cibuildwheel.linux]
+# Build + test against the CPU torch on Linux. The default PyPI index serves the
+# ~2.5 GB CUDA build, but libneml2 is cuda-free by design (see the torch::cuda
+# note in CMakeLists.txt), so we only need libtorch_cpu/libc10 to compile against
+# -- the CPU wheel is ~10x smaller and far faster to install on every build. The
+# resulting wheel still runs under a cuda torch at runtime (the cuda-channel rows
+# in the compat test matrix verify that). Routing the index via env vars (rather
+# than rewriting before-build / test-requires) redirects EVERY pip invocation in
+# the build + test -- before-build, the wheel's own torch dep at test time, and
+# test-requires -- to the CPU index, with PyPI as the fallback for everything it
+# doesn't mirror (scikit-build-core, nmhit, pyzag, ...). The linux `environment`
+# replaces (does not merge with) the global one, so CMAKE_GENERATOR is repeated.
+environment = { CMAKE_GENERATOR = "Ninja", PIP_INDEX_URL = "https://download.pytorch.org/whl/cpu", PIP_EXTRA_INDEX_URL = "https://pypi.org/simple" }
 repair-wheel-command = "python {project}/scripts/repair_wheel.py {wheel} {dest_dir}"
 
 [tool.cibuildwheel.macos]

--- a/scripts/compat_matrix.py
+++ b/scripts/compat_matrix.py
@@ -205,9 +205,28 @@ def cmd_expand(args) -> None:
         print(json.dumps(["cp" + p.replace(".", "") for p in pys], separators=(",", ":")))
         return
     if args.kind == "test":
+        # Default channel: every row installs a CPU-index torch at runtime.
         include = [
-            {"torch": r["torch"], "python": r["python"], "os": r["os"]} for r in combinations
+            {"torch": r["torch"], "python": r["python"], "os": r["os"], "channel": "cpu"}
+            for r in combinations
         ]
+        # cuda-runtime rows: the wheel is built against CPU torch, so additionally
+        # import + cpu-test it under a *cuda* torch to catch any ABI / DT_NEEDED
+        # skew between the two PyTorch distribution channels -- the bug class that
+        # made the AOTI binding fail to import under a cpu-only torch. cuda torch
+        # ships only for Linux, and this is a C++-ABI check that does not vary
+        # with the Python version, so cover just the Linux torch extremes at the
+        # newest Python. Full mode only (push to main / workflow_dispatch): the
+        # cuda wheel is ~2.5 GB to install, so PRs skip it for a fast signal.
+        if args.mode == "full":
+            linux = [r for r in data["combinations"] if r["os"] == "ubuntu-latest"]
+            if linux:
+                torches = sorted({r["torch"] for r in linux}, key=_ver_tuple)
+                newest_py = sorted({r["python"] for r in linux}, key=_ver_tuple)[-1]
+                for t in sorted({torches[0], torches[-1]}, key=_ver_tuple):
+                    include.append(
+                        {"torch": t, "python": newest_py, "os": "ubuntu-latest", "channel": "cuda"}
+                    )
     elif args.kind == "wheel":
         seen: set[tuple[str, str]] = set()
         include = []


### PR DESCRIPTION
## Problem

On a **cpu-only torch** (e.g. Colab's `torch==2.11.0+cpu`), loading a `neml2-compile` stub via `neml2.load_model` raised:

```
KeyError: "Type 'AOTIModel' is not registered in NativeRegistry ..."
```

That `KeyError` is a downstream symptom. The actual failure (from the Colab traceback) is:

```
ImportError: libc10_cuda.so: cannot open shared object file: No such file or directory
```

## Root cause

The **published wheel** hard-linked `torch::cuda`, so `libneml2.so` / `_aoti.so` carried a `DT_NEEDED` on `libc10_cuda.so`. The link came from `CMakeLists.txt` (`if(TARGET torch::cuda) target_link_libraries(... torch::cuda)`), which fires because cibuildwheel's `before-build` installs `torch` from the **default PyPI index = the CUDA build**. A cpu-only torch ships no `libc10_cuda.so`, so the binding can't `dlopen`; `neml2/__init__.py`'s `except ImportError: pass` then swallows it and `AOTIModel` is never registered.

The cuda link was **spurious**: `nm -D --undefined-only libneml2` shows zero cuda symbols and `grep -r 'c10::cuda|at::cuda|CUDAStream' neml2/csrc/` is empty. neml2 reaches the GPU only through torch's device-generic dispatch (torch loads `libtorch_cuda` itself at runtime), so a single cuda-free `libneml2` runs under both cpu and cuda torch. Verified locally: a `--device cuda` artifact runs on `cuda:0` through the cuda-free library.

### Why CI missed it

Every lane was single-channel: `compat` builds + tests on the cpu index (never links cuda); cibuildwheel builds + self-tests on the default-index cuda torch (so `libc10_cuda` is present in its own test env → green). Nobody imported a **cuda-built wheel under cpu torch** — the Colab configuration.

## Fix

- **`CMakeLists.txt`** — drop the `torch::cuda` link on both the `aoti` and `eager` targets (kept `OPTIONAL_COMPONENTS cuda` for future use).
- **`pyproject.toml`** — build + test cibuildwheel against the cpu torch index on Linux (smaller/faster, cuda-free by construction).
- **`scripts/compat_matrix.py` + `.github/workflows/compat.yaml`** — add a runtime `cpu|cuda` channel to the test matrix. **Full mode** (push to main / dispatch) additionally imports + cpu-tests the wheel under a **cuda** torch (Linux torch-extremes @ newest Python); PRs skip it (the cuda wheel is ~2.5 GB to install). Harden the import check to `from neml2.aoti import Model`, since plain `import neml2` swallows a binding-load failure. GPU kernels are not exercised (GitHub runners have no GPU).
- **`neml2/__init__.py`** — when the AOTI binding is present on disk but fails to import, emit a warning with the underlying exception instead of silently swallowing it.

## Test plan

- [x] Local rebuild: `libneml2` `DT_NEEDED` reduced to `libc10` + `libtorch_cpu`; `from neml2.aoti import Model` imports; `--device cuda` artifact runs on `cuda:0`.
- [x] `compat_matrix.py expand`: PR mode adds 0 cuda rows; full mode adds 2; `check` / `render` unaffected.
- [x] `dep_manager check`, `ruff`, actionlint (pre-commit) all pass.
- [ ] CI: the new full-mode cuda rows confirm the cpu-built wheel imports + cpu-tests under cuda torch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)