### PR TITLE
Bump version to 3.0.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # dependencies: cmake.version_min
 cmake_minimum_required(VERSION 3.26.1)
 # dependencies: neml2.version
-project(NEML2 VERSION 3.0.4 LANGUAGES C CXX)
+project(NEML2 VERSION 3.0.5 LANGUAGES C CXX)
 
 # ----------------------------------------------------------------------------
 # Testing (enable_testing + ctest plumbing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ build.targets = ["aoti", "eager", "pyneml2", "cpp_tests"]
 [project]
 name = "neml2"
 # dependencies: neml2.version
-version = "3.0.4"
+version = "3.0.5"
 authors = [
   { name = "Mark Messner", email = "messner@anl.gov" },
   { name = "Gary Hu", email = "thu@anl.gov" },

--- a/scripts/dependencies.yaml
+++ b/scripts/dependencies.yaml
@@ -91,7 +91,7 @@ python:
 
 # ---- Project version ----
 neml2:
-  version: "3.0.4"
+  version: "3.0.5"
   files:
     - CMakeLists.txt
     - pyproject.toml


### PR DESCRIPTION
Patch version bump 3.0.4 → 3.0.5 via `dep_manager` (propagated to `CMakeLists.txt`, `pyproject.toml`, `dependencies.yaml`).

This PR also serves as the first live exercise of the new versioned-docs pipeline:
- **On this PR**: the docs build should deploy a preview to `pr-preview/<N>/` (no Colab badges, since the ref is `main`) and post the preview link comment.
- **On merge + release**: since `3.0.5` is a patch of the current stable minor (`v3.0`), `deploy_versioned.sh` will overwrite `stable/` in place — exercising the stable update route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)