### PR TITLE
py-eager typed jvp/jacobian + cross-route runtime fixes (Newton verbose, cpp-aoti broadcast, opaque_pow)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ add_library(aoti SHARED
       neml2/csrc/aoti/jacobian.cpp
       neml2/csrc/aoti/newton.cpp
       neml2/csrc/aoti/nonlinear_system_aoti.cpp
+      neml2/csrc/aoti/custom_ops.cpp
       neml2/csrc/dispatchers/WorkScheduler.cpp
       neml2/csrc/dispatchers/SimpleScheduler.cpp
       neml2/csrc/dispatchers/MPISimpleScheduler.cpp

--- a/doc/content/references/py_eager.md
+++ b/doc/content/references/py_eager.md
@@ -26,11 +26,36 @@ all behave the way they do for any torch module.
 
 ## Sensitivities
 
-Two complementary ways to get derivatives:
+`model.jvp` and `model.jacobian` are the typed forward-mode derivative surface —
+the same `forward` / `jvp` / `jacobian` API the compiled and embedded routes
+expose, so derivative code reads identically on every route:
+
+```python
+model = neml2.load_model("input.i", "elasticity")
+
+# Jacobian-vector product: one cheap directional derivative.
+outputs, jvp = model.jvp({"strain": eps}, {"strain": deps})
+#   jvp["stress"] is an SR2 — the directional derivative of stress along deps.
+
+# Full Jacobian: every (output, input) block.
+outputs, J = model.jacobian({"strain": eps})
+#   J["stress"]["strain"] is a typed block d(stress)/d(strain).
+```
+
+Inputs and tangents are keyed by variable name and accept typed wrappers or raw
+tensors. `jvp` returns each directional derivative as a wrapper of the output's
+type; `jacobian` returns the nested `{output: {input: block}}` map, each block a
+dynamic-base `Tensor` of shape `(*batch, *sub_batch, *out_base, *in_base)`.
+Sub-batch models (e.g. crystal plasticity) are supported — the per-site axis
+stays in the block's sub-batch region. The reverse-mode parameter derivatives
+$\partial(\text{output})/\partial(\text{parameter})$ are a separate surface:
+`param_jacobian` / `param_vjp`.
+
+Two lower-level paths remain for when you need them:
 
 - **Chain rule** — the first/second-order sensitivity dicts threaded through
   `forward(..., v=, v2=, vh=)` propagate tangents analytically through the
-  composed model.
+  composed model; `jvp` / `jacobian` are thin typed wrappers over exactly this.
 - **Autograd** — because evaluation is eager, ordinary `torch.autograd` works
   end to end; this is what the calibration tutorials use. See
   [](tutorials-optimization-autograd).

--- a/neml2/csrc/aoti/Model.cpp
+++ b/neml2/csrc/aoti/Model.cpp
@@ -85,6 +85,11 @@ parse_dtype(const std::string & s)
 Model::Impl::Impl(const std::filesystem::path & meta_path,
                   std::optional<at::Device> device_override)
 {
+  // Register any custom ops a compiled artifact may reference (e.g.
+  // neml2::opaque_pow) before a segment loads/evaluates. Lazy + idempotent so it
+  // does not collide with the Python package's registration (cpp-eager / py-aoti).
+  ensure_neml2_custom_ops_registered();
+
   std::ifstream meta_f(meta_path);
   _assert(static_cast<bool>(meta_f),
           "aoti::Model: failed to open metadata file '",

--- a/neml2/csrc/aoti/custom_ops.cpp
+++ b/neml2/csrc/aoti/custom_ops.cpp
@@ -1,0 +1,95 @@
+// Copyright 2024, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// ----------------------------------------------------------------------------
+// C++ registration of NEML2's custom Torch operators into libneml2
+// ----------------------------------------------------------------------------
+// A compiled `.pt2` can reference NEML2 custom ops that `torch.export`
+// deliberately preserves -- chiefly `neml2::opaque_pow`, the Inductor fusion
+// barrier defined in `neml2/types/functions.py` (used by crystal-plasticity's
+// PowerLawSlipRule and PerzynaPlasticFlowRate). The Python package registers
+// those ops on import, but the cpp-aoti / cpp-dispatch runtimes load the
+// artifact through libneml2 WITHOUT importing the Python package -- so libneml2
+// must register the same schema + a runtime kernel itself, or the dispatcher
+// throws "Could not find schema for neml2::opaque_pow" when the artifact loads.
+
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/ops/pow.h>
+#include <torch/library.h>
+
+namespace neml2::aoti
+{
+namespace
+{
+// Runtime kernel for `neml2::opaque_pow`. The op is opaque only to Inductor's
+// fusion pass; semantically it is a plain power. The fake (abstract) impl and
+// the autograd backward are export-time concerns already baked into the
+// artifact, so the C++ runtime needs only this forward.
+at::Tensor
+opaque_pow(const at::Tensor & base, const at::Tensor & exponent)
+{
+  return at::pow(base, exponent);
+}
+
+// Register at library load -- but only if the op is not already present. A host
+// that imports the Python neml2 package (the py-aoti route) has already defined
+// `neml2::opaque_pow`, and a second `def` would abort the process; guarding lets
+// a single libneml2 serve both the pure-C++ host (we register) and the Python
+// host (we defer). The kernel is registered on `CompositeExplicitAutograd` so a
+// single definition serves every backend (cpu + cuda).
+struct CustomOpRegistrar
+{
+  CustomOpRegistrar()
+  {
+    // Two constraints, both to avoid pulling in __cxa_call_terminate -- a
+    // libstdc++ EH symbol the wheel/dev link toolchain fails to resolve when
+    // executables link against libneml2 (this is the first torch::Library in the
+    // library):
+    //   * no exception may escape this static-initializer ctor (an escape would
+    //     terminate the process), hence the try/catch; and
+    //   * the torch::Library must have no destructor (a noexcept dtor's
+    //     terminate-on-throw thunk is the actual culprit here), hence it is
+    //     heap-allocated and intentionally never freed -- the registration must
+    //     persist for the whole process anyway.
+    // The expected "op already defined by the Python neml2 package" case
+    // (py-aoti) is handled by the findOp guard, not by the catch.
+    try
+    {
+      if (c10::Dispatcher::singleton().findOp({"neml2::opaque_pow", ""}).has_value())
+        return;
+      auto * lib =
+          new torch::Library(torch::Library::FRAGMENT, "neml2", std::nullopt, __FILE__, __LINE__);
+      lib->def("opaque_pow(Tensor base, Tensor exponent) -> Tensor");
+      lib->impl("opaque_pow",
+                torch::dispatch(c10::DispatchKey::CompositeExplicitAutograd, TORCH_FN(opaque_pow)));
+    }
+    catch (...)
+    {
+    }
+  }
+};
+
+const CustomOpRegistrar registrar;
+} // namespace
+} // namespace neml2::aoti

--- a/neml2/csrc/aoti/custom_ops.cpp
+++ b/neml2/csrc/aoti/custom_ops.cpp
@@ -33,25 +33,43 @@
 // artifact through libneml2 WITHOUT importing the Python package -- so libneml2
 // must register the same schema + a runtime kernel itself, or the dispatcher
 // throws "Could not find schema for neml2::opaque_pow" when the artifact loads.
+//
+// This uses torch's STABLE ABI (`torch/csrc/stable/library.h`) rather than the
+// regular `torch::Library` C++ API. `torch::Library::def` lowers to a `_def`
+// overload whose signature carries a `Tag` type that moved namespaces across the
+// supported torch range (`at::Tag` -> `torch::headeronly::Tag`); a libneml2
+// built against the max torch then fails to load against the min torch with
+// "undefined symbol: torch::Library::_def(...)". The stable entry points
+// (`aoti_torch_library_def`, which takes only a schema string -- no Tag -- plus
+// `torch_library_impl` / `torch_call_dispatcher`) exist across the whole range,
+// so the one wheel imports on every supported torch. See the torch-compat matrix
+// (`.github/workflows/compat.yaml`).
 
 #include <mutex>
 
-#include <ATen/core/dispatch/Dispatcher.h>
-#include <ATen/ops/pow.h>
-#include <torch/library.h>
+#include <ATen/core/dispatch/Dispatcher.h>          // c10::Dispatcher::findOp (registration guard)
+#include <torch/csrc/inductor/aoti_runtime/utils.h> // AOTI_TORCH_ERROR_CODE_CHECK (header-only)
+#include <torch/csrc/stable/library.h> // StableLibrary + torch_call_dispatcher + StableIValue
 
 namespace neml2::aoti
 {
 namespace
 {
-// Runtime kernel for `neml2::opaque_pow`. The op is opaque only to Inductor's
-// fusion pass; semantically it is a plain power. The fake (abstract) impl and
-// the autograd backward are export-time concerns already baked into the
-// artifact, so the C++ runtime needs only this forward.
-at::Tensor
-opaque_pow(const at::Tensor & base, const at::Tensor & exponent)
+// Boxed runtime kernel for `neml2::opaque_pow`. The op is opaque only to
+// Inductor's fusion pass; semantically and by signature it is exactly
+// `aten::pow.Tensor_Tensor`, so we forward the boxed `[base, exponent]` stack
+// straight to that op through the stable dispatcher. Forwarding the stack avoids
+// any `at::Tensor` round-trip, so no unstable-ABI symbol leaks into the kernel
+// body either. `TORCH_ABI_VERSION` is the extension's BUILD version (per the
+// `torch_call_dispatcher` contract), which lets an older runtime libtorch
+// negotiate compatibility. The fake/abstract impl and autograd backward are
+// export-time concerns already baked into the artifact, so the runtime needs
+// only this forward.
+void
+opaque_pow_boxed(StableIValue * stack, uint64_t /*num_args*/, uint64_t /*num_outputs*/)
 {
-  return at::pow(base, exponent);
+  AOTI_TORCH_ERROR_CODE_CHECK(
+      torch_call_dispatcher("aten::pow", "Tensor_Tensor", stack, TORCH_ABI_VERSION));
 }
 
 } // namespace
@@ -69,21 +87,25 @@ ensure_neml2_custom_ops_registered()
   // the pure cpp-aoti path (no Python) registers it here; py-aoti (Python
   // imported first) skips via the findOp guard.
   //
-  // The torch::Library is heap-allocated and never freed: it must outlive the
-  // process, and a destructor would pull in the __cxa_call_terminate EH symbol
-  // the wheel/dev link toolchain cannot resolve.
+  // The stable-ABI library objects are heap-allocated and never freed: they must
+  // outlive the process, and a destructor would pull in the __cxa_call_terminate
+  // EH symbol the wheel/dev link toolchain cannot resolve. `def` (schema) and
+  // `impl` (kernel) are separate library objects so the kernel can be pinned to
+  // the CompositeExplicitAutograd key -- a bare FRAGMENT `impl` has no key slot.
   static std::once_flag flag;
-  std::call_once(flag,
-                 []
-                 {
-                   if (c10::Dispatcher::singleton().findOp({"neml2::opaque_pow", ""}).has_value())
-                     return;
-                   auto * lib = new torch::Library(
-                       torch::Library::FRAGMENT, "neml2", std::nullopt, __FILE__, __LINE__);
-                   lib->def("opaque_pow(Tensor base, Tensor exponent) -> Tensor");
-                   lib->impl("opaque_pow",
-                             torch::dispatch(c10::DispatchKey::CompositeExplicitAutograd,
-                                             TORCH_FN(opaque_pow)));
-                 });
+  std::call_once(
+      flag,
+      []
+      {
+        if (c10::Dispatcher::singleton().findOp({"neml2::opaque_pow", ""}).has_value())
+          return;
+        using StableLibrary = torch::stable::detail::StableLibrary;
+        auto * def_lib =
+            new StableLibrary(StableLibrary::Kind::FRAGMENT, "neml2", "", __FILE__, __LINE__);
+        def_lib->def("opaque_pow(Tensor base, Tensor exponent) -> Tensor");
+        auto * impl_lib = new StableLibrary(
+            StableLibrary::Kind::IMPL, "neml2", "CompositeExplicitAutograd", __FILE__, __LINE__);
+        impl_lib->impl("opaque_pow", &opaque_pow_boxed);
+      });
 }
 } // namespace neml2::aoti

--- a/neml2/csrc/aoti/custom_ops.cpp
+++ b/neml2/csrc/aoti/custom_ops.cpp
@@ -34,6 +34,8 @@
 // must register the same schema + a runtime kernel itself, or the dispatcher
 // throws "Could not find schema for neml2::opaque_pow" when the artifact loads.
 
+#include <mutex>
+
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/ops/pow.h>
 #include <torch/library.h>
@@ -52,44 +54,36 @@ opaque_pow(const at::Tensor & base, const at::Tensor & exponent)
   return at::pow(base, exponent);
 }
 
-// Register at library load -- but only if the op is not already present. A host
-// that imports the Python neml2 package (the py-aoti route) has already defined
-// `neml2::opaque_pow`, and a second `def` would abort the process; guarding lets
-// a single libneml2 serve both the pure-C++ host (we register) and the Python
-// host (we defer). The kernel is registered on `CompositeExplicitAutograd` so a
-// single definition serves every backend (cpu + cuda).
-struct CustomOpRegistrar
-{
-  CustomOpRegistrar()
-  {
-    // Two constraints, both to avoid pulling in __cxa_call_terminate -- a
-    // libstdc++ EH symbol the wheel/dev link toolchain fails to resolve when
-    // executables link against libneml2 (this is the first torch::Library in the
-    // library):
-    //   * no exception may escape this static-initializer ctor (an escape would
-    //     terminate the process), hence the try/catch; and
-    //   * the torch::Library must have no destructor (a noexcept dtor's
-    //     terminate-on-throw thunk is the actual culprit here), hence it is
-    //     heap-allocated and intentionally never freed -- the registration must
-    //     persist for the whole process anyway.
-    // The expected "op already defined by the Python neml2 package" case
-    // (py-aoti) is handled by the findOp guard, not by the catch.
-    try
-    {
-      if (c10::Dispatcher::singleton().findOp({"neml2::opaque_pow", ""}).has_value())
-        return;
-      auto * lib =
-          new torch::Library(torch::Library::FRAGMENT, "neml2", std::nullopt, __FILE__, __LINE__);
-      lib->def("opaque_pow(Tensor base, Tensor exponent) -> Tensor");
-      lib->impl("opaque_pow",
-                torch::dispatch(c10::DispatchKey::CompositeExplicitAutograd, TORCH_FN(opaque_pow)));
-    }
-    catch (...)
-    {
-    }
-  }
-};
-
-const CustomOpRegistrar registrar;
 } // namespace
+
+void
+ensure_neml2_custom_ops_registered()
+{
+  // Registered lazily -- on first aoti Model construction, not from a static
+  // initializer at libneml2 load -- and only if absent. A single process can
+  // hold BOTH libneml2 and the embedded-Python interpreter (MOOSE's cpp-eager
+  // runtime, or py-aoti); registering at load time raced the Python package's
+  // identical `def` in neml2/types/functions.py ("registered multiple times").
+  // Deferring to first use means the cpp-eager path -- which constructs no aoti
+  // Model -- never registers in C++, so the Python package owns the op there;
+  // the pure cpp-aoti path (no Python) registers it here; py-aoti (Python
+  // imported first) skips via the findOp guard.
+  //
+  // The torch::Library is heap-allocated and never freed: it must outlive the
+  // process, and a destructor would pull in the __cxa_call_terminate EH symbol
+  // the wheel/dev link toolchain cannot resolve.
+  static std::once_flag flag;
+  std::call_once(flag,
+                 []
+                 {
+                   if (c10::Dispatcher::singleton().findOp({"neml2::opaque_pow", ""}).has_value())
+                     return;
+                   auto * lib = new torch::Library(
+                       torch::Library::FRAGMENT, "neml2", std::nullopt, __FILE__, __LINE__);
+                   lib->def("opaque_pow(Tensor base, Tensor exponent) -> Tensor");
+                   lib->impl("opaque_pow",
+                             torch::dispatch(c10::DispatchKey::CompositeExplicitAutograd,
+                                             TORCH_FN(opaque_pow)));
+                 });
+}
 } // namespace neml2::aoti

--- a/neml2/csrc/aoti/internal.h
+++ b/neml2/csrc/aoti/internal.h
@@ -370,6 +370,15 @@ struct Model::Impl
   /// has already passed for this input.
   std::vector<int64_t> _batch_shape_of(std::size_t idx, const at::Tensor & t) const;
 
+  /// The DYNAMIC (plain) batch of a canonical input: the leading axes before
+  /// both the per-input sub-batch axes (`_input_sub_batch_shapes[idx]`) and the
+  /// trailing `base_shape`. Unlike `_batch_shape_of` (which returns dynamic +
+  /// sub-batch), this excludes the sub-batch axes -- the structural per-site
+  /// axes (e.g. crystal-plasticity per-grain / per-slip) that must NOT be
+  /// broadcast across inputs. Used by `_prepare_inputs` to unify only the plain
+  /// batch across a mix of global and sub-batched inputs.
+  std::vector<int64_t> _dynamic_batch_shape_of(std::size_t idx, const at::Tensor & t) const;
+
   /// Validate every required input and return them as a `state` map with the
   /// dynamic-batch axes broadcast to a single common shape (base axes
   /// preserved), so a batch-independent input -- e.g. MOOSE's scalar TIME force

--- a/neml2/csrc/aoti/internal.h
+++ b/neml2/csrc/aoti/internal.h
@@ -363,6 +363,16 @@ struct Model::Impl
   /// has already passed for this input.
   std::vector<int64_t> _batch_shape_of(std::size_t idx, const at::Tensor & t) const;
 
+  /// Validate every required input and return them as a `state` map with the
+  /// dynamic-batch axes broadcast to a single common shape (base axes
+  /// preserved), so a batch-independent input -- e.g. MOOSE's scalar TIME force
+  /// -- is lifted to the call batch instead of colliding with the batched
+  /// inputs in a downstream `cat`. This is the C++ analogue of
+  /// `neml2/types/_boundary.py::broadcast_to_common_batch`, which the typed
+  /// (eager / py-aoti shim) routes already apply at their raw-tensor boundary.
+  std::map<std::string, at::Tensor>
+  _prepare_inputs(const std::map<std::string, at::Tensor> & inputs) const;
+
   /// Compose the master Jacobian carrier: returns the output values plus the
   /// per-variable `dstate` map, where `dstate[var]` is `(*common_dyn,
   /// var_folded, M_req)` -- the variable's sensitivity to the requested input

--- a/neml2/csrc/aoti/internal.h
+++ b/neml2/csrc/aoti/internal.h
@@ -56,6 +56,13 @@ class AOTIModelPackageLoader;
 
 namespace neml2::aoti
 {
+/// Lazily register NEML2's custom Torch operators (currently `neml2::opaque_pow`)
+/// into the dispatcher -- once per process, only if absent. Called from the aoti
+/// `Model` constructor rather than a static initializer so a process that also
+/// embeds the Python neml2 package (cpp-eager / py-aoti) does not double-`def` the
+/// op (the Python package registers the same schema). Defined in `custom_ops.cpp`.
+void ensure_neml2_custom_ops_registered();
+
 /// Opaque implementation of `Model`. Holds the per-segment AOTI graph state and
 /// all the value / Jacobian machinery; the public `Model` methods are one-line
 /// forwarders onto the identically-named members here.

--- a/neml2/csrc/aoti/jacobian.cpp
+++ b/neml2/csrc/aoti/jacobian.cpp
@@ -81,16 +81,8 @@ Model::Impl::_forward_pair_blocks(const std::map<std::string, at::Tensor> & inpu
 {
   const auto & seg = _segments.front();
 
-  // Pack + validate caller inputs into a state map (canonical (*B, *base)).
-  std::map<std::string, at::Tensor> state;
-  for (std::size_t k = 0; k < _input_names.size(); ++k)
-  {
-    const auto & n = _input_names[k];
-    auto it = inputs.find(n);
-    _assert(it != inputs.end(), "aoti::Model::jacobian: missing required input '", n, "'.");
-    _validate_input_shape(k, it->second);
-    state[n] = it->second.contiguous();
-  }
+  // Pack + validate caller inputs, broadcasting to the common batch.
+  auto state = _prepare_inputs(inputs);
 
   // Run the jvp loader once: it returns (*outputs, *per-pair blocks) where the
   // blocks are row-major over seg.jacobian_pairs (the requested pairs).
@@ -164,16 +156,8 @@ Model::Impl::_forward_param_pair_blocks(const std::map<std::string, at::Tensor> 
 {
   const auto & seg = _segments.front();
 
-  // Pack + validate caller inputs into a state map (canonical (*B, *base)).
-  std::map<std::string, at::Tensor> state;
-  for (std::size_t k = 0; k < _input_names.size(); ++k)
-  {
-    const auto & n = _input_names[k];
-    auto it = inputs.find(n);
-    _assert(it != inputs.end(), "aoti::Model::param_jacobian: missing required input '", n, "'.");
-    _validate_input_shape(k, it->second);
-    state[n] = it->second.contiguous();
-  }
+  // Pack + validate caller inputs, broadcasting to the common batch.
+  auto state = _prepare_inputs(inputs);
 
   // Runtime batch shape from the first structural input. The param-Jacobian graph
   // takes per-batch parameter inputs, so broadcast the stored scalar parameters
@@ -224,16 +208,8 @@ Model::Impl::_implicit_param_pair_blocks(const std::map<std::string, at::Tensor>
 {
   const auto & seg = _segments.front();
 
-  // Pack + validate caller inputs into a state map (canonical (*B, *base)).
-  std::map<std::string, at::Tensor> state;
-  for (std::size_t k = 0; k < _input_names.size(); ++k)
-  {
-    const auto & n = _input_names[k];
-    auto it = inputs.find(n);
-    _assert(it != inputs.end(), "aoti::Model::param_jacobian: missing required input '", n, "'.");
-    _validate_input_shape(k, it->second);
-    state[n] = it->second.contiguous();
-  }
+  // Pack + validate caller inputs, broadcasting to the common batch.
+  auto state = _prepare_inputs(inputs);
 
   // Run the Newton solve to convergence; this writes the converged unknowns back
   // into `state` and hands us the converged per-group unknowns + per-group givens
@@ -391,16 +367,8 @@ Model::Impl::_add_implicit_param_direct(const Segment & seg,
 std::pair<std::map<std::string, at::Tensor>, std::map<std::string, at::Tensor>>
 Model::Impl::_param_jacobian_dstate(const std::map<std::string, at::Tensor> & inputs) const
 {
-  // Pack + validate caller inputs (canonical (*B, *base)).
-  std::map<std::string, at::Tensor> state;
-  for (std::size_t k = 0; k < _input_names.size(); ++k)
-  {
-    const auto & n = _input_names[k];
-    auto it = inputs.find(n);
-    _assert(it != inputs.end(), "aoti::Model::param_jacobian: missing required input '", n, "'.");
-    _validate_input_shape(k, it->second);
-    state[n] = it->second.contiguous();
-  }
+  // Pack + validate caller inputs, broadcasting to the common batch.
+  auto state = _prepare_inputs(inputs);
 
   // Shared dynamic batch (input 0's leading shape minus its own sub-batch), the
   // same `common_dyn` the input-Jacobian carrier uses for its per-variable

--- a/neml2/csrc/aoti/ops.cpp
+++ b/neml2/csrc/aoti/ops.cpp
@@ -30,6 +30,9 @@
 
 #include "neml2/csrc/aoti/internal.h"
 
+// at::infer_size (broadcast two shapes) for the common-batch computation.
+#include <ATen/ExpandUtils.h>
+
 // param_vjp runs an AOTI loader directly (the other ops delegate loader calls to
 // jacobian.cpp); pull in the full loader type for ->run().
 #include <torch/csrc/inductor/aoti_package/model_package_loader.h>
@@ -87,19 +90,41 @@ Model::Impl::_batch_shape_of(std::size_t idx, const at::Tensor & t) const
 }
 
 std::map<std::string, at::Tensor>
-Model::Impl::forward(const std::map<std::string, at::Tensor> & inputs,
-                     const std::map<std::string, at::Tensor> & param_overrides) const
+Model::Impl::_prepare_inputs(const std::map<std::string, at::Tensor> & inputs) const
 {
-  const ParamOverrideGuard _pog(this, param_overrides);
   std::map<std::string, at::Tensor> state;
+  // First pass: validate + materialize each input, accumulating the common
+  // dynamic batch (torch broadcasting) across all of them.
+  std::vector<int64_t> batch;
   for (std::size_t k = 0; k < _input_names.size(); ++k)
   {
     const auto & n = _input_names[k];
     auto it = inputs.find(n);
-    _assert(it != inputs.end(), "aoti::Model::forward: missing required input '", n, "'.");
+    _assert(it != inputs.end(), "aoti::Model: missing required input '", n, "'.");
     _validate_input_shape(k, it->second);
     state[n] = it->second.contiguous();
+    batch = at::infer_size(batch, _batch_shape_of(k, state[n]));
   }
+  // Second pass: lift every input's dynamic batch up to the common shape (its
+  // trailing base axes untouched), so a batch-independent input (e.g. a scalar
+  // TIME force) no longer collides with the batched inputs downstream.
+  for (std::size_t k = 0; k < _input_names.size(); ++k)
+  {
+    const auto & n = _input_names[k];
+    std::vector<int64_t> target(batch);
+    const auto & base = _input_base_shapes[k];
+    target.insert(target.end(), base.begin(), base.end());
+    state[n] = state[n].broadcast_to(target).contiguous();
+  }
+  return state;
+}
+
+std::map<std::string, at::Tensor>
+Model::Impl::forward(const std::map<std::string, at::Tensor> & inputs,
+                     const std::map<std::string, at::Tensor> & param_overrides) const
+{
+  const ParamOverrideGuard _pog(this, param_overrides);
+  auto state = _prepare_inputs(inputs);
 
   // Call batch from the first structural input (its base stripped). Forward
   // segments broadcast each promoted parameter to this batch before the call,
@@ -137,16 +162,8 @@ Model::Impl::forward(const std::map<std::string, at::Tensor> & inputs,
 std::pair<std::map<std::string, at::Tensor>, std::map<std::string, at::Tensor>>
 Model::Impl::_jacobian_dstate(const std::map<std::string, at::Tensor> & inputs) const
 {
-  // Pack state from caller inputs (validating each is canonical (*B, *base)).
-  std::map<std::string, at::Tensor> state;
-  for (std::size_t k = 0; k < _input_names.size(); ++k)
-  {
-    const auto & n = _input_names[k];
-    auto it = inputs.find(n);
-    _assert(it != inputs.end(), "aoti::Model::jacobian: missing required input '", n, "'.");
-    _validate_input_shape(k, it->second);
-    state[n] = it->second.contiguous();
-  }
+  // Pack state from caller inputs (validating + broadcasting to the common batch).
+  auto state = _prepare_inputs(inputs);
 
   // dstate[var] is (*B, var_size, M) where M = _input_total_size. Initialized
   // with identity columns for each master input, then composed segment-by-
@@ -349,16 +366,9 @@ Model::Impl::param_vjp(const std::map<std::string, at::Tensor> & inputs,
   if (_segments.size() == 1 && seg.kind == SegmentKind::Forward &&
       static_cast<bool>(seg.param_vjp_loader))
   {
-    // Validate + pack structural inputs (canonical (*B, *base)).
-    std::map<std::string, at::Tensor> state;
-    for (std::size_t k = 0; k < _input_names.size(); ++k)
-    {
-      const auto & n = _input_names[k];
-      auto it = inputs.find(n);
-      _assert(it != inputs.end(), "aoti::Model::param_vjp: missing required input '", n, "'.");
-      _validate_input_shape(k, it->second);
-      state[n] = it->second.contiguous();
-    }
+    // Validate + pack structural inputs (canonical (*B, *base)), broadcasting to
+    // the common batch.
+    auto state = _prepare_inputs(inputs);
 
     // Loader inputs: structural state, promoted parameters broadcast PER-BATCH
     // (the adjoint graph differentiates a per-batch leaf -> per-batch-element

--- a/neml2/csrc/aoti/ops.cpp
+++ b/neml2/csrc/aoti/ops.cpp
@@ -89,13 +89,36 @@ Model::Impl::_batch_shape_of(std::size_t idx, const at::Tensor & t) const
   return batch;
 }
 
+std::vector<int64_t>
+Model::Impl::_dynamic_batch_shape_of(std::size_t idx, const at::Tensor & t) const
+{
+  // Strip BOTH the sub-batch axes and the trailing base axes; what remains is
+  // the leading plain (dynamic) batch. `_input_sub_batch_shapes` is populated
+  // per input at construction (an empty vector for a plain-batch input, and
+  // empty overall for an older cache without the metadata -> sub_ndim 0).
+  const int64_t sub_ndim = _input_sub_batch_shapes.empty()
+                               ? 0
+                               : static_cast<int64_t>(_input_sub_batch_shapes[idx].size());
+  const int64_t trailing = static_cast<int64_t>(_input_base_shapes[idx].size()) + sub_ndim;
+  std::vector<int64_t> dyn;
+  for (int64_t d = 0; d < t.dim() - trailing; ++d)
+    dyn.push_back(t.size(d));
+  return dyn;
+}
+
 std::map<std::string, at::Tensor>
 Model::Impl::_prepare_inputs(const std::map<std::string, at::Tensor> & inputs) const
 {
   std::map<std::string, at::Tensor> state;
   // First pass: validate + materialize each input, accumulating the common
-  // dynamic batch (torch broadcasting) across all of them.
-  std::vector<int64_t> batch;
+  // DYNAMIC (plain) batch across all of them. Only the plain batch is unified:
+  // a sub-batched input's per-site axes (crystal-plasticity per-grain /
+  // per-slip) are structural and are stripped alongside the base axes before
+  // broadcasting -- unifying them would collide a global input's (B,) against a
+  // per-grain input's (B, ngrain). This mirrors the typed routes, whose
+  // broadcast_to_common_batch broadcasts only the dynamic batch per its
+  // per-input sub_batch_ndim.
+  std::vector<int64_t> dyn;
   for (std::size_t k = 0; k < _input_names.size(); ++k)
   {
     const auto & n = _input_names[k];
@@ -103,18 +126,26 @@ Model::Impl::_prepare_inputs(const std::map<std::string, at::Tensor> & inputs) c
     _assert(it != inputs.end(), "aoti::Model: missing required input '", n, "'.");
     _validate_input_shape(k, it->second);
     state[n] = it->second.contiguous();
-    batch = at::infer_size(batch, _batch_shape_of(k, state[n]));
+    dyn = at::infer_size(dyn, _dynamic_batch_shape_of(k, state[n]));
   }
-  // Second pass: lift every input's dynamic batch up to the common shape (its
-  // trailing base axes untouched), so a batch-independent input (e.g. a scalar
-  // TIME force) no longer collides with the batched inputs downstream.
+  // Second pass: lift every input's dynamic batch to the common shape, leaving
+  // its sub-batch and base axes untouched -- a batch-independent input (e.g. a
+  // scalar TIME force) is broadcast to the call batch without disturbing a
+  // sub-batched input's per-grain axes.
   for (std::size_t k = 0; k < _input_names.size(); ++k)
   {
     const auto & n = _input_names[k];
-    std::vector<int64_t> target(batch);
-    const auto & base = _input_base_shapes[k];
-    target.insert(target.end(), base.begin(), base.end());
-    state[n] = state[n].broadcast_to(target).contiguous();
+    const at::Tensor & t = state[n];
+    const int64_t sub_ndim = _input_sub_batch_shapes.empty()
+                                 ? 0
+                                 : static_cast<int64_t>(_input_sub_batch_shapes[k].size());
+    const int64_t keep = static_cast<int64_t>(_input_base_shapes[k].size()) + sub_ndim;
+    // target = (*common_dyn, *sub_k, *base_k): common plain batch, then this
+    // input's own trailing sub-batch + base axes verbatim.
+    std::vector<int64_t> target(dyn);
+    for (int64_t d = t.dim() - keep; d < t.dim(); ++d)
+      target.push_back(t.size(d));
+    state[n] = t.broadcast_to(target).contiguous();
   }
   return state;
 }

--- a/neml2/csrc/eager/interpreter.cpp
+++ b/neml2/csrc/eager/interpreter.cpp
@@ -56,6 +56,21 @@ InterpreterGuard::InterpreterGuard()
   if (g_started_by_us || Py_IsInitialized())
     return;
   py::initialize_interpreter();
+  // Line-buffer the interpreter's stdio. We never finalize the interpreter (see
+  // the destructor), so Python's atexit flush never runs; a block-buffered
+  // stream -- the default when the host's stdout is not a TTY (redirected to a
+  // file or pipe) -- would never be flushed and its output would be lost. Line
+  // buffering flushes on each newline, so Python-side prints (e.g. a solver's
+  // `verbose` convergence log) surface whether or not stdout is a TTY.
+  {
+    auto sys = py::module_::import("sys");
+    for (const char * name : {"stdout", "stderr"})
+    {
+      py::object stream = sys.attr(name);
+      if (!stream.is_none() && py::hasattr(stream, "reconfigure"))
+        stream.attr("reconfigure")(py::arg("line_buffering") = true);
+    }
+  }
   g_release = new py::gil_scoped_release();
   g_started_by_us = true;
 }

--- a/neml2/models/model.py
+++ b/neml2/models/model.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
 
     from ..factory import _NativeInputFile
     from ..schema import HitSchema
+    from ..types import Tensor
 
 #: Bound to the concrete typed-wrapper class a caller expects from
 #: :meth:`Model._get_param`, so the return type is narrowed at the call site.
@@ -1030,6 +1031,112 @@ class Model(nn.Module, ABC):
         if len(typed_outs) == 1:
             return (typed_outs[0], v_out)
         return (*typed_outs, v_out)
+
+    # ------------------------------------------------------------------
+    # Forward-mode input derivatives (the public jvp / jacobian surface)
+    # ------------------------------------------------------------------
+    #
+    # The py-eager analogue of the ``forward`` / ``jvp`` / ``jacobian`` surface
+    # every other route exposes (``neml2.aoti.Model`` / ``neml2::aoti::Model`` /
+    # the cpp-eager ``_EagerModel``), so the same code reads identically on any
+    # route. Both are thin, typed wrappers over the ``forward(v=)`` chain rule: a
+    # leading-K seed is threaded per input through the forward, then the typed
+    # contributions are assembled (the typed-output counterparts of the raw
+    # ``neml2.types._boundary`` assembly helpers the C++-facing routes use). The
+    # reverse-mode *parameter* derivatives (:meth:`param_jacobian` /
+    # :meth:`param_vjp`) below are a separate surface.
+
+    def jvp(
+        self,
+        inputs: Mapping[str, TensorWrapper | torch.Tensor],
+        tangents: Mapping[str, TensorWrapper | torch.Tensor],
+    ) -> tuple[dict[str, TensorWrapper], dict[str, TensorWrapper]]:
+        """Evaluate the model and its Jacobian-vector product, all typed.
+
+        Returns ``(outputs, jvp_outputs)``, both keyed by output name with typed
+        values. *inputs* and *tangents* are keyed by input name (typed wrappers or
+        raw tensors, wrapped via ``input_spec``); a missing tangent defaults to
+        zero (that input contributes nothing). ``jvp_outputs[name]`` is the
+        directional derivative -- a wrapper of the output's type at its natural
+        ``(*batch, *sub_batch, *out_base)`` shape.
+
+        Each supplied tangent is seeded as a single formal leading-K direction and
+        threaded through the ``forward(v=)`` chain rule; the per-input
+        contributions to each output are summed. The forward-mode companion of the
+        reverse-mode :meth:`param_jacobian` / :meth:`param_vjp`, and the typed
+        py-eager analogue of the (raw, name-keyed) ``jvp`` the compiled / embedded
+        routes expose.
+        """
+        from ..types._boundary import (  # noqa: PLC0415
+            assemble_jvp_outputs_typed,
+            leading_k1_seed,
+        )
+
+        typed_args = tuple(t(inputs[n]) for n, t in self.input_spec.items())  # type: ignore[call-arg]
+        seed: dict[str, dict[str, TensorWrapper]] = {}
+        for n, t_cls in self.input_spec.items():
+            tg = tangents.get(n)
+            if tg is None:
+                continue
+            tw = tg if isinstance(tg, TensorWrapper) else t_cls(tg)  # type: ignore[call-arg]
+            seed[n] = {n: leading_k1_seed(tw)}
+        *typed_outs, v_out = self(*typed_args, v=seed)
+        output_names = list(self.output_spec)
+        outputs = dict(zip(output_names, typed_outs, strict=True))
+        jvp_outputs = assemble_jvp_outputs_typed(v_out, tuple(typed_outs), output_names)
+        return outputs, jvp_outputs
+
+    def jacobian(
+        self,
+        inputs: Mapping[str, TensorWrapper | torch.Tensor],
+    ) -> tuple[dict[str, TensorWrapper], dict[str, dict[str, Tensor]]]:
+        """Evaluate the model and its full Jacobian as typed variable-pair blocks.
+
+        Returns ``(outputs, J)`` -- ``outputs`` keyed by output name (typed) and
+        ``J`` the nested ``{out_name: {in_name: block}}`` map (rows in
+        ``output_spec`` order, cols in ``input_spec`` order). Each block is a
+        dynamic-base :class:`~neml2.types.Tensor` of shape
+        ``(*batch, *sub_batch, *out_base, *in_base)`` -- there is no single static
+        wrapper for an arbitrary derivative pair. A constant ``(out, in)`` pair is
+        an explicit zero block.
+
+        Built on the same ``forward(v=)`` chain rule as :meth:`jvp`, seeding each
+        input with a leading-K identity (one direction per input base component,
+        reusing the AOTI export's :func:`~neml2.cli.aoti_export._leading_k_identity_seed`)
+        and reshaping the result into per-pair blocks. The seed batch is
+        ``broadcast(input batches, parameter batches)`` so a per-batch-element
+        parameter is handled, matching ``_EagerModel.jacobian``. The typed
+        py-eager analogue of the (raw, name-keyed) ``jacobian`` the compiled /
+        embedded routes expose.
+        """
+        from ..cli.aoti_export import _leading_k_identity_seed  # noqa: PLC0415
+        from ..types._boundary import assemble_jacobian_typed  # noqa: PLC0415
+        from .param_ad import call_batch_shape, enumerate_typed_params  # noqa: PLC0415
+
+        typed_args = tuple(t(inputs[n]) for n, t in self.input_spec.items())  # type: ignore[call-arg]
+        typed_params = enumerate_typed_params(self)
+        param_qnames = [q for q, _ in typed_params]
+        param_base = {q: tuple(cls.BASE_SHAPE) for q, cls in typed_params}
+        # The output batches on broadcast(input batches, parameter batches); build
+        # every identity seed at that common call batch so the chain rule and the
+        # output-batch-keyed assembly agree (a parameter may carry its own batch).
+        call_batch = call_batch_shape(typed_args, self, param_qnames, param_base)
+        seed = {
+            n: {n: _leading_k_identity_seed(t_cls, call_batch, dtype=ta.dtype, device=ta.device)}
+            for (n, t_cls), ta in zip(self.input_spec.items(), typed_args, strict=True)
+        }
+        *typed_outs, v_out = self(*typed_args, v=seed)
+        output_names = list(self.output_spec)
+        outputs = dict(zip(output_names, typed_outs, strict=True))
+        jac = assemble_jacobian_typed(
+            v_out,
+            tuple(typed_outs),
+            output_names,
+            self.output_spec,
+            list(self.input_spec),
+            self.input_spec,
+        )
+        return outputs, jac
 
     # ------------------------------------------------------------------
     # Parameter derivatives (reverse-mode autograd over calibration params)

--- a/neml2/solvers/newton_linesearch.py
+++ b/neml2/solvers/newton_linesearch.py
@@ -91,6 +91,7 @@ class NewtonWithLineSearch(Newton):
         atol = node.param_optional_float("abs_tol", 1.0e-10)
         rtol = node.param_optional_float("rel_tol", 1.0e-8)
         miters = int(node.param_optional_int("max_its", 25))
+        verbose = node.param_optional_bool("verbose", False)
         ls_type = node.param_optional_str("linesearch_type", "BACKTRACKING")
         ls_miter = int(node.param_optional_int("max_linesearch_iterations", 10))
         ls_sigma = node.param_optional_float("linesearch_cutback", 2.0)
@@ -101,6 +102,7 @@ class NewtonWithLineSearch(Newton):
             atol=atol,
             rtol=rtol,
             miters=miters,
+            verbose=verbose,
             linesearch_type=ls_type,
             max_linesearch_iterations=ls_miter,
             linesearch_cutback=ls_sigma,

--- a/neml2/types/_boundary.py
+++ b/neml2/types/_boundary.py
@@ -51,6 +51,7 @@ import torch
 
 if TYPE_CHECKING:
     from . import TensorWrapper
+    from .tensor import Tensor
 
 
 def check_tensor(
@@ -317,5 +318,153 @@ def assemble_jacobian(
             else:
                 # (*batch, *out_base, *in_base).
                 row[i_name] = _leading_k_block_to_per_pair(block, input_spec[i_name]).contiguous()
+        jac[o_name] = row
+    return jac
+
+
+# ---------------------------------------------------------------------------
+# Typed-output assembly — the py-eager native ``Model.jvp`` / ``Model.jacobian``
+# counterparts of the raw ``assemble_*`` helpers above.
+#
+# The raw variants exist for the C++ embed / AOTI boundaries, which hand back raw
+# ``torch.Tensor`` by contract. The native ``Model`` methods are NOT a framework
+# boundary, so they must return typed wrappers (CLAUDE.md Rule 1). These helpers
+# keep the chain-rule result typed: a directional JVP is a wrapper of the output
+# type, and a Jacobian block is a dynamic-base :class:`~neml2.types.tensor.Tensor`
+# of shape ``(*batch, *sub_batch, *out_base, *in_base)`` (there is no single
+# static wrapper for an arbitrary derivative pair). The ``.data`` reads below are
+# the same sanctioned typed↔raw site as the raw helpers — this module is that
+# boundary's home — but here the result is re-wrapped to typed before returning.
+# ---------------------------------------------------------------------------
+
+
+def leading_k1_seed(tangent: TensorWrapper) -> TensorWrapper:
+    """Wrap a primal tangent as a single formal leading-K (K=1) directional seed.
+
+    The ``forward(v=)`` chain rule expects seeds with a formal K region (not a
+    phantom leading batch axis) so that a derivative leaf (e.g. ``Normality``)
+    emitting its own ``k_ndim=1`` tangents aligns with the seed in ``align_k``
+    — the same reason :func:`neml2.cli.aoti_export._leading_k_identity_seed`
+    establishes the K region at the seed. *tangent* is a primal wrapper
+    (``k_ndim == 0``) at the input's ``(*batch, *sub_batch, *base)`` shape; the
+    result is the same type carrying one ``"full"`` K axis of size 1, preserving
+    the tangent's sub-batch metadata.
+    """
+    return type(tangent)(
+        tangent.data.unsqueeze(0),  # data-ok: typed-boundary seed construction
+        sub_batch_ndim=tangent.sub_batch_ndim,
+        sub_batch_state=tangent.sub_batch_state,
+        sub_batch_meta=tangent.sub_batch_meta,
+        k_ndim=1,
+        k_state=("full",),
+        k_pairing=(None,),
+    )
+
+
+def assemble_jvp_outputs_typed(
+    v_out: dict,
+    typed_outputs: tuple[TensorWrapper, ...],
+    output_names: list[str],
+) -> dict[str, TensorWrapper]:
+    """Typed counterpart of :func:`assemble_jvp_outputs`.
+
+    ``v_out`` is the chain-rule result ``{out_name: {seed_name: block}}`` from a
+    single leading-K=1 directional seed per input (see :func:`leading_k1_seed`):
+    each block is a wrapper of the output type carrying one K axis, data
+    ``(1, *batch, *sub, *out_base)``. For each output the per-seed contributions
+    are summed (typed ``+`` — which aligns sub-batch, the reason a plain raw
+    stack-sum would not do for sub-batched models) and the singleton K axis is
+    dropped, giving the directional derivative as a clean ``k_ndim=0`` wrapper of
+    the output type. An output with no dependence on any seeded input is a typed
+    zero of the output type.
+    """
+    out: dict[str, TensorWrapper] = {}
+    for typed_out, name in zip(typed_outputs, output_names, strict=True):
+        # Reconstruct a primal (k_ndim=0) wrapper of the value output's type,
+        # carrying its sub-batch metadata verbatim (k_* default to empty).
+        def _as_output(data: torch.Tensor, _o: TensorWrapper = typed_out) -> TensorWrapper:
+            return type(_o)(
+                data,
+                sub_batch_ndim=_o.sub_batch_ndim,
+                sub_batch_state=_o.sub_batch_state,
+                sub_batch_meta=_o.sub_batch_meta,
+            )
+
+        contribs = list(v_out.get(name, {}).values())
+        if not contribs:
+            # Same type / shape as the value output, all zeros.
+            out[name] = _as_output(torch.zeros_like(typed_out.data))  # data-ok
+            continue
+        summed = contribs[0]
+        for c in contribs[1:]:
+            summed = summed + c
+        # summed: output type, k_ndim=1, data (1, *batch, *sub, *out_base). Drop
+        # the single K direction -> the value output's natural (*batch, *sub,
+        # *out_base).
+        out[name] = _as_output(summed.data.squeeze(0))  # data-ok
+    return out
+
+
+def assemble_jacobian_typed(
+    v_out: dict,
+    typed_outputs: tuple[TensorWrapper, ...],
+    output_names: list[str],
+    output_spec: dict[str, type[TensorWrapper]],
+    input_names: list[str],
+    input_spec: dict[str, type[TensorWrapper]],
+) -> dict[str, dict[str, Tensor]]:
+    """Typed counterpart of :func:`assemble_jacobian`.
+
+    Returns the nested ``{out_name: {in_name: block}}`` where each block is a
+    dynamic-base :class:`~neml2.types.tensor.Tensor` of shape
+    ``(*batch, *sub_batch, *out_base, *in_base)`` — the natural typed Jacobian
+    block (no single static wrapper spans an arbitrary derivative pair). The
+    leading-K identity-seed block ``(K, *batch, *sub, *out_base)`` (K = prod of
+    the input base) has its K axis moved to the trailing end and reshaped into
+    the input's base axes; sub-batch metadata is carried over. A constant
+    ``(out, in)`` pair (absent from ``v_out``) is an explicit typed zero block
+    shaped from the value output.
+    """
+    from .tensor import Tensor  # noqa: PLC0415 — same-package, avoid import cycle
+
+    jac: dict[str, dict[str, Tensor]] = {}
+    for typed_out, o_name in zip(typed_outputs, output_names, strict=True):
+        o_base = tuple(output_spec[o_name].BASE_SHAPE)
+        sub_ndim = typed_out.sub_batch_ndim
+        # Split into the plain-batch region and the sub-batch region via the
+        # framework's region accessors. ``dynamic_batch_shape`` is the plain batch
+        # (it excludes both K and sub-batch); the static-wrapper ``batch_shape``
+        # deliberately bundles dynamic + sub-batch, so it is the wrong accessor to
+        # locate a sub-batched output's plain-batch axes. The value output carries
+        # no K region (k_ndim == 0).
+        batch = tuple(typed_out.dynamic_batch_shape)
+        sub = tuple(typed_out.sub_batch_shape)
+        bnd = len(batch)
+        opts = {"dtype": typed_out.dtype, "device": typed_out.device}
+        row: dict[str, Tensor] = {}
+        for i_name in input_names:
+            i_base = tuple(input_spec[i_name].BASE_SHAPE)
+            block = v_out.get(o_name, {}).get(i_name)
+            if block is None:
+                # Constant (out, in) pair: a structural zero block at the
+                # value output's batch + sub-batch, with (out_base, in_base).
+                data = torch.zeros(*batch, *sub, *o_base, *i_base, **opts)
+            else:
+                # block: output type, k_ndim=1, data (K, *batch, *sub, *out_base);
+                # the contribution was retagged to the output's sub-batch, so it
+                # shares the value output's batch + sub-batch split.
+                moved = block.data.movedim(0, -1)  # data-ok; (*batch, *sub, *out_base, K)
+                if i_base:
+                    data = moved.reshape(*moved.shape[:-1], *i_base)
+                else:
+                    data = moved.squeeze(-1)  # scalar input: K == 1, no trailing axis
+                data = data.contiguous()
+            row[i_name] = Tensor(
+                data,
+                batch_ndim=bnd,
+                sub_batch_ndim=sub_ndim,
+                sub_batch_state=typed_out.sub_batch_state,
+                sub_batch_meta=typed_out.sub_batch_meta,
+            )
         jac[o_name] = row
     return jac

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -85,6 +85,42 @@ set_tests_properties(test_dispatcher test_load_model PROPERTIES
       ENVIRONMENT_MODIFICATION "LD_LIBRARY_PATH=path_list_prepend:${torch_LINK_DIR}"
 )
 
+# --- Custom-op coverage: a model that uses neml2::opaque_pow -------------------
+# The dispatcher fixtures above compile LinearIsotropicElasticity (no custom ops),
+# so nothing exercised the cpp-aoti path for an op that torch.export preserves
+# into the artifact and that the Python-free libneml2 must register itself
+# (neml2::opaque_pow -- crystal plasticity / Perzyna). PerzynaPlasticFlowRate is
+# the smallest plain-batch leaf that uses it. Reuses _fixture_devices (cpu [+cuda]).
+set(_pz_dir ${CMAKE_CURRENT_BINARY_DIR}/custom_op_fixture)
+set(_pz_input ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/opaque_pow_model.i)
+
+add_test(
+      NAME custom_op_fixture_compile
+      COMMAND ${Python3_EXECUTABLE} -m neml2.cli.aoti_compile ${_pz_input}
+              --model model --device ${_fixture_devices} --dtype float64
+              -d flow_rate:yield_function
+              --output-dir ${_pz_dir}
+      WORKING_DIRECTORY ${NEML2_SOURCE_DIR}
+)
+set_tests_properties(custom_op_fixture_compile PROPERTIES
+      FIXTURES_SETUP custom_op_artifact
+      LABELS "dispatcher"
+      TIMEOUT 600
+      ENVIRONMENT "TORCHINDUCTOR_CACHE_DIR=${_pz_dir}/aoti-cache"
+)
+
+add_executable(test_custom_ops test_custom_ops.cpp)
+target_link_libraries(test_custom_ops PRIVATE aoti)
+target_compile_options(test_custom_ops PRIVATE -Wall -Wextra)
+set_target_properties(test_custom_ops PROPERTIES BUILD_RPATH "${NEML2_BINARY_DIR};${torch_LINK_DIR}")
+add_test(NAME test_custom_ops COMMAND test_custom_ops ${_pz_dir})
+set_tests_properties(test_custom_ops PROPERTIES
+      FIXTURES_REQUIRED custom_op_artifact
+      LABELS "dispatcher"
+      TIMEOUT 300
+      ENVIRONMENT_MODIFICATION "LD_LIBRARY_PATH=path_list_prepend:${torch_LINK_DIR}"
+)
+
 # --- Eager embed test: links libneml2_eager, embeds a CPython interpreter, and
 # runs a model straight from the original .i (no compile fixture needed). New
 # "eager" label so it runs independently of the AOTI dispatcher tests.

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -121,6 +121,41 @@ set_tests_properties(test_custom_ops PROPERTIES
       ENVIRONMENT_MODIFICATION "LD_LIBRARY_PATH=path_list_prepend:${torch_LINK_DIR}"
 )
 
+# --- Input broadcast: a batch-independent input alongside a batched one --------
+# Every AOTI fixture above feeds uniformly-batched inputs, so the runtime's
+# broadcast of a batch-independent input (the shape MOOSE produces for a scalar
+# TIME force) was uncovered. ScalarLinearCombination C = A + B + offset, with B
+# supplied as a 0-dim scalar. Reuses _fixture_devices (cpu [+cuda]).
+set(_bc_dir ${CMAKE_CURRENT_BINARY_DIR}/broadcast_fixture)
+set(_bc_input ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/batch_broadcast_model.i)
+
+add_test(
+      NAME broadcast_fixture_compile
+      COMMAND ${Python3_EXECUTABLE} -m neml2.cli.aoti_compile ${_bc_input}
+              --model model --device ${_fixture_devices} --dtype float64
+              -d C:A -d C:B
+              --output-dir ${_bc_dir}
+      WORKING_DIRECTORY ${NEML2_SOURCE_DIR}
+)
+set_tests_properties(broadcast_fixture_compile PROPERTIES
+      FIXTURES_SETUP broadcast_artifact
+      LABELS "dispatcher"
+      TIMEOUT 600
+      ENVIRONMENT "TORCHINDUCTOR_CACHE_DIR=${_bc_dir}/aoti-cache"
+)
+
+add_executable(test_input_broadcast test_input_broadcast.cpp)
+target_link_libraries(test_input_broadcast PRIVATE aoti)
+target_compile_options(test_input_broadcast PRIVATE -Wall -Wextra)
+set_target_properties(test_input_broadcast PROPERTIES BUILD_RPATH "${NEML2_BINARY_DIR};${torch_LINK_DIR}")
+add_test(NAME test_input_broadcast COMMAND test_input_broadcast ${_bc_dir})
+set_tests_properties(test_input_broadcast PROPERTIES
+      FIXTURES_REQUIRED broadcast_artifact
+      LABELS "dispatcher"
+      TIMEOUT 300
+      ENVIRONMENT_MODIFICATION "LD_LIBRARY_PATH=path_list_prepend:${torch_LINK_DIR}"
+)
+
 # --- Eager embed test: links libneml2_eager, embeds a CPython interpreter, and
 # runs a model straight from the original .i (no compile fixture needed). New
 # "eager" label so it runs independently of the AOTI dispatcher tests.

--- a/tests/cpp/fixtures/batch_broadcast_model.i
+++ b/tests/cpp/fixtures/batch_broadcast_model.i
@@ -1,0 +1,12 @@
+# A minimal two-input model for the cpp-aoti batch-independent-input test:
+# ScalarLinearCombination C = A + B + offset. test_input_broadcast supplies A
+# batched and B as a 0-dim scalar (the shape MOOSE produces for a TIME force);
+# the runtime must broadcast B up to the call batch.
+[Models]
+  [model]
+    type = ScalarLinearCombination
+    from = 'A B'
+    to = 'C'
+    offset = 2.0
+  []
+[]

--- a/tests/cpp/fixtures/opaque_pow_model.i
+++ b/tests/cpp/fixtures/opaque_pow_model.i
@@ -1,0 +1,13 @@
+# A minimal model that routes through the neml2::opaque_pow custom op:
+# PerzynaPlasticFlowRate computes flow_rate = (yield_function / reference_stress)^exponent
+# via opaque_pow (the Inductor fusion barrier from neml2/types/functions.py).
+# Compiled by the custom_op_fixture_compile ctest fixture and loaded by
+# test_custom_ops through the Python-free cpp-aoti runtime, which must register
+# neml2::opaque_pow in libneml2 itself.
+[Models]
+  [model]
+    type = PerzynaPlasticFlowRate
+    reference_stress = 150
+    exponent = 6
+  []
+[]

--- a/tests/cpp/test_custom_ops.cpp
+++ b/tests/cpp/test_custom_ops.cpp
@@ -1,0 +1,124 @@
+// Copyright 2024, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Exercises the cpp-aoti runtime with a model that uses a NEML2 custom op that
+// torch.export deliberately preserves into the artifact -- neml2::opaque_pow,
+// the Inductor fusion barrier from neml2/types/functions.py. The other AOTI
+// dispatcher fixtures use LinearIsotropicElasticity (no custom ops), so nothing
+// covered the path where the Python-free libneml2 must register the op itself:
+// the Python package's registration is absent in a pure-C++ host, and the
+// dispatcher otherwise throws "Could not find schema for neml2::opaque_pow"
+// when the artifact loads. The fixture compiles PerzynaPlasticFlowRate, whose
+// flow_rate = (yield_function / reference_stress)^exponent routes through
+// opaque_pow. argv[1] is the fixture (collection) dir.
+
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <string>
+
+#include <ATen/ATen.h>
+
+#include "neml2/csrc/aoti/Model.h"
+#include "neml2/csrc/dispatchers/SimpleScheduler.h"
+#include "neml2/csrc/dispatchers/factory.h"
+
+#include "test_util.h"
+
+using namespace neml2::aoti;
+
+namespace
+{
+// reference_stress=150, exponent=6, yield_function=50:
+// flow_rate = (50/150)^6 = (1/3)^6 = 1/729 -- the PerzynaPlasticFlowRate
+// ModelUnitTest gold. A value-level check (not just "load succeeds") confirms
+// the C++ opaque_pow kernel computes the right thing, not merely that a schema
+// is present.
+constexpr double kYieldFunction = 50.0;
+constexpr double kExpectedFlowRate = 0.0013717421124828527;
+
+std::map<std::string, at::Tensor>
+make_inputs(const Model & model, int64_t b)
+{
+  std::vector<int64_t> shape{b};
+  const auto & base = model.input_base_shapes()[0];
+  shape.insert(shape.end(), base.begin(), base.end());
+  const auto opts = at::TensorOptions().dtype(model.dtype()).device(model.device());
+  return {{"yield_function", at::full(shape, kYieldFunction, opts)}};
+}
+
+// forward() resolves neml2::opaque_pow through the dispatcher; without the C++
+// registration in libneml2 this throws before returning. Templated because the
+// load_model factory returns a DispatchedModel while the direct artifact is a
+// Model -- both expose forward().
+template <typename ModelT>
+bool
+flow_rate_ok(const ModelT & model,
+             const std::map<std::string, at::Tensor> & inputs,
+             double rtol,
+             double atol)
+{
+  const auto out = model.forward(inputs);
+  const auto & fr = out.at("flow_rate");
+  return at::allclose(fr, at::full_like(fr, kExpectedFlowRate), rtol, atol);
+}
+} // namespace
+
+int
+main(int argc, char ** argv)
+{
+  NEML2_CHECK(argc >= 2); // argv[1] = the fixture (collection) dir
+  const std::string fixture_dir = argv[1];
+  const std::string stub = fixture_dir + "/model_aoti.i";
+  const std::string cpu_meta = fixture_dir + "/model/cpu/model_meta.json";
+
+  const int64_t b = 8;
+
+  // Direct cpu artifact.
+  Model ref(cpu_meta);
+  NEML2_CHECK(ref.input_names().size() == 1);
+  NEML2_CHECK(ref.input_names()[0] == "yield_function");
+  const auto inputs = make_inputs(ref, b);
+  NEML2_CHECK(flow_rate_ok(ref, inputs, 1e-10, 1e-12));
+
+  // Through the load_model(stub, name) factory.
+  {
+    auto m = load_model(stub, "model");
+    NEML2_CHECK(m.device().is_cpu());
+    NEML2_CHECK(flow_rate_ok(m, inputs, 1e-10, 1e-12));
+  }
+
+  // cuda: dispatch the cpu inputs onto the GPU when a cuda artifact exists, so
+  // the op resolves on the cuda backend too.
+  const std::string cuda_meta = fixture_dir + "/model/cuda/model_meta.json";
+  if (at::hasCUDA() && std::filesystem::exists(cuda_meta))
+  {
+    auto sched = std::make_shared<SimpleScheduler>(SimpleScheduler::Config{"cuda", 4});
+    auto m = load_model(stub, "model", sched);
+    NEML2_CHECK(m.device().is_cuda());
+    NEML2_CHECK(flow_rate_ok(m, inputs, 1e-8, 1e-10));
+  }
+
+  return 0;
+}

--- a/tests/cpp/test_input_broadcast.cpp
+++ b/tests/cpp/test_input_broadcast.cpp
@@ -1,0 +1,71 @@
+// Copyright 2024, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Exercises the cpp-aoti runtime with a batch-INDEPENDENT input alongside a
+// batched one -- the shape MOOSE produces for a scalar TIME force. The dispatcher
+// fixtures (test_load_model / test_dispatcher) and test_custom_ops all feed
+// uniformly-batched inputs, so the runtime's input-broadcast path was uncovered;
+// the cpp-aoti Model must lift a batch-independent input up to the common call
+// batch the same way the typed (eager / py-aoti shim) routes do.
+//
+// Model: ScalarLinearCombination C = A + B + offset, with A batched and B a 0-dim
+// scalar. forward() broadcasts inside the graph, so the *jacobian* -- whose block
+// assembly cats per-input columns -- is the discriminating call: without the
+// broadcast it raises "Tensors must have same number of dimensions: got 2 and 1".
+// argv[1] is the fixture (collection) dir.
+
+#include <map>
+#include <string>
+
+#include <ATen/ATen.h>
+
+#include "neml2/csrc/aoti/Model.h"
+
+#include "test_util.h"
+
+using namespace neml2::aoti;
+
+int
+main(int argc, char ** argv)
+{
+  NEML2_CHECK(argc >= 2); // argv[1] = the fixture (collection) dir
+  const std::string cpu_meta = std::string(argv[1]) + "/model/cpu/model_meta.json";
+
+  Model m(cpu_meta);
+  const int64_t b = 6;
+  const double offset = 2.0; // matches batch_broadcast_model.i
+  const auto opts = at::TensorOptions().dtype(m.dtype()).device(m.device());
+
+  const auto A = at::arange(b, opts);     // batched      -> (b,)
+  const auto B = at::full({}, 5.0, opts); // batch-indep. -> 0-dim scalar
+  const std::map<std::string, at::Tensor> ins{{"A", A}, {"B", B}};
+
+  // jacobian() drives the block-assembly cat; without the input broadcast the
+  // 0-dim B collides with the batched A and this throws. The value half of the
+  // result also confirms B was lifted to the batch: C = A + B + offset.
+  const auto outputs = m.jacobian(ins).first;
+  NEML2_CHECK(at::allclose(outputs.at("C"), A + 5.0 + offset));
+
+  return 0;
+}

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -273,6 +273,30 @@ def test_load_newton_solver_from_hit():
     assert abs(solver.rtol - 1e-6) < 1e-15
 
 
+def test_newton_with_linesearch_from_hit_honors_verbose():
+    """Regression: ``NewtonWithLineSearch.from_hit`` must honor the inherited
+    ``verbose`` option. It previously failed to read it, so a ``verbose = true``
+    input silently produced a quiet solver -- the schema accepts the field
+    (inherited from ``Newton``), so no error flagged the dropped option."""
+    from neml2.solvers import NewtonWithLineSearch
+
+    hit_text = """
+[Solvers]
+  [newton]
+    type = NewtonWithLineSearch
+    verbose = true
+  []
+[]
+"""
+    import nmhit
+
+    root = nmhit.parse_text(hit_text)
+    factory = _NativeInputFile(root, Path("synthetic.i"))
+    solver = factory.get_solver("newton")
+    assert isinstance(solver, NewtonWithLineSearch)
+    assert solver.verbose is True
+
+
 # ---------------------------------------------------------------------------
 # load_input / load_model public API
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_native_jvp_jacobian.py
+++ b/tests/unit/test_native_jvp_jacobian.py
@@ -1,0 +1,245 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Unit tests for the native (py-eager) ``Model.jvp`` / ``Model.jacobian``.
+
+These are the typed forward-mode input-derivative surface ``neml2.load_model``
+returns -- the py-eager analogue of the ``forward`` / ``jvp`` / ``jacobian``
+methods every other route exposes. The guarantees pinned here:
+
+* **parity** -- value-for-value agreement with the trusted raw ``_EagerModel``
+  adapter (which is itself pinned against the AOTI routes), so the typed native
+  surface and the compiled/embedded routes never diverge;
+* **typed returns** (CLAUDE.md Rule 1) -- jvp outputs are wrappers of the output
+  type; Jacobian blocks are dynamic-base ``neml2.types.Tensor`` carrying the
+  correct ``(batch, sub_batch, base)`` region split;
+* **sub-batch support** -- unlike the plain-batch-only eager bridge, the native
+  surface handles a sub-batched model (crystal-plasticity ``ResolvedShear``),
+  with the per-site axis kept in the sub-batch region of the Jacobian block;
+* **the implicit (IFT) path** -- a Newton-solved ``ImplicitUpdate`` matches
+  ``torch.autograd``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+import neml2
+from neml2 import CrystalGeometry, ResolvedShear, cubic_symmetry_operators
+from neml2.eager import _EagerModel
+from neml2.types import R2, SR2, MillerIndex, Scalar
+from neml2.types import Tensor as DynTensor
+
+_REPO = Path(__file__).resolve().parents[2]
+_SINGLE = _REPO / "tests" / "aoti" / "forward_single" / "model.i"  # SR2 strain -> SR2 stress
+_COMPOSED = _REPO / "tests" / "aoti" / "forward_composed" / "model.i"  # 2-leaf, multi-output
+_IMPLICIT = _REPO / "tests" / "aoti" / "implicit_simple" / "model.i"  # ImplicitUpdate (Newton)
+
+
+def _raw_inputs(m, b):
+    return {
+        n: torch.randn(b, *base, dtype=m.dtype, device=m.device)
+        for n, base in zip(m.input_names, m.input_base_shapes, strict=True)
+    }
+
+
+# --- parity with the trusted raw _EagerModel adapter --------------------------
+
+
+@pytest.mark.parametrize("inp", [_SINGLE, _COMPOSED], ids=["single", "composed"])
+def test_value_jvp_jacobian_match_eager(inp):
+    """The typed native surface agrees value-for-value with the raw eager adapter
+    on value, jvp, and every Jacobian block."""
+    torch.manual_seed(0)
+    native = neml2.load_model(str(inp), "model")
+    eager = _EagerModel(str(inp), "model")
+    b = 4
+    raw = _raw_inputs(eager, b)
+    tang = _raw_inputs(eager, b)
+
+    nout, njac = native.jacobian(raw)
+    eout, ejac = eager.jacobian(raw)
+    assert set(nout) == set(eout)
+    for o in eout:
+        assert torch.allclose(nout[o].data, eout[o])
+        for i in ejac[o]:
+            assert isinstance(njac[o][i], DynTensor)  # Rule 1: typed block
+            assert tuple(njac[o][i].data.shape) == tuple(ejac[o][i].shape)
+            assert torch.allclose(njac[o][i].data, ejac[o][i], atol=1e-12)
+
+    _, njvp = native.jvp(raw, tang)
+    _, ejvp = eager.jvp(raw, tang)
+    for o in ejvp:
+        # jvp output is a wrapper of the output's type (not a raw tensor).
+        assert type(njvp[o]).__name__ == type(nout[o]).__name__
+        assert torch.allclose(njvp[o].data, ejvp[o], atol=1e-12)
+
+
+def test_jacobian_matches_autograd():
+    """The (stress, strain) block matches torch.autograd's Jacobian."""
+    native = neml2.load_model(str(_SINGLE), "model")
+    torch.manual_seed(0)
+    x = torch.randn(4, 6, dtype=next(native.parameters()).dtype)
+
+    _, jac = native.jacobian({"strain": x})
+    block = jac["stress"]["strain"]
+    assert block.data.shape == (4, 6, 6)
+    assert tuple(block.base_shape) == (6, 6)  # d SR2 / d SR2
+
+    def f(t):
+        r = native(SR2(t))
+        return (r if not isinstance(r, tuple) else r[0]).data.sum(0)  # (6,)
+
+    ref = torch.autograd.functional.jacobian(f, x).permute(1, 0, 2)  # (4, 6, 6)
+    assert torch.allclose(block.data, ref, atol=1e-10)
+
+
+def test_jvp_equals_jacobian_times_tangent():
+    native = neml2.load_model(str(_SINGLE), "model")
+    torch.manual_seed(0)
+    dt = next(native.parameters()).dtype
+    x = torch.randn(3, 6, dtype=dt)
+    v = torch.randn(3, 6, dtype=dt)
+
+    _, jvp_out = native.jvp({"strain": x}, {"strain": v})
+    _, jac = native.jacobian({"strain": x})
+    block = jac["stress"]["strain"].data  # (3, 6, 6)
+    assert jvp_out["stress"].data.shape == (3, 6)
+    assert torch.allclose(jvp_out["stress"].data, torch.einsum("bij,bj->bi", block, v), atol=1e-12)
+
+
+def test_jvp_missing_tangent_is_zero():
+    native = neml2.load_model(str(_SINGLE), "model")
+    x = torch.ones(2, 6, dtype=next(native.parameters()).dtype)
+    _, jvp_out = native.jvp({"strain": x}, {})  # no tangent seeded
+    assert isinstance(jvp_out["stress"], SR2)
+    assert jvp_out["stress"].data.shape == (2, 6)
+    assert torch.count_nonzero(jvp_out["stress"].data) == 0
+
+
+def test_composed_multi_output_block_shapes():
+    native = neml2.load_model(str(_COMPOSED), "model")
+    eager = _EagerModel(str(_COMPOSED), "model")
+    torch.manual_seed(0)
+    b = 5
+    raw = _raw_inputs(eager, b)
+
+    outputs, jac = native.jacobian(raw)
+    assert set(outputs) == set(eager.output_names)
+    for o_name, o_base in zip(eager.output_names, eager.output_base_shapes, strict=True):
+        for i_name, i_base in zip(eager.input_names, eager.input_base_shapes, strict=True):
+            assert tuple(jac[o_name][i_name].data.shape) == (b, *o_base, *i_base)
+
+
+# --- sub-batch (crystal plasticity): native handles what the eager bridge can't
+
+
+@pytest.fixture
+def fcc_resolved_shear():
+    fcc = CrystalGeometry(
+        sym_ops=cubic_symmetry_operators(),
+        lattice_vectors=torch.eye(3),
+        slip_directions=MillerIndex(torch.tensor([1.0, 1.0, 0.0])),
+        slip_planes=MillerIndex(torch.tensor([1.0, 1.0, 1.0])),
+    )
+    return ResolvedShear(crystal_geometry=fcc)
+
+
+def test_subbatch_jacobian_region_split_and_numerics(fcc_resolved_shear):
+    """A sub-batched output keeps its per-slip axis in the Jacobian block's
+    SUB-batch region (not folded into plain batch), and the values match
+    autograd. This is the regression guard for the batch_shape-vs-
+    dynamic_batch_shape root fix."""
+    leaf = fcc_resolved_shear
+    stress_name, orient_name = list(leaf.input_spec)
+    R = R2(torch.eye(3))
+    sigma = SR2(torch.randn(4, 6))  # plain batch 4
+    nslip = leaf(SR2(torch.randn(6)), R).data.shape[0]
+
+    _, jac = leaf.jacobian({stress_name: sigma, orient_name: R})
+    block = jac["resolved_shears"][stress_name]
+    # d(scalar-per-slip)/d(SR2): batch (4,), sub (nslip,), base (6,).
+    assert block.batch_ndim == 1
+    assert tuple(block.batch_shape) == (4,)
+    assert block.sub_batch_ndim == 1
+    assert tuple(block.sub_batch_shape) == (nslip,)
+    assert tuple(block.base_shape) == (6,)
+
+    # numerics vs autograd (single, unbatched, for a clean per-slip Jacobian).
+    s0 = torch.randn(6)
+    _, jac0 = leaf.jacobian({stress_name: SR2(s0), orient_name: R})
+    sl = s0.detach().clone().requires_grad_(True)
+    ref = torch.autograd.functional.jacobian(lambda s: leaf(SR2(s), R).data, sl)  # (nslip, 6)
+    assert torch.allclose(jac0["resolved_shears"][stress_name].data, ref, atol=1e-5)
+
+
+def test_subbatch_jvp_is_output_typed(fcc_resolved_shear):
+    """jvp on a sub-batched output returns an output-typed wrapper that keeps the
+    per-slip sub-batch axis."""
+    leaf = fcc_resolved_shear
+    stress_name, orient_name = list(leaf.input_spec)
+    R = R2(torch.eye(3))
+    sigma = SR2(torch.randn(6))
+    nslip = leaf(sigma, R).data.shape[0]
+
+    _, jvp_out = leaf.jvp({stress_name: sigma, orient_name: R}, {stress_name: SR2(torch.randn(6))})
+    rss = jvp_out["resolved_shears"]
+    assert isinstance(rss, Scalar)
+    assert rss.sub_batch_ndim == 1
+    assert tuple(rss.sub_batch_shape) == (nslip,)
+
+
+# --- implicit (IFT) path ------------------------------------------------------
+
+
+def test_implicit_jacobian_matches_autograd():
+    """A Newton-solved ImplicitUpdate: the chain-rule Jacobian (built on the
+    implicit-function-theorem adjoint) matches torch.autograd through the solve."""
+    native = neml2.load_model(str(_IMPLICIT), "model").to(torch.float64)
+    names = list(native.input_spec)
+    b = 3
+    torch.manual_seed(2)
+    # Physically-sane backward-Euler inputs (positive time step) so the 1-D
+    # Newton solve converges; random t/t_old would give a garbage step.
+    raw = {
+        "x": torch.zeros(b, dtype=torch.float64),
+        "x~1": torch.rand(b, dtype=torch.float64),
+        "t": torch.full((b,), 1.0, dtype=torch.float64),
+        "t~1": torch.zeros(b, dtype=torch.float64),
+        "x_rate": torch.rand(b, dtype=torch.float64),
+    }
+
+    _, jac = native.jacobian(raw)
+
+    def f(*vals):
+        r = native(*(Scalar(v) for v in vals))
+        return (r if not isinstance(r, tuple) else r[0]).data
+
+    leaves = [raw[n].detach().clone().requires_grad_(True) for n in names]
+    J = torch.autograd.functional.jacobian(f, tuple(leaves))
+    for k, n in enumerate(names):
+        assert torch.allclose(jac["x"][n].data, torch.diagonal(J[k]), atol=1e-8)


### PR DESCRIPTION
Bundles the native py-eager derivative surface with several cross-route deployment-runtime fixes surfaced while exercising it (Newton convergence logging, cpp-aoti input broadcasting, and `opaque_pow` registration). All six routes stay in parity.

## Commits

1. **Add typed `jvp` / `jacobian` to the native py-eager `Model`.** `neml2.load_model` previously exposed only `forward` (with `v=` chain-rule seeding) plus the reverse-mode `param_jacobian` / `param_vjp`; the clean `forward`/`jvp`/`jacobian` tri-method surface lived only on the AOTI shim and the cpp-eager `_EagerModel`. The new methods return typed wrappers (Rule 1): jvp outputs are wrappers of the output type, Jacobian blocks are dynamic-base `Tensor` of shape `(*batch, *sub_batch, *out_base, *in_base)`. Thin wrappers over the existing `forward(v=)` chain rule, with typed assembly helpers added alongside the raw eager/AOTI-boundary ones in `neml2/types/_boundary.py`. Sub-batch models (crystal plasticity) are supported, splitting via the canonical `dynamic_batch_shape` accessor.

2. **Honor `verbose` in `NewtonWithLineSearch.from_hit`.** The inherited schema field was silently dropped, so `verbose = true` loaded a quiet solver.

3. **Line-buffer cpp-eager interpreter stdio.** The embedded interpreter is never finalized, so Python's `atexit` stdout flush never runs; a block-buffered stream (redirected stdout) swallowed the solver's `verbose` convergence log. Reconfigure to line buffering after init.

4. **Register `neml2::opaque_pow` in libneml2** (lazy, once-only, `findOp`-guarded from the aoti Model ctor) so the Python-free cpp-aoti / cpp-dispatch runtimes can load artifacts that preserve the op, without double-defining against the embedded Python in the cpp-eager / MOOSE host.

5. **Broadcast batch-independent inputs in cpp-aoti** via a shared `_prepare_inputs` (the C++ analogue of `broadcast_to_common_batch`), so a scalar input (e.g. MOOSE's TIME force) no longer collides with batched inputs in the Jacobian block-assembly `cat`. MOOSE-driven transient models now run in cpp-aoti, not only cpp-eager.

## Testing

- Python: full `tests/unit/` suite (633) green; new `tests/unit/test_native_jvp_jacobian.py` pins value/jvp/jacobian parity with `_EagerModel`, agreement with `torch.autograd` (incl. the implicit IFT path), and the sub-batch region split; new `from_hit` verbose regression test.
- C++ (cpp-aoti / eager): new `test_custom_ops` (PerzynaPlasticFlowRate through the C++ runtime) and `test_input_broadcast` (scalar input broadcast) pass with their Inductor compile fixtures; `test_eager` passes.
- `doc/content/references/py_eager.md` updated so the advertised `forward`/`jvp`/`jacobian` surface is literally the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)