### PR TITLE
Add boundary variable/parameter renaming to neml2-compile

### DIFF
--- a/doc/content/deployment/cli.md
+++ b/doc/content/deployment/cli.md
@@ -162,6 +162,25 @@ Derivative graphs are opt-in: with no `-d` flag only `forward` is
 compiled and `jvp` / `jacobian` raise at runtime. Request the pairs you
 need with `-d OUT:IN` (e.g. `-d stress:strain`, or `-d :` for all).
 
+### Boundary renaming
+
+A downstream consumer may need the compiled model's variables to carry its own
+names. Rename them at the artifact's boundary with `--rename-input ORIG:NEW`,
+`--rename-output ORIG:NEW`, and `--rename-parameter ORIG:NEW` (each repeatable).
+The rename is **shallow**: only the names reported at the interface change — the
+inputs / outputs a caller passes and reads, the promoted-parameter names in
+`named_parameters()`, and the keys of every `forward` / `jvp` / `jacobian`
+result. The compiled graphs and all internal wiring keep the original authored
+names, so a rename is a pure relabel with identical values. `ORIG` must be an
+existing structural input, output, or promoted parameter (`--rename-parameter`
+targets a name from `-p`), and the resulting names must stay unique.
+
+Renaming applies to the compiled routes only (Python `neml2.aoti.Model`, C++
+`neml2::aoti::Model`, and the dispatcher); the eager routes run the un-exported
+model and keep the authored names. It is available with `--model` only — with
+`--driver` the bundled driver is wired to the original names, so combining them
+is rejected.
+
 The end-to-end walkthrough — emitted file layout, loading the
 artifact from Python, parameter promotion (`-p <name>`), and the
 trade-offs against eager mode — lives in
@@ -170,10 +189,11 @@ trade-offs against eager mode — lives in
 ### Interactive mode (`-i` / `--interactive`)
 
 `neml2-compile`'s flag surface is wide and interdependent: the promotable
-parameter names (`-p`) and the valid `OUT:IN` derivative pairs (`-d`) only exist
-once the model is loaded and introspected. Pass `-i` / `--interactive` to be
-guided through the options with prompts populated from the model, ending on a
-review you can run, edit, or copy as a plain `neml2-compile` command:
+parameter names (`-p`), the valid `OUT:IN` derivative pairs (`-d`), and the
+variables available to rename (`--rename-*`) only exist once the model is loaded
+and introspected. Pass `-i` / `--interactive` to be guided through the options
+with prompts populated from the model, ending on a review you can run, edit, or
+copy as a plain `neml2-compile` command:
 
 ```bash
 neml2-compile -i input.i

--- a/doc/content/references/aoti_packages.md
+++ b/doc/content/references/aoti_packages.md
@@ -146,6 +146,15 @@ the Python source. It records, at a high level:
   split on; executed in order at runtime, with each segment's outputs
   feeding the next segment's inputs via a shared `name → tensor` state
   map.
+- **Boundary aliases** (optional `boundary_aliases`) — shallow renames
+  applied at the interface only. Present only when the artifact was
+  compiled with `--rename-input` / `--rename-output` / `--rename-parameter`;
+  a map with `inputs` / `outputs` / `parameters` sub-maps of
+  `{original_name: boundary_name}`. Every other field above keeps the
+  **original** authored names; a loader reads them as the internal identity
+  and applies the alias only when reporting names and keying the public
+  `forward` / `jvp` / `jacobian` / `named_parameters` surface. Absent means
+  the interface uses the authored names.
 
 The exact field layout evolves alongside the export pipeline, so it is
 not mirrored field-by-field here. The metadata carries an integer
@@ -154,7 +163,7 @@ refuses any non-matching version with a clear "regenerate via
 `neml2-compile`" message; the only remediation is a re-compile.
 
 <!-- dependencies: aoti.schema_version -->
-The current schema version is `7`.
+The current schema version is `8`.
 
 ### Segment kinds
 

--- a/neml2/aoti/_shim.py
+++ b/neml2/aoti/_shim.py
@@ -166,15 +166,26 @@ class AOTIModel(nn.Module):
         # (e.g. Scalar vs SR2) which the metadata records under `var_type`.
         with open(meta_path) as f:
             meta = json.load(f)
-        self.input_spec = self._spec_from_meta(meta["inputs"])
-        self.output_spec = self._spec_from_meta(meta["outputs"])
+        # Boundary renames (shallow): the metadata records each variable's
+        # ORIGINAL authored name plus an optional ``boundary_aliases`` map. The
+        # C++ binding's public surface (``input_names`` / ``forward`` / ...)
+        # already speaks the boundary names, so the shim keys its own
+        # ``input_spec`` / ``output_spec`` / per-input metadata by the boundary
+        # name too -- keeping ``raw_inputs`` / ``raw_outs`` aligned with what
+        # ``self._inner`` expects and returns. Absent => original names.
+        aliases = meta.get("boundary_aliases", {})
+        in_alias = aliases.get("inputs", {})
+        out_alias = aliases.get("outputs", {})
+        self.input_spec = self._spec_from_meta(meta["inputs"], in_alias)
+        self.output_spec = self._spec_from_meta(meta["outputs"], out_alias)
         # Per-input sub-batch shape (empty tuple when the input has none).
         # ``_broadcast_to_common_batch`` consults this to split each input's
         # batch axes into (dyn, sub) and broadcast only the dyn portion --
         # the sub-batch axis is part of the input's identity and must not
         # be flattened against a global (no-sub-batch) sibling.
         self.input_sub_batch: dict[str, tuple[int, ...]] = {
-            info["name"]: tuple(info.get("sub_batch_shape", ())) for info in meta["inputs"]
+            in_alias.get(info["name"], info["name"]): tuple(info.get("sub_batch_shape", ()))
+            for info in meta["inputs"]
         }
         # Per-input / per-output sub-batch labels (empty tuple when the
         # variable carries none). Persisted at export time via
@@ -183,18 +194,30 @@ class AOTIModel(nn.Module):
         # per-axis label dispatch (preserved-label storage, BLOCK-aware
         # matmul) survives the export-and-load round-trip.
         self.input_labels: dict[str, tuple[str, ...]] = {
-            info["name"]: tuple(info.get("sub_batch_labels", ())) for info in meta["inputs"]
+            in_alias.get(info["name"], info["name"]): tuple(info.get("sub_batch_labels", ()))
+            for info in meta["inputs"]
         }
         self.output_labels: dict[str, tuple[str, ...]] = {
-            info["name"]: tuple(info.get("sub_batch_labels", ())) for info in meta["outputs"]
+            out_alias.get(info["name"], info["name"]): tuple(info.get("sub_batch_labels", ()))
+            for info in meta["outputs"]
         }
 
     @staticmethod
-    def _spec_from_meta(infos: list[dict]) -> dict[str, type[TensorWrapper]]:
-        """Map each metadata ``var_type`` string to the TensorWrapper class."""
+    def _spec_from_meta(
+        infos: list[dict], alias: dict[str, str] | None = None
+    ) -> dict[str, type[TensorWrapper]]:
+        """Map each metadata ``var_type`` string to the TensorWrapper class.
+
+        *alias* is the boundary-rename sub-map for this namespace (``{original:
+        boundary}``); each entry's key is remapped to its boundary name so the
+        returned spec matches the C++ binding's renamed public surface. Empty /
+        ``None`` => original names.
+        """
+        alias = alias or {}
         spec: dict[str, type[TensorWrapper]] = {}
         for info in infos:
-            name = info["name"]
+            orig: str = info["name"]
+            name = alias[orig] if orig in alias else orig
             type_name = info["var_type"]
             type_cls = getattr(_types, type_name, None)
             if type_cls is None or not (

--- a/neml2/cli/_compile_interactive.py
+++ b/neml2/cli/_compile_interactive.py
@@ -59,6 +59,10 @@ class FormState:
     output_dir: str = "./aoti"
     promoted: tuple[str, ...] = ()
     derivatives: tuple[str, ...] = ()  # "OUT:IN" specs
+    # Shallow boundary renames, each a tuple of "ORIG:NEW" specs (model mode only).
+    rename_inputs: tuple[str, ...] = ()
+    rename_outputs: tuple[str, ...] = ()
+    rename_parameters: tuple[str, ...] = ()
     example_shape: tuple[str, ...] = ()  # raw --example-batch-shape entries
     dynamic_batch: bool | None = None  # None => emit neither flag
     load: tuple[str, ...] = ()  # --load extension modules
@@ -128,6 +132,15 @@ def build_compile_argv(state: FormState) -> list[str]:
 
     for spec in state.derivatives:
         argv += ["-d", spec]
+
+    # Shallow boundary renames (model mode only; the CLI rejects them with
+    # --driver). Emitted per namespace, matching the three CLI flags.
+    for spec in state.rename_inputs:
+        argv += ["--rename-input", spec]
+    for spec in state.rename_outputs:
+        argv += ["--rename-output", spec]
+    for spec in state.rename_parameters:
+        argv += ["--rename-parameter", spec]
 
     for spec in state.example_shape:
         argv += ["--example-batch-shape", spec]

--- a/neml2/cli/_compile_wizard.py
+++ b/neml2/cli/_compile_wizard.py
@@ -69,6 +69,7 @@ _FIELDS: list[tuple[str, str]] = [
     ("name", "Name"),
     ("promoted", "Parameters"),
     ("derivatives", "Derivatives"),
+    ("rename", "Renames"),
     ("devices", "Devices"),
     ("dtype", "dtype"),
     ("output_dir", "Output dir"),
@@ -92,6 +93,8 @@ _HELP: dict[str, str] = {
     "constants; space toggles, enter confirms.",
     "derivatives": "Also compile Jacobian/JVP graphs for chosen output:input pairs "
     "(needed for jvp()/jacobian() at runtime).",
+    "rename": "Rename input/output/parameter names at the compiled boundary for a "
+    "downstream consumer; the model internals keep the original names. Model target only.",
     "devices": "Target device(s), baked at export; one artifact is emitted per device.",
     "dtype": "Floating-point precision baked into the artifact.",
     "output_dir": "Directory for the .pt2 artifacts and the runnable HIT stub.",
@@ -171,12 +174,18 @@ def run_wizard(*, input_file: str, initial_load: tuple[str, ...] = ()) -> int:
             _ask_field("name", input_file, state, cache)
 
 
+def _empty_renames() -> dict[str, dict[str, str]]:
+    return {"inputs": {}, "outputs": {}, "parameters": {}}
+
+
 def _default_state() -> dict:
     return {
         "target": "model",
         "name": "",
         "promoted": (),
         "derivatives": (),
+        # {"inputs"|"outputs"|"parameters": {orig: new}} -- shallow boundary renames.
+        "rename": _empty_renames(),
         "devices": ("cpu",),
         "dtype": "float64",
         "output_dir": "./aoti",
@@ -251,6 +260,23 @@ def _ask_field(field: str, input_file: str, state: dict, cache: dict) -> bool:
         if specs is None:
             return False
         state["derivatives"] = tuple(specs)
+        return True
+
+    if field == "rename":
+        # Renaming is a model-target-only boundary feature (the driver stub keeps
+        # the original [Drivers] wiring). Skip cleanly in driver mode.
+        if state["target"] != "model":
+            state["rename"] = _empty_renames()
+            questionary.print(
+                "(renaming is only available with a model target, not a driver)",
+                style="italic",
+            )
+            return True
+        intro = _ensure_intro(input_file, state, cache)
+        renames = _ask_renames(intro, tuple(state["promoted"]), state.get("rename", {}))
+        if renames is None:
+            return False
+        state["rename"] = renames
         return True
 
     if field == "devices":
@@ -371,13 +397,16 @@ def _ask_example_shape(input_file: str, state: dict, cache: dict) -> bool:
 
 
 def _reset_model_dependent(state: dict) -> None:
-    """Drop parameter / derivative selections that belong to the previous model."""
-    if state["promoted"] or state["derivatives"]:
+    """Drop parameter / derivative / rename selections that belong to the previous model."""
+    renames = state.get("rename", {})
+    if state["promoted"] or state["derivatives"] or any(renames.values()):
         questionary.print(
-            "(cleared parameter / derivative selections for the new model)", style="italic"
+            "(cleared parameter / derivative / rename selections for the new model)",
+            style="italic",
         )
     state["promoted"] = ()
     state["derivatives"] = ()
+    state["rename"] = _empty_renames()
 
 
 def _ensure_intro(input_file: str, state: dict, cache: dict) -> IntrospectionForm | None:
@@ -399,6 +428,11 @@ def _ensure_intro(input_file: str, state: dict, cache: dict) -> IntrospectionFor
 
 
 def _form_state(input_file: str, state: dict, initial_load: tuple[str, ...]) -> FormState:
+    ren = state.get("rename", {})
+
+    def _specs(ns: str) -> tuple[str, ...]:
+        return tuple(f"{orig}:{new}" for orig, new in ren.get(ns, {}).items())
+
     return FormState(
         input_file=input_file,
         target=state["target"],
@@ -408,6 +442,9 @@ def _form_state(input_file: str, state: dict, initial_load: tuple[str, ...]) -> 
         output_dir=state["output_dir"],
         promoted=tuple(state["promoted"]),
         derivatives=tuple(state["derivatives"]),
+        rename_inputs=_specs("inputs"),
+        rename_outputs=_specs("outputs"),
+        rename_parameters=_specs("parameters"),
         example_shape=tuple(state["example_shape"]),
         dynamic_batch=state["dynamic_batch"],
         load=tuple(initial_load),
@@ -416,10 +453,20 @@ def _form_state(input_file: str, state: dict, initial_load: tuple[str, ...]) -> 
 
 def _print_review(fs: FormState) -> None:
     questionary.print("\nReview:", style="bold")
+    ren_bits = [
+        f"{prefix} {spec.replace(':', '->')}"
+        for prefix, specs in (
+            ("in", fs.rename_inputs),
+            ("out", fs.rename_outputs),
+            ("param", fs.rename_parameters),
+        )
+        for spec in specs
+    ]
     rows = [
         ("Target", f"{fs.target}: {fs.name or '(unset)'}"),
         ("Parameters", ", ".join(fs.promoted) or "(none)"),
         ("Derivatives", ", ".join(fs.derivatives) or "(none)"),
+        ("Renames", ", ".join(ren_bits) or "(none)"),
         ("Devices", ", ".join(fs.devices) or "(none)"),
         ("dtype", fs.dtype),
         ("Output dir", fs.output_dir),
@@ -516,6 +563,58 @@ def _ask_derivatives(
             new = _bulk_select_pairs(outputs, inputs, pairs)
             if new is not None:
                 pairs = list(dict.fromkeys([*pairs, *new]))
+
+
+def _ask_renames(
+    intro: IntrospectionForm | None,
+    promoted: tuple[str, ...],
+    current: dict[str, dict[str, str]],
+) -> dict[str, dict[str, str]] | None:
+    """Collect shallow boundary renames per namespace.
+
+    Returns ``{"inputs"|"outputs"|"parameters": {orig: new}}`` (empty sub-maps =
+    no renames) or ``None`` if the user cancelled. Gates on a single confirm, then
+    for each namespace lets the user check which names to rename (candidates come
+    from introspection: the model's inputs / outputs, and the currently-promoted
+    parameters) and type each new boundary name. An empty or unchanged new name
+    leaves that variable as-is.
+    """
+    if intro is None:
+        return dict(current)  # can't introspect -> leave the selection unchanged
+    namespaces = [
+        ("inputs", "inputs", list(intro.inputs)),
+        ("outputs", "outputs", list(intro.outputs)),
+        ("parameters", "promoted parameters", list(promoted)),
+    ]
+    has_any = any(current.get(ns) for ns, _, _ in namespaces)
+    want = questionary.confirm("Rename any boundary variables?", default=has_any).ask()
+    if want is None:
+        return None
+    if not want:
+        return _empty_renames()
+
+    result = _empty_renames()
+    for ns, label, candidates in namespaces:
+        cur: dict[str, str] = current.get(ns, {})
+        if not candidates:
+            continue
+        which = questionary.checkbox(
+            f"Rename which {label}? (leave unchecked to keep the original name)",
+            choices=[questionary.Choice(c, c, checked=(c in cur)) for c in candidates],
+        ).ask()
+        if which is None:
+            return None
+        mapping: dict[str, str] = {}
+        for name in which:
+            default_new = cur[name] if name in cur else name
+            new = questionary.text(f"  {name} -> ", default=default_new).ask()
+            if new is None:
+                return None
+            new = new.strip()
+            if new and new != name:
+                mapping[name] = new
+        result[ns] = mapping
+    return result
 
 
 def _bulk_select_pairs(

--- a/neml2/cli/aoti_compile.py
+++ b/neml2/cli/aoti_compile.py
@@ -193,6 +193,38 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "parameter has rank>=1 and would specialize the dynamic dim."
         ),
     )
+    parser.add_argument(
+        "--rename-input",
+        action="append",
+        default=[],
+        metavar="ORIG:NEW",
+        help=(
+            "Rename an input variable at the compiled artifact's boundary: a "
+            "downstream consumer sees NEW while the model's internal wiring keeps "
+            "ORIG. Repeatable. Only valid with --model (not --driver)."
+        ),
+    )
+    parser.add_argument(
+        "--rename-output",
+        action="append",
+        default=[],
+        metavar="ORIG:NEW",
+        help=(
+            "Rename an output variable at the boundary (the consumer sees NEW; "
+            "the internals keep ORIG). Repeatable. Only valid with --model."
+        ),
+    )
+    parser.add_argument(
+        "--rename-parameter",
+        action="append",
+        default=[],
+        metavar="ORIG:NEW",
+        help=(
+            "Rename a promoted parameter at the boundary (the consumer sees NEW; "
+            "the internals keep the qualified ORIG). ORIG must be a promoted "
+            "parameter (see -p). Repeatable. Only valid with --model."
+        ),
+    )
     add_load_argument(parser)
     return parser
 
@@ -209,6 +241,7 @@ def compile_and_emit_stub(
     example_batch_shape=None,
     dynamic_batch: bool | None = None,
     derivatives: tuple[str, ...] = (),
+    renames: dict[str, dict[str, str]] | None = None,
     pre: tuple[str, ...] = (),
     additional_args: tuple[str, ...] = (),
 ) -> Path:
@@ -230,6 +263,12 @@ def compile_and_emit_stub(
 
     if (driver is None) == (model is None):
         raise ValueError("compile_and_emit_stub: pass exactly one of `driver` or `model`")
+    if driver is not None and renames and any(renames.values()):
+        raise ValueError(
+            "compile_and_emit_stub: boundary renames are only supported with "
+            "`model` (not `driver`): the bundled [Drivers] block is wired to the "
+            "original names."
+        )
     model_name = driver_target_model(input_path, driver) if driver else model
     assert model_name is not None  # for type narrowing
 
@@ -246,6 +285,7 @@ def compile_and_emit_stub(
         example_batch_shape=example_batch_shape,
         dynamic_batch=dynamic_batch,
         derivatives=derivatives,
+        renames=renames,
         pre=pre,
         additional_args=additional_args,
     )
@@ -258,6 +298,36 @@ def compile_and_emit_stub(
         keep_drivers=(driver is not None),
     )
     return stub_path
+
+
+def _parse_rename_pairs(specs: list[str], flag: str) -> dict[str, str]:
+    """Parse ``ORIG:NEW`` rename tokens into an ``{orig: new}`` map.
+
+    Splits on the FIRST colon: variable names carry no colon and a qualified
+    promoted-parameter name (e.g. ``elasticity.E``) uses dots, so the first
+    colon is unambiguously the ORIG/NEW separator. Raises ``ValueError`` on a
+    malformed token (missing colon, empty side) or a duplicate ORIG.
+    """
+    out: dict[str, str] = {}
+    for spec in specs:
+        if ":" not in spec:
+            raise ValueError(f"{flag}: expected ORIG:NEW, got {spec!r} (missing ':').")
+        orig, new = (part.strip() for part in spec.split(":", 1))
+        if not orig or not new:
+            raise ValueError(f"{flag}: expected ORIG:NEW with both sides non-empty, got {spec!r}.")
+        if orig in out:
+            raise ValueError(f"{flag}: duplicate rename for {orig!r}.")
+        out[orig] = new
+    return out
+
+
+def _renames_from_args(args) -> dict[str, dict[str, str]]:
+    """Assemble the ``{inputs, outputs, parameters}`` rename map from parsed CLI args."""
+    return {
+        "inputs": _parse_rename_pairs(args.rename_input, "--rename-input"),
+        "outputs": _parse_rename_pairs(args.rename_output, "--rename-output"),
+        "parameters": _parse_rename_pairs(args.rename_parameter, "--rename-parameter"),
+    }
 
 
 def driver_target_model(original_hit: Path, driver_name: str) -> str:
@@ -546,6 +616,21 @@ def main(argv: list[str] | None = None) -> int:
     if (args.model is None) == (args.driver is None):
         parser.error("exactly one of --model / --driver is required (or use --interactive)")
 
+    # Boundary renames (shallow). Parse early, and reject in --driver mode: the
+    # driver stub bakes the original [Drivers] block (wired to the original
+    # names) into the runnable stub, which the renamed interface would break.
+    try:
+        renames = _renames_from_args(args)
+    except ValueError as exc:
+        parser.error(str(exc))
+    if args.driver is not None and any(renames.values()):
+        parser.error(
+            "--rename-input / --rename-output / --rename-parameter are only "
+            "supported with --model (not --driver): the bundled [Drivers] block "
+            "is wired to the original names. Compile with --model and pair the "
+            "renamed artifact with your own consumer."
+        )
+
     input_path: Path = args.input.resolve()
     if not input_path.exists():
         print(f"Error: input file not found: {input_path}", file=sys.stderr)
@@ -603,6 +688,7 @@ def main(argv: list[str] | None = None) -> int:
                 example_batch_shape=example_batch_shape,
                 dynamic_batch=args.dynamic_batch,
                 derivatives=tuple(args.derivative),
+                renames=renames,
                 additional_args=tuple(additional_args),
             )
         except Exception as exc:  # noqa: BLE001

--- a/neml2/cli/aoti_export.py
+++ b/neml2/cli/aoti_export.py
@@ -76,91 +76,15 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-#: Metadata schema version. Bumped at every breaking change so the C++ loader
-#: can refuse mismatched caches with a clear "wipe and re-export" message
-#: rather than failing on a missing field deep in the parser.
-#:
-#: v2: bake-by-default; promoted parameters listed under top-level
-#: ``parameters`` with per-segment ``param_inputs``. No ``buffers`` section.
-#: Adds top-level ``device`` + ``dtype`` keys.
-#:
-#: v3: implicit-segment Newton step graph split into a step-direction
-#: artifact (cheap A + solve, no residual recompute) plus a C++-side
-#: backtracking line search using the existing rhs graph; forward-segment
-#: per-input/output metadata collapsed to ``{"name": ...}``; and
-#: implicit-segment I/O moved from a single packed ``(*dyn, u_size)`` slab
-#: to per-variable tensors at their natural ``(*dyn, *sub_batch, *base)``
-#: shape (per-variable ``sub_batch_shape`` / ``sub_batch_labels`` /
-#: ``base_shape`` recorded so the C++ side can reshape per-variable slots).
-#:
-#: v4: solver convergence / line-search configuration is no longer
-#: baked into the metadata. The implicit-segment ``atol`` / ``rtol`` /
-#: ``miters`` / ``linesearch`` keys are gone -- the generated stub ``.i``
-#: carries a minimal ``[Solvers]`` block (the honored knobs only; the linear
-#: solver, which is baked into the step/IFT graphs, is omitted) and the
-#: ``AOTIModel`` shim forwards it to the C++ runtime at load time. The
-#: predictor is unchanged: it still lowers to its own ``_predictor.pt2``
-#: graph with ``predictor_package`` / ``predictor_inputs`` /
-#: ``predictor_outputs`` metadata.
-#:
-#: v5: per-group / per-cell metadata for implicit segments
-#: (``unknown_group_infos`` / ``given_group_infos`` / ``residual_group_infos``
-#: / ``ift_cells``) so the C++ Newton loop + IFT composition runs per group.
-#:
-#: v6: derivative graphs are opt-in. A new top-level ``derivatives``
-#: array lists the master ``[out, in]`` pairs the artifact supports (empty =>
-#: none; ``jvp`` / ``jacobian`` raise). A forward segment's ``jvp_package`` /
-#: ``jacobian_pairs`` and an implicit segment's ``ift_package`` are present
-#: only when some requested pair needs them, and each ``jacobian_pairs`` entry
-#: gains a ``batch_independent`` flag (the block does not depend on the dynamic
-#: batch, e.g. a constant elasticity tensor, so the runtime may carry / return
-#: it unbatched).
-#:
-#: v7: parameter derivatives ``d(out)/d(param)`` are opt-in, separate
-#: from the input-variable derivatives. A new top-level ``parameter_derivatives``
-#: array lists the master ``[out, param_qname]`` pairs (param on a promoted
-#: parameter); when some pair is requested a forward segment gains two graphs,
-#: both computed by reverse-mode autograd (the only AD that lowers through
-#: AOTInductor):
-#:   * ``param_jacobian_package`` + ``param_jacobian_pairs`` -- the dense
-#:     ``d(out)/d(param)`` blocks. This graph takes the promoted parameter(s) as
-#:     PER-BATCH inputs (``(*dyn, *param_base)``); the C++ runtime broadcasts the
-#:     stored scalar parameter to the runtime batch before calling it.
-#:   * ``param_vjp_package`` + ``param_vjp_params`` + ``param_vjp_outputs`` -- the
-#:     adjoint ``dL/d(param)`` for ``L = sum_o <cotangent_o, out_o>`` (the cheaper
-#:     form for many-parameter optimization). Its inputs are the model inputs
-#:     (parameters stay scalar here) followed by one cotangent per output (in
-#:     ``param_vjp_outputs`` order); its outputs are the parameter gradients (in
-#:     ``param_vjp_params`` order).
-#: The value / input-jvp graphs are unchanged (parameters stay scalar there).
-#:
-#: v8: parameter derivatives for a single ``ImplicitUpdate`` segment.
-#: A promoted parameter living INSIDE the implicit residual is threaded as a
-#: positional tail through the segment's rhs / step / ift graphs (the same
-#: ``param_inputs`` list already carried for forward segments; the stored scalar
-#: is bound constant across the solve and the input-Jacobian). When some
-#: ``parameter_derivatives`` pair targets such a parameter the implicit segment
-#: gains a ``param_ift_package`` + ``param_jacobian_pairs`` graph
-#: (:class:`~neml2.es.implicit.ParamIFT`) emitting the per-(unknown, param)
-#: blocks of ``du/dθ = -A⁻¹ ∂r/∂θ`` -- ``A`` from the analytic chain rule,
-#: ``∂r/∂θ`` from reverse-mode autograd. Like the forward dense
-#: parameter-Jacobian graph it takes the promoted parameter PER-BATCH; the C++
-#: runtime broadcasts the stored scalar to the runtime batch before the call.
-#: Multi-segment (composed) parameter Jacobians remain a follow-up.
-#:
-#: v9 (current): batched parameters. A promoted parameter may carry its own batch
-#: dim (e.g. a per-batch-element Scalar set via ``set_parameter``). The forward /
-#: input-jvp / input-jacobian VALUE graphs now take each promoted parameter as a
-#: PER-BATCH input ``(*dyn, *param_base)`` with the batch dim marked dynamic (was a
-#: scalar baked at its natural shape), so a batched parameter flows through; the C++
-#: runtime broadcasts a stored scalar parameter up to the call batch before calling.
-#: Each ``parameters[]`` entry gains ``param_base_shape`` (the NATURAL base from the
-#: typed class) so the runtime can split a stored ``(*pbatch, *base)`` parameter into
-#: batch vs base. ``param_jacobian`` parameter blocks now record the natural base
-#: too. Batched ``param_vjp`` (per-element, un-summed) and batched parameters inside
-#: an implicit segment's value path remain follow-ups.
+#: Metadata schema version -- the wire-format handshake between the exporter and
+#: the C++/Python loaders. Bumped on every breaking layout change so a loader
+#: refuses a mismatched cache with a clear "regenerate via ``neml2-compile``"
+#: message rather than failing on a missing field deep in the parser. The
+#: canonical value lives in ``scripts/dependencies.yaml``; bump it there with
+#: ``scripts/dep_manager.py`` (which keeps this literal, the C++ loader, and the
+#: docs in sync).
 # dependencies: aoti.schema_version
-AOTI_META_SCHEMA_VERSION = 7
+AOTI_META_SCHEMA_VERSION = 8
 
 
 def _var_size(type_cls) -> int:
@@ -846,6 +770,67 @@ def _snapshot_promoted(model: nn.Module, names: list[str]) -> dict[str, torch.Te
     buffers = dict(model.named_buffers(recurse=True))
     available = {**params, **buffers}
     return {n: available[n].detach() for n in names}
+
+
+def _validate_renames(
+    renames: dict[str, dict[str, str]] | None,
+    *,
+    input_names: list[str],
+    output_names: list[str],
+    param_names: list[str],
+) -> dict[str, dict[str, str]]:
+    """Validate + normalize the boundary-rename maps for the exported artifact.
+
+    *renames* maps each of ``"inputs"`` / ``"outputs"`` / ``"parameters"`` to an
+    ``{original_name: boundary_name}`` sub-map (any namespace omitted => no
+    renames there). Renaming is *shallow*: only the names a downstream consumer
+    sees at the artifact boundary change; the compiled graphs and every internal
+    wiring keep the original authored names.
+
+    Each original name must exist in its namespace -- the structural input
+    names, the output names, or the promoted-parameter qualified names -- and the
+    resulting boundary names must stay unique within the namespace (a new name
+    may not collide with another new name or with an unrenamed sibling).
+    Identity entries (boundary == original) are dropped. Raises ``ValueError``
+    with a clear listing on any violation.
+
+    Returns a normalized ``{"inputs": {...}, "outputs": {...}, "parameters":
+    {...}}`` carrying only the non-identity renames.
+    """
+    allowed = {
+        "inputs": list(input_names),
+        "outputs": list(output_names),
+        "parameters": list(param_names),
+    }
+    out: dict[str, dict[str, str]] = {"inputs": {}, "outputs": {}, "parameters": {}}
+    if not renames:
+        return out
+
+    unknown_ns = sorted(set(renames) - set(allowed))
+    if unknown_ns:
+        raise ValueError(
+            f"Unknown rename namespace(s) {unknown_ns}; expected a subset of {sorted(allowed)}."
+        )
+
+    for ns, names in allowed.items():
+        mapping = renames.get(ns) or {}
+        singular = ns[:-1]  # "inputs" -> "input"
+        missing = sorted(set(mapping) - set(names))
+        if missing:
+            avail = ", ".join(names) or "<none>"
+            raise ValueError(
+                f"Renamed {singular} name(s) not found in model: {missing}. Available: {avail}."
+            )
+        clean = {o: n for o, n in mapping.items() if o != n}
+        final = [clean.get(name, name) for name in names]
+        dupes = sorted({n for n in final if final.count(n) > 1})
+        if dupes:
+            raise ValueError(
+                f"Renaming the model's {ns} would produce duplicate boundary name(s): {dupes} "
+                f"(a boundary name must be unique among the {ns}, including unrenamed ones)."
+            )
+        out[ns] = clean
+    return out
 
 
 def _promote_parameters(
@@ -2779,6 +2764,7 @@ def export_model_for_aoti(
     example_batch_shape: dict[str, str] | str | None = None,
     dynamic_batch: bool | None = None,
     derivatives: Sequence[str] = (),
+    renames: dict[str, dict[str, str]] | None = None,
     pre: Sequence[str] = (),
     additional_args: tuple[str, ...] = (),
 ) -> dict:
@@ -2833,6 +2819,16 @@ def export_model_for_aoti(
         runtime ``jvp`` / ``jacobian`` raise until recompiled with ``-d``.
         Resolved against the model's outputs + structural inputs after
         promotion (see :func:`_resolve_derivative_specs`).
+    renames:
+        Optional shallow boundary renames (the ``--rename-input`` /
+        ``--rename-output`` / ``--rename-parameter`` CLI surface). A dict with
+        any of ``"inputs"`` / ``"outputs"`` / ``"parameters"`` keys, each an
+        ``{original_name: boundary_name}`` sub-map. Only the names reported at
+        the compiled artifact's interface change; the graphs and every internal
+        wiring keep the original authored names. Validated against the
+        post-promotion boundary namespaces (see :func:`_validate_renames`) and
+        recorded under ``boundary_aliases`` in the metadata. ``None`` (default)
+        keeps the original names.
     pre:
         HIT snippets prepended before parsing (same semantics as
         ``nmhit.parse_file``'s ``pre`` arg). Use to bind ``${var}``
@@ -2923,6 +2919,18 @@ def export_model_for_aoti(
         derivatives,
         list(model.output_spec),
         structural_input_names,
+        param_names=sorted(promoted_qnames),
+    )
+
+    # Validate + normalize boundary renames against the post-promotion boundary
+    # namespaces (structural inputs, outputs, promoted parameters). Fails fast
+    # here -- before the expensive graph compile -- on an unknown or colliding
+    # name. Shallow: only the interface names change; the graphs keep the
+    # original authored names.
+    boundary_aliases = _validate_renames(
+        renames,
+        input_names=structural_input_names,
+        output_names=list(model.output_spec),
         param_names=sorted(promoted_qnames),
     )
 
@@ -3021,6 +3029,13 @@ def export_model_for_aoti(
     meta["parameter_derivatives"] = [
         [o, p] for (o, p) in sorted(param_pairs, key=lambda x: (out_order.get(x[0], 0), x[1]))
     ]
+    # Boundary renames (shallow): remap only the names reported at the artifact's
+    # interface. Absent => the interface uses the original authored names. Only
+    # namespaces with an actual rename are written, so a fully-baked artifact is
+    # unchanged.
+    active_aliases = {ns: m for ns, m in boundary_aliases.items() if m}
+    if active_aliases:
+        meta["boundary_aliases"] = active_aliases
 
     _write_meta(output_dir / f"{model_name}_meta.json", meta)
     return meta

--- a/neml2/csrc/aoti/Model.cpp
+++ b/neml2/csrc/aoti/Model.cpp
@@ -80,6 +80,37 @@ parse_dtype(const std::string & s)
   _assert(false, "aoti::Model: unsupported dtype '", s, "' in metadata.");
   return at::kDouble;
 }
+
+// Boundary-rename helpers (used only when the artifact carries `boundary_aliases`).
+// Re-key a name->tensor map through a translation map; a key absent from `tr`
+// passes through unchanged (identity). Small maps, called once per public op.
+std::map<std::string, at::Tensor>
+rekey(const std::map<std::string, at::Tensor> & in, const std::map<std::string, std::string> & tr)
+{
+  std::map<std::string, at::Tensor> out;
+  for (const auto & [k, v] : in)
+  {
+    auto it = tr.find(k);
+    out.emplace(it == tr.end() ? k : it->second, v);
+  }
+  return out;
+}
+
+// Re-key a nested output->(input->tensor) Jacobian through an outer + inner
+// translation (either may be empty => identity on that axis).
+VariablePairJacobian
+rekey_nested(const VariablePairJacobian & in,
+             const std::map<std::string, std::string> & outer_tr,
+             const std::map<std::string, std::string> & inner_tr)
+{
+  VariablePairJacobian out;
+  for (const auto & [o, inner] : in)
+  {
+    auto oit = outer_tr.find(o);
+    out.emplace(oit == outer_tr.end() ? o : oit->second, rekey(inner, inner_tr));
+  }
+  return out;
+}
 } // namespace
 
 Model::Impl::Impl(const std::filesystem::path & meta_path,
@@ -97,17 +128,12 @@ Model::Impl::Impl(const std::filesystem::path & meta_path,
           "'. Path must point at the _meta.json written by `neml2-compile`.");
   const auto meta = nlohmann::json::parse(meta_f);
 
-  // Schema-version handshake. v5 makes the runtime variable-native: the master
-  // `inputs`/`outputs` metadata records each variable's full `base_shape`, so
-  // the C++ side reports input_base_shapes()/output_base_shapes(), validates
-  // canonical (*B, *base) inputs, and returns unflattened jvp (*B, *out_base)
-  // and variable-pair jacobian blocks (*B, *out_base, *in_base). (v5 also keeps
-  // the per-segment per-variable sub_batch_shape / base_shape used to pack the
-  // segment loaders' positional inputs and sum convergence norms.) Older caches
-  // lack the master base_shape; we fail loudly instead of misinterpreting them.
-  // dependencies: aoti.schema_version (NOT auto-managed -- C++ `//` comments are
-  // not scanned by scripts/dep_manager.py; keep this literal in sync by hand).
-  static constexpr int kSupportedSchemaVersion = 7;
+  // Wire-format handshake: the loader refuses any metadata whose schema_version
+  // differs, so a stale cache fails with a clear "regenerate" message instead of
+  // a cryptic missing-field error deep in the parser. The canonical value lives
+  // in scripts/dependencies.yaml; this literal is kept in sync by dep_manager.py.
+  // dependencies: aoti.schema_version
+  static constexpr int kSupportedSchemaVersion = 8;
   const auto schema_version = meta.value("schema_version", 0);
   _assert(schema_version == kSupportedSchemaVersion,
           "aoti::Model: metadata schema_version=",
@@ -156,6 +182,36 @@ Model::Impl::Impl(const std::filesystem::path & meta_path,
   // file itself.
   const auto cache_dir = meta_path.parent_path();
 
+  // Boundary renames (shallow, optional). Only the names reported at the public
+  // surface change; every internal structure keeps the ORIGINAL authored names.
+  // Load the per-namespace forward / reverse maps now so the parameter loop can
+  // store `_named_parameters` boundary-keyed and the ext views can be built
+  // below. Absent => `_has_aliases` stays false and the runtime behaves exactly
+  // as an unrenamed artifact.
+  if (meta.contains("boundary_aliases"))
+  {
+    const auto & ba = meta["boundary_aliases"];
+    auto load_pair_maps = [&ba](const char * key,
+                                std::map<std::string, std::string> & o2e,
+                                std::map<std::string, std::string> & e2o)
+    {
+      if (!ba.contains(key))
+        return;
+      for (auto it = ba[key].begin(); it != ba[key].end(); ++it)
+      {
+        const auto ext = it.value().get<std::string>();
+        o2e[it.key()] = ext;
+        e2o[ext] = it.key();
+      }
+    };
+    load_pair_maps("inputs", _in_orig2ext, _in_ext2orig);
+    load_pair_maps("outputs", _out_orig2ext, _out_ext2orig);
+    if (ba.contains("parameters"))
+      for (auto it = ba["parameters"].begin(); it != ba["parameters"].end(); ++it)
+        _param_orig2ext[it.key()] = it.value().get<std::string>();
+  }
+  _has_aliases = !(_in_orig2ext.empty() && _out_orig2ext.empty() && _param_orig2ext.empty());
+
   // Master inputs / outputs.
   _input_names.reserve(meta["inputs"].size());
   _input_base_shapes.reserve(meta["inputs"].size());
@@ -182,6 +238,26 @@ Model::Impl::Impl(const std::filesystem::path & meta_path,
     _output_names.push_back(v["name"].get<std::string>());
     _output_base_shapes.push_back(v["base_shape"].get<std::vector<int64_t>>());
     _output_sizes.push_back(v["var_size"].get<int>());
+  }
+
+  // Pre-build the boundary (renamed) name vectors the public accessors return
+  // (identity for any variable without a rename). Only when some rename is
+  // active -- the unrenamed common case leaves these empty and the accessors
+  // return the original vectors.
+  if (_has_aliases)
+  {
+    _ext_input_names.reserve(_input_names.size());
+    for (const auto & n : _input_names)
+    {
+      auto it = _in_orig2ext.find(n);
+      _ext_input_names.push_back(it == _in_orig2ext.end() ? n : it->second);
+    }
+    _ext_output_names.reserve(_output_names.size());
+    for (const auto & n : _output_names)
+    {
+      auto it = _out_orig2ext.find(n);
+      _ext_output_names.push_back(it == _out_orig2ext.end() ? n : it->second);
+    }
   }
 
   // Master (out, in) derivative pairs the artifact supports (v6+). Absent /
@@ -273,8 +349,19 @@ Model::Impl::Impl(const std::filesystem::path & meta_path,
                 "' uses the values_in spill format which is not yet "
                 "supported on the C++ side. Re-export with smaller tensors.");
       }
-      _named_parameters.emplace(name, t.contiguous());
+      // `_named_parameters` is keyed by BOUNDARY name (identity when unaliased):
+      // it is the mutable public surface AND the map the dispatcher slot-assigns
+      // into for multi-device sync, and `_resolve_param` reads it back through
+      // the same boundary key, so all mutation paths stay coherent. The natural
+      // base shape stays keyed by the ORIGINAL name (every internal reader uses
+      // original names); the boundary-keyed view is built below.
+      _named_parameters.emplace(_param_boundary_name(name), t.contiguous());
     }
+    // Boundary-keyed view of the natural base shapes for the public accessor
+    // (`parameter_base_shapes()`), so it lines up with `named_parameters()`.
+    if (_has_aliases)
+      for (const auto & [orig, base] : _param_base_shapes)
+        _ext_param_base_shapes[_param_boundary_name(orig)] = base;
   }
 
   // Narrowed parameter-column layout for the multi-segment parameter-Jacobian
@@ -286,7 +373,9 @@ Model::Impl::Impl(const std::filesystem::path & meta_path,
   {
     if (_req_param_offset.count(p))
       continue; // already laid out (a param may pair with several outputs)
-    auto pit = _named_parameters.find(p);
+    // `p` is the ORIGINAL param name (from `_param_derivatives`); look it up in
+    // the boundary-keyed `_named_parameters` via its boundary name.
+    auto pit = _named_parameters.find(_param_boundary_name(p));
     _assert(pit != _named_parameters.end(),
             "aoti::Model: parameter-derivative references promoted parameter '",
             p,
@@ -512,13 +601,17 @@ Model::Impl::Impl(const std::filesystem::path & meta_path,
 const at::Tensor &
 Model::Impl::_resolve_param(const std::string & name) const
 {
+  // `name` is the ORIGINAL segment/metadata name; `_named_parameters` and the
+  // per-call `_param_overrides` are keyed by BOUNDARY name (identity when the
+  // parameter is unaliased), so map it through first.
+  const std::string & key = _param_boundary_name(name);
   if (_param_overrides != nullptr)
   {
-    auto oit = _param_overrides->find(name);
+    auto oit = _param_overrides->find(key);
     if (oit != _param_overrides->end())
       return oit->second;
   }
-  auto it = _named_parameters.find(name);
+  auto it = _named_parameters.find(key);
   _assert(it != _named_parameters.end(),
           "aoti::Model: segment references promoted parameter '",
           name,
@@ -572,16 +665,30 @@ Model::output_base_shapes() const noexcept
   return _impl->output_base_shapes();
 }
 
-// The three ops run through `_guarded` so every exception leaving the public
-// surface is a neml2 Exception with a meaningful `recoverable()`: a recoverable
+// The ops run through `_guarded` so every exception leaving the public surface
+// is a neml2 Exception with a meaningful `recoverable()`: a recoverable
 // ConvergenceError from the Newton solve passes through, while a foreign torch
 // error (e.g. a shape / device mismatch raised inside a compiled graph) is
 // normalized to a non-recoverable FatalError.
+//
+// When the artifact carries boundary renames (`_has_aliases`) each op re-keys at
+// the interface: incoming input / tangent dicts BOUNDARY->original, cotangents
+// BOUNDARY->original (keyed by output name), and results original->BOUNDARY.
+// `param_overrides` passes through unchanged -- it is keyed by boundary name and
+// `_resolve_param` maps each original segment name to its boundary key. The
+// unrenamed common case takes the no-copy fast path.
 std::map<std::string, at::Tensor>
 Model::forward(const std::map<std::string, at::Tensor> & inputs,
                const std::map<std::string, at::Tensor> & param_overrides) const
 {
-  return _guarded([&] { return _impl->forward(inputs, param_overrides); });
+  return _guarded(
+      [&]() -> std::map<std::string, at::Tensor>
+      {
+        if (!_impl->_has_aliases)
+          return _impl->forward(inputs, param_overrides);
+        auto out = _impl->forward(rekey(inputs, _impl->_in_ext2orig), param_overrides);
+        return rekey(out, _impl->_out_orig2ext);
+      });
 }
 
 std::pair<std::map<std::string, at::Tensor>, std::map<std::string, at::Tensor>>
@@ -589,21 +696,51 @@ Model::jvp(const std::map<std::string, at::Tensor> & inputs,
            const std::map<std::string, at::Tensor> & tangents,
            const std::map<std::string, at::Tensor> & param_overrides) const
 {
-  return _guarded([&] { return _impl->jvp(inputs, tangents, param_overrides); });
+  using Ret = std::pair<std::map<std::string, at::Tensor>, std::map<std::string, at::Tensor>>;
+  return _guarded(
+      [&]() -> Ret
+      {
+        if (!_impl->_has_aliases)
+          return _impl->jvp(inputs, tangents, param_overrides);
+        auto [out, jout] = _impl->jvp(rekey(inputs, _impl->_in_ext2orig),
+                                      rekey(tangents, _impl->_in_ext2orig),
+                                      param_overrides);
+        return {rekey(out, _impl->_out_orig2ext), rekey(jout, _impl->_out_orig2ext)};
+      });
 }
 
 std::pair<std::map<std::string, at::Tensor>, VariablePairJacobian>
 Model::jacobian(const std::map<std::string, at::Tensor> & inputs,
                 const std::map<std::string, at::Tensor> & param_overrides) const
 {
-  return _guarded([&] { return _impl->jacobian(inputs, param_overrides); });
+  using Ret = std::pair<std::map<std::string, at::Tensor>, VariablePairJacobian>;
+  return _guarded(
+      [&]() -> Ret
+      {
+        if (!_impl->_has_aliases)
+          return _impl->jacobian(inputs, param_overrides);
+        auto [out, jac] = _impl->jacobian(rekey(inputs, _impl->_in_ext2orig), param_overrides);
+        return {rekey(out, _impl->_out_orig2ext),
+                rekey_nested(jac, _impl->_out_orig2ext, _impl->_in_orig2ext)};
+      });
 }
 
 std::pair<std::map<std::string, at::Tensor>, VariablePairJacobian>
 Model::param_jacobian(const std::map<std::string, at::Tensor> & inputs,
                       const std::map<std::string, at::Tensor> & param_overrides) const
 {
-  return _guarded([&] { return _impl->param_jacobian(inputs, param_overrides); });
+  using Ret = std::pair<std::map<std::string, at::Tensor>, VariablePairJacobian>;
+  return _guarded(
+      [&]() -> Ret
+      {
+        if (!_impl->_has_aliases)
+          return _impl->param_jacobian(inputs, param_overrides);
+        auto [out, pjac] =
+            _impl->param_jacobian(rekey(inputs, _impl->_in_ext2orig), param_overrides);
+        // Inner keys are promoted-parameter names -> boundary via _param_orig2ext.
+        return {rekey(out, _impl->_out_orig2ext),
+                rekey_nested(pjac, _impl->_out_orig2ext, _impl->_param_orig2ext)};
+      });
 }
 
 std::map<std::string, at::Tensor>
@@ -611,7 +748,18 @@ Model::param_vjp(const std::map<std::string, at::Tensor> & inputs,
                  const std::map<std::string, at::Tensor> & cotangents,
                  const std::map<std::string, at::Tensor> & param_overrides) const
 {
-  return _guarded([&] { return _impl->param_vjp(inputs, cotangents, param_overrides); });
+  return _guarded(
+      [&]() -> std::map<std::string, at::Tensor>
+      {
+        if (!_impl->_has_aliases)
+          return _impl->param_vjp(inputs, cotangents, param_overrides);
+        // cotangents are keyed by OUTPUT name (BOUNDARY->original); the result is
+        // keyed by promoted-parameter name (original->BOUNDARY).
+        auto grads = _impl->param_vjp(rekey(inputs, _impl->_in_ext2orig),
+                                      rekey(cotangents, _impl->_out_ext2orig),
+                                      param_overrides);
+        return rekey(grads, _impl->_param_orig2ext);
+      });
 }
 
 std::map<std::string, at::Tensor> &

--- a/neml2/csrc/aoti/internal.h
+++ b/neml2/csrc/aoti/internal.h
@@ -104,8 +104,22 @@ struct Model::Impl
             const std::map<std::string, at::Tensor> & param_overrides = {}) const;
 
   // --- Accessors (forwarded from Model) ------------------------------------
-  const std::vector<std::string> & input_names() const noexcept { return _input_names; }
-  const std::vector<std::string> & output_names() const noexcept { return _output_names; }
+  //
+  // Boundary renames (shallow): with an active alias map the public surface
+  // reports the RENAMED (boundary) names, while every internal structure below
+  // keeps the ORIGINAL authored names. `input_names` / `output_names` /
+  // `parameter_base_shapes` therefore return the pre-built ext views when
+  // `_has_aliases`; `named_parameters` is itself stored boundary-keyed (see
+  // `_named_parameters`), so it needs no view. Base-shape vectors are positional
+  // (aligned with the name vectors) so they are returned as-is either way.
+  const std::vector<std::string> & input_names() const noexcept
+  {
+    return _has_aliases ? _ext_input_names : _input_names;
+  }
+  const std::vector<std::string> & output_names() const noexcept
+  {
+    return _has_aliases ? _ext_output_names : _output_names;
+  }
   const std::vector<std::vector<int64_t>> & input_base_shapes() const noexcept
   {
     return _input_base_shapes;
@@ -121,10 +135,22 @@ struct Model::Impl
   }
   /// Natural base shape per promoted parameter (Scalar => {}, SR2 => {6}). The
   /// dispatcher needs this to tell a batched stored parameter `(*pbatch, *base)`
-  /// from an unbatched one when slicing per chunk.
+  /// from an unbatched one when slicing per chunk. Boundary-keyed on the public
+  /// surface (via the ext view) so it lines up with `named_parameters()`.
   const std::map<std::string, std::vector<int64_t>> & parameter_base_shapes() const noexcept
   {
-    return _param_base_shapes;
+    return _has_aliases ? _ext_param_base_shapes : _param_base_shapes;
+  }
+
+  /// The boundary (renamed) name for an ORIGINAL promoted-parameter name --
+  /// identity when the parameter is unaliased. `_named_parameters` and the
+  /// per-call `_param_overrides` are stored/keyed by boundary name, so every
+  /// internal read (all through `_resolve_param`, plus the ctor's existence
+  /// check) maps its original segment/metadata name through this first.
+  const std::string & _param_boundary_name(const std::string & orig) const noexcept
+  {
+    auto it = _param_orig2ext.find(orig);
+    return it == _param_orig2ext.end() ? orig : it->second;
   }
   at::Device device() const noexcept { return _device; }
   at::ScalarType dtype() const noexcept { return _dtype; }
@@ -562,8 +588,27 @@ struct Model::Impl
   // (Scalar => {}, SR2 => {6}). Used to split a (possibly batched) stored
   // parameter `(*pbatch, *base)` into batch vs base -- for broadcasting it to the
   // call batch and for reshaping parameter-derivative blocks. Distinct from the
-  // stored tensor's full shape, which carries any batch dim.
+  // stored tensor's full shape, which carries any batch dim. Keyed by ORIGINAL
+  // name (every internal reader uses original names); the boundary-keyed view is
+  // `_ext_param_base_shapes`.
   std::map<std::string, std::vector<int64_t>> _param_base_shapes;
+
+  // --- Boundary renames (shallow) ------------------------------------------
+  // Optional `boundary_aliases` from the metadata. Only the names reported at
+  // the public surface change; every internal structure above keeps the ORIGINAL
+  // authored names. `_*_orig2ext` / `_*_ext2orig` are the per-namespace forward /
+  // reverse maps (present only for renamed entries); `_ext_*` are the pre-built
+  // boundary views the public accessors return. `_named_parameters` and the
+  // per-call `_param_overrides` are themselves stored boundary-keyed, so params
+  // need only the forward map (`_param_orig2ext`, consulted by
+  // `_param_boundary_name`). `_has_aliases` gates the facade's key translation so
+  // the fully-baked / unrenamed common case pays nothing.
+  bool _has_aliases = false;
+  std::map<std::string, std::string> _in_orig2ext, _in_ext2orig;
+  std::map<std::string, std::string> _out_orig2ext, _out_ext2orig;
+  std::map<std::string, std::string> _param_orig2ext;
+  std::vector<std::string> _ext_input_names, _ext_output_names;
+  std::map<std::string, std::vector<int64_t>> _ext_param_base_shapes;
 
   // Device + dtype baked into the artifact at export time.
   at::Device _device = at::kCPU;

--- a/scripts/dep_manager.py
+++ b/scripts/dep_manager.py
@@ -81,10 +81,13 @@ def _value_fields(dep_data: dict) -> dict:
 
 
 def _is_annotation_line(line: str) -> bool:
-    """True if the line is any `# dependencies: ...` / HTML-comment annotation."""
+    """True if the line is any `# dependencies: ...` / `// dependencies: ...` /
+    HTML-comment annotation."""
     stripped = line.strip()
-    return stripped.startswith("# dependencies:") or (
-        stripped.startswith("<!-- dependencies:") and stripped.endswith("-->")
+    return (
+        stripped.startswith("# dependencies:")
+        or stripped.startswith("// dependencies:")
+        or (stripped.startswith("<!-- dependencies:") and stripped.endswith("-->"))
     )
 
 
@@ -100,6 +103,7 @@ def _find_annotated_lines(filepath: Path, annotation_key: str) -> list[tuple[int
     lines = filepath.read_text().splitlines()
     markers = {
         f"# dependencies: {annotation_key}",
+        f"// dependencies: {annotation_key}",
         f"<!-- dependencies: {annotation_key} -->",
     }
     results = []

--- a/scripts/dependencies.yaml
+++ b/scripts/dependencies.yaml
@@ -105,7 +105,7 @@ neml2:
 # ``doc/content/tutorials/models/compiled_models/`` are regenerated at
 # tutorial-rebuild time and so are not tracked here.
 aoti:
-  schema_version: "7"
+  schema_version: "8"
   files:
     - neml2/cli/aoti_export.py
     - neml2/csrc/aoti/Model.cpp

--- a/tests/aoti/test_rename.py
+++ b/tests/aoti/test_rename.py
@@ -32,6 +32,12 @@ rename is a pure relabel: with an active ``boundary_aliases`` map the reported
 key use the RENAMED boundary names, while the values are byte-for-byte identical
 to an unrenamed compile of the same model. The internal wiring keeps the original
 authored names -- verified indirectly by the numerical parity.
+
+Input / output / promoted-parameter *name* renaming (forward, jvp, jacobian,
+named_parameters, set_parameter) runs on every torch. The parameter-*derivative*
+blocks (param_jacobian / param_vjp) additionally need reverse-mode AD to lower
+through AOTInductor (torch >= 2.11), so that case is skipped on the exact
+predicate the exporter guards on.
 """
 
 from __future__ import annotations
@@ -42,20 +48,24 @@ import pytest
 import torch
 
 import neml2  # noqa: F401 — registers models
+from neml2.cli.aoti_export import _reverse_ad_aoti_unsupported_reason
 
 _TESTS_ROOT = Path(__file__).resolve().parents[1]
 # Forward model: structural input `x` (Scalar) -> output `out` (Scalar), with a
 # promotable Scalar parameter `ys.C`. Small + fast to compile.
 _MODEL_I = _TESTS_ROOT / "aoti/forward_exp_param/model.i"
 
-# Structural + parameter derivatives, in ORIGINAL names (rename is applied at the
-# boundary only; derivative specs resolve against the authored names).
-_DERIV = [":", "out:ys.C"]
 _RENAMES = {
     "inputs": {"x": "strain"},
     "outputs": {"out": "stress"},
     "parameters": {"ys.C": "Cbar"},
 }
+
+_PARAM_DERIV_UNSUPPORTED = _reverse_ad_aoti_unsupported_reason()
+_REQUIRES_PARAM_DERIV_TORCH = pytest.mark.skipif(
+    _PARAM_DERIV_UNSUPPORTED is not None,
+    reason=f"reverse-mode AD AOTI compilation {_PARAM_DERIV_UNSUPPORTED}",
+)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -66,24 +76,26 @@ def _f64():
     torch.set_default_dtype(prev)
 
 
-def _compile(tmp_path: Path, sub: str, *, renames=None):
+def _compile(tmp_path: Path, sub: str, *, derivatives, renames=None):
     from neml2.aoti import AOTIModel
     from neml2.cli.aoti_export import export_model_for_aoti
 
     out = tmp_path / sub
     meta = export_model_for_aoti(
-        _MODEL_I, "model", out, promoted={"ys.C"}, derivatives=_DERIV, renames=renames
+        _MODEL_I, "model", out, promoted={"ys.C"}, derivatives=derivatives, renames=renames
     )
     return AOTIModel(str(out / "model_meta.json")), meta
 
 
-def test_rename_round_trip_matches_plain_compile(tmp_path):
-    """A renamed artifact reports boundary names on every surface and is
-    numerically identical to an unrenamed compile of the same model."""
-    plain, plain_meta = _compile(tmp_path, "plain")
-    ren, ren_meta = _compile(tmp_path, "ren", renames=_RENAMES)
+def test_rename_names_and_value_derivatives_match_plain(tmp_path):
+    """A renamed artifact reports boundary names on every surface and its
+    forward / jvp / jacobian / promoted-parameter values are identical to an
+    unrenamed compile. Structural derivatives only, so this runs on every torch."""
+    deriv = [":"]  # all structural (out, in) pairs; no parameter derivatives
+    plain, plain_meta = _compile(tmp_path, "plain", derivatives=deriv)
+    ren, ren_meta = _compile(tmp_path, "ren", derivatives=deriv, renames=_RENAMES)
 
-    # Reported names are the boundary names.
+    # Reported names are the boundary names (inputs, outputs, AND promoted params).
     assert list(ren.input_spec) == ["strain"]
     assert list(ren.output_spec) == ["stress"]
     assert list(ren.named_parameters()) == ["Cbar"]
@@ -114,6 +126,26 @@ def test_rename_round_trip_matches_plain_compile(tmp_path):
     assert list(jr) == ["stress"]
     assert torch.allclose(jp["out"], jr["stress"])
 
+    # set_parameter by the boundary name flows into the value graph identically to
+    # the authored-name path (promotion needs no reverse-mode AD).
+    plain.set_parameter("ys.C", torch.tensor(0.25))
+    ren.set_parameter("Cbar", torch.tensor(0.25))
+    assert torch.allclose(
+        plain.forward(neml2.Scalar(x))[0].data, ren.forward(neml2.Scalar(x))[0].data
+    )
+
+
+@_REQUIRES_PARAM_DERIV_TORCH
+def test_rename_parameter_derivatives_match_plain(tmp_path):
+    """The renamed parameter-derivative blocks (param_jacobian / param_vjp) key by
+    the boundary parameter name and match the unrenamed compile. Needs reverse-mode
+    AD lowering (torch >= 2.11)."""
+    deriv = [":", "out:ys.C"]  # structural + the d(out)/d(ys.C) parameter pair
+    plain, _ = _compile(tmp_path, "plain", derivatives=deriv)
+    ren, _ = _compile(tmp_path, "ren", derivatives=deriv, renames=_RENAMES)
+
+    x = torch.linspace(0.1, 0.5, 5)
+
     # param_jacobian: P[stress][Cbar] == P[out][ys.C].
     _, Pp = plain.param_jacobian({"x": x})
     _, Pr = ren.param_jacobian({"strain": x})
@@ -126,17 +158,3 @@ def test_rename_round_trip_matches_plain_compile(tmp_path):
     gr = ren.param_vjp({"strain": x}, {"stress": cot})
     assert list(gr) == ["Cbar"]
     assert torch.allclose(gp["ys.C"], gr["Cbar"])
-
-
-def test_rename_set_parameter_by_boundary_name(tmp_path):
-    """A promoted parameter is set / read through its boundary name, and the change
-    flows into the value graph identically to the authored-name path."""
-    plain, _ = _compile(tmp_path, "plain")
-    ren, _ = _compile(tmp_path, "ren", renames=_RENAMES)
-
-    x = torch.linspace(0.1, 0.5, 5)
-    plain.set_parameter("ys.C", torch.tensor(0.25))
-    ren.set_parameter("Cbar", torch.tensor(0.25))
-    op = plain.forward(neml2.Scalar(x))[0].data
-    orr = ren.forward(neml2.Scalar(x))[0].data
-    assert torch.allclose(op, orr)

--- a/tests/aoti/test_rename.py
+++ b/tests/aoti/test_rename.py
@@ -1,0 +1,142 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""End-to-end tests for shallow boundary renames (``neml2-compile --rename-*``).
+
+Compiles real artifacts and drives the public :class:`~neml2.aoti.AOTIModel`
+shim (whose ops delegate to the C++ ``neml2::aoti::Model`` facade) to confirm the
+rename is a pure relabel: with an active ``boundary_aliases`` map the reported
+``input_spec`` / ``output_spec`` / ``named_parameters`` and every
+``forward`` / ``jvp`` / ``jacobian`` / ``param_jacobian`` / ``param_vjp`` dict
+key use the RENAMED boundary names, while the values are byte-for-byte identical
+to an unrenamed compile of the same model. The internal wiring keeps the original
+authored names -- verified indirectly by the numerical parity.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+import neml2  # noqa: F401 — registers models
+
+_TESTS_ROOT = Path(__file__).resolve().parents[1]
+# Forward model: structural input `x` (Scalar) -> output `out` (Scalar), with a
+# promotable Scalar parameter `ys.C`. Small + fast to compile.
+_MODEL_I = _TESTS_ROOT / "aoti/forward_exp_param/model.i"
+
+# Structural + parameter derivatives, in ORIGINAL names (rename is applied at the
+# boundary only; derivative specs resolve against the authored names).
+_DERIV = [":", "out:ys.C"]
+_RENAMES = {
+    "inputs": {"x": "strain"},
+    "outputs": {"out": "stress"},
+    "parameters": {"ys.C": "Cbar"},
+}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _f64():
+    prev = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
+    yield
+    torch.set_default_dtype(prev)
+
+
+def _compile(tmp_path: Path, sub: str, *, renames=None):
+    from neml2.aoti import AOTIModel
+    from neml2.cli.aoti_export import export_model_for_aoti
+
+    out = tmp_path / sub
+    meta = export_model_for_aoti(
+        _MODEL_I, "model", out, promoted={"ys.C"}, derivatives=_DERIV, renames=renames
+    )
+    return AOTIModel(str(out / "model_meta.json")), meta
+
+
+def test_rename_round_trip_matches_plain_compile(tmp_path):
+    """A renamed artifact reports boundary names on every surface and is
+    numerically identical to an unrenamed compile of the same model."""
+    plain, plain_meta = _compile(tmp_path, "plain")
+    ren, ren_meta = _compile(tmp_path, "ren", renames=_RENAMES)
+
+    # Reported names are the boundary names.
+    assert list(ren.input_spec) == ["strain"]
+    assert list(ren.output_spec) == ["stress"]
+    assert list(ren.named_parameters()) == ["Cbar"]
+    # ... and the plain compile keeps the authored names (control).
+    assert list(plain.input_spec) == ["x"]
+    assert list(plain.named_parameters()) == ["ys.C"]
+
+    # Metadata: renamed carries boundary_aliases; plain omits it.
+    assert ren_meta["boundary_aliases"] == _RENAMES
+    assert "boundary_aliases" not in plain_meta
+
+    x = torch.linspace(0.1, 0.5, 5)
+
+    # forward (dict keys are boundary names in / out).
+    op = plain.forward(neml2.Scalar(x))[0].data
+    orr = ren.forward(neml2.Scalar(x))[0].data
+    assert torch.allclose(op, orr)
+
+    # jacobian: J[stress][strain] == J[out][x].
+    _, Jp = plain.jacobian({"x": x})
+    _, Jr = ren.jacobian({"strain": x})
+    assert list(Jr) == ["stress"] and list(Jr["stress"]) == ["strain"]
+    assert torch.allclose(Jp["out"]["x"], Jr["stress"]["strain"])
+
+    # jvp: seeded by boundary input name, keyed by boundary output name.
+    _, jp = plain.jvp({"x": x}, {"x": torch.ones(5)})
+    _, jr = ren.jvp({"strain": x}, {"strain": torch.ones(5)})
+    assert list(jr) == ["stress"]
+    assert torch.allclose(jp["out"], jr["stress"])
+
+    # param_jacobian: P[stress][Cbar] == P[out][ys.C].
+    _, Pp = plain.param_jacobian({"x": x})
+    _, Pr = ren.param_jacobian({"strain": x})
+    assert list(Pr["stress"]) == ["Cbar"]
+    assert torch.allclose(Pp["out"]["ys.C"], Pr["stress"]["Cbar"])
+
+    # param_vjp: cotangent keyed by boundary output name; result by boundary param.
+    cot = torch.ones(5)
+    gp = plain.param_vjp({"x": x}, {"out": cot})
+    gr = ren.param_vjp({"strain": x}, {"stress": cot})
+    assert list(gr) == ["Cbar"]
+    assert torch.allclose(gp["ys.C"], gr["Cbar"])
+
+
+def test_rename_set_parameter_by_boundary_name(tmp_path):
+    """A promoted parameter is set / read through its boundary name, and the change
+    flows into the value graph identically to the authored-name path."""
+    plain, _ = _compile(tmp_path, "plain")
+    ren, _ = _compile(tmp_path, "ren", renames=_RENAMES)
+
+    x = torch.linspace(0.1, 0.5, 5)
+    plain.set_parameter("ys.C", torch.tensor(0.25))
+    ren.set_parameter("Cbar", torch.tensor(0.25))
+    op = plain.forward(neml2.Scalar(x))[0].data
+    orr = ren.forward(neml2.Scalar(x))[0].data
+    assert torch.allclose(op, orr)

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -85,6 +85,44 @@ set_tests_properties(test_dispatcher test_load_model PROPERTIES
       ENVIRONMENT_MODIFICATION "LD_LIBRARY_PATH=path_list_prepend:${torch_LINK_DIR}"
 )
 
+# --- Boundary renames: a renamed artifact reports the boundary names on the C++
+# Model facade + DispatchedModel, and dispatch parity is preserved. ------------
+# Same forward_promoted leaf as the dispatcher fixture, but compiled with the
+# three --rename-* flags so the authored strain/stress/model.{E,nu} surface as
+# eps/sig/youngs/poisson. Reuses _fixture_devices (cpu [+cuda]).
+set(_ren_dir ${CMAKE_CURRENT_BINARY_DIR}/rename_fixture)
+set(_ren_artifact_dir ${_ren_dir}/model)
+
+add_test(
+      NAME rename_fixture_compile
+      COMMAND ${Python3_EXECUTABLE} -m neml2.cli.aoti_compile ${_fixture_input}
+              --model model --device ${_fixture_devices} -p model.E -p model.nu
+              -d : -d stress:model.E -d stress:model.nu
+              --rename-input strain:eps --rename-output stress:sig
+              --rename-parameter model.E:youngs --rename-parameter model.nu:poisson
+              --output-dir ${_ren_dir}
+      WORKING_DIRECTORY ${NEML2_SOURCE_DIR}
+)
+set_tests_properties(rename_fixture_compile PROPERTIES
+      FIXTURES_SETUP rename_artifact
+      LABELS "dispatcher"
+      TIMEOUT 600
+      ENVIRONMENT "TORCHINDUCTOR_CACHE_DIR=${_ren_dir}/aoti-cache"
+)
+
+add_executable(test_dispatcher_rename test_dispatcher_rename.cpp)
+target_link_libraries(test_dispatcher_rename PRIVATE aoti)
+target_compile_options(test_dispatcher_rename PRIVATE -Wall -Wextra)
+set_target_properties(test_dispatcher_rename PROPERTIES
+      BUILD_RPATH "${NEML2_BINARY_DIR};${torch_LINK_DIR}")
+add_test(NAME test_dispatcher_rename COMMAND test_dispatcher_rename ${_ren_artifact_dir})
+set_tests_properties(test_dispatcher_rename PROPERTIES
+      FIXTURES_REQUIRED rename_artifact
+      LABELS "dispatcher"
+      TIMEOUT 300
+      ENVIRONMENT_MODIFICATION "LD_LIBRARY_PATH=path_list_prepend:${torch_LINK_DIR}"
+)
+
 # --- Custom-op coverage: a model that uses neml2::opaque_pow -------------------
 # The dispatcher fixtures above compile LinearIsotropicElasticity (no custom ops),
 # so nothing exercised the cpp-aoti path for an op that torch.export preserves

--- a/tests/cpp/test_dispatcher_rename.cpp
+++ b/tests/cpp/test_dispatcher_rename.cpp
@@ -1,0 +1,133 @@
+// Copyright 2024, UChicago Argonne, LLC
+// All Rights Reserved
+// Software Name: NEML2 -- the New Engineering material Model Library, version 2
+// By: Argonne National Laboratory
+// OPEN SOURCE LICENSE (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// End-to-end: a boundary-renamed artifact must report the RENAMED names on both
+// the C++ `Model` facade and the `DispatchedModel`, accept / return them on every
+// op, and keep dispatch parity (chunked == single shot). The fixture compiles
+// forward_promoted (LinearIsotropicElasticity, E + nu promoted) with
+// `--rename-input strain:eps --rename-output stress:sig
+//  --rename-parameter model.E:youngs --rename-parameter model.nu:poisson`, so the
+// authored names must NOT appear at the boundary while the values are unchanged.
+
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <string>
+
+#include <ATen/ATen.h>
+
+#include "neml2/csrc/aoti/Model.h"
+#include "neml2/csrc/dispatchers/DispatchedModel.h"
+#include "neml2/csrc/dispatchers/SimpleScheduler.h"
+
+#include "test_util.h"
+
+using namespace neml2::aoti;
+
+namespace
+{
+std::map<std::string, at::Tensor>
+make_inputs(const Model & model, int64_t b)
+{
+  const auto & names = model.input_names();
+  const auto & bases = model.input_base_shapes();
+  const auto opts = at::TensorOptions().dtype(model.dtype()).device(model.device());
+  std::map<std::string, at::Tensor> inputs;
+  for (std::size_t i = 0; i < names.size(); ++i)
+  {
+    std::vector<int64_t> shape{b};
+    shape.insert(shape.end(), bases[i].begin(), bases[i].end());
+    inputs.emplace(names[i], at::randn(shape, opts));
+  }
+  return inputs;
+}
+} // namespace
+
+int
+main(int argc, char ** argv)
+{
+  NEML2_CHECK(argc >= 2); // argv[1] = the renamed fixture artifact root (holds cpu/)
+  const std::string artifact_root = argv[1];
+  const std::string meta_path = artifact_root + "/cpu/model_meta.json";
+
+  at::manual_seed(0);
+
+  Model ref(meta_path);
+
+  // The boundary reports the RENAMED names, never the authored ones.
+  NEML2_CHECK(ref.input_names() == std::vector<std::string>{"eps"});
+  NEML2_CHECK(ref.output_names() == std::vector<std::string>{"sig"});
+  const auto & params = ref.named_parameters();
+  NEML2_CHECK(params.count("youngs") == 1 && params.count("poisson") == 1);
+  NEML2_CHECK(params.count("model.E") == 0 && params.count("model.nu") == 0);
+  const auto & pbases = ref.parameter_base_shapes();
+  NEML2_CHECK(pbases.count("youngs") == 1 && pbases.count("poisson") == 1);
+
+  const int64_t b = 10;
+  const auto inputs = make_inputs(ref, b); // keyed by "eps"
+  NEML2_CHECK(inputs.count("eps") == 1);
+
+  const auto ref_out = ref.forward(inputs);
+  NEML2_CHECK(ref_out.count("sig") == 1 && ref_out.count("stress") == 0);
+
+  const auto ref_jac = ref.jacobian(inputs);
+  NEML2_CHECK(std::get<1>(ref_jac).at("sig").count("eps") == 1);
+  const auto ref_pjac = ref.param_jacobian(inputs);
+  NEML2_CHECK(std::get<1>(ref_pjac).at("sig").count("youngs") == 1);
+
+  // Dispatch parity across chunk sizes -- the dispatcher stitches by the renamed
+  // keys, so its results match the single-shot reference bit-for-bit.
+  for (std::size_t k : {std::size_t{3}, std::size_t{4}, std::size_t{0}})
+  {
+    auto scheduler = std::make_shared<SimpleScheduler>(SimpleScheduler::Config{"cpu", k});
+    DispatchedModel disp(artifact_root, scheduler);
+
+    NEML2_CHECK(disp.input_names() == std::vector<std::string>{"eps"});
+    NEML2_CHECK(disp.output_names() == std::vector<std::string>{"sig"});
+    NEML2_CHECK(disp.named_parameters().count("youngs") == 1);
+    NEML2_CHECK(disp.named_parameters().count("model.E") == 0);
+
+    auto out = disp.forward(inputs);
+    NEML2_CHECK(out.count("sig") == 1);
+    NEML2_CHECK(at::allclose(out.at("sig"), ref_out.at("sig"), 1e-8, 1e-10));
+
+    auto [jout, j] = disp.jacobian(inputs);
+    NEML2_CHECK(
+        at::allclose(j.at("sig").at("eps"), std::get<1>(ref_jac).at("sig").at("eps"), 1e-8, 1e-10));
+
+    auto [pout, P] = disp.param_jacobian(inputs);
+    NEML2_CHECK(at::allclose(
+        P.at("sig").at("youngs"), std::get<1>(ref_pjac).at("sig").at("youngs"), 1e-8, 1e-10));
+  }
+
+  // set_parameter by the BOUNDARY name flows into the value graph: perturbing
+  // "youngs" (the renamed model.E) changes the forward output.
+  Model mutated(meta_path);
+  const auto base_out = mutated.forward(inputs).at("sig").clone();
+  mutated.set_parameter("youngs", mutated.named_parameters().at("youngs") * 1.5);
+  const auto new_out = mutated.forward(inputs).at("sig");
+  NEML2_CHECK(!at::allclose(base_out, new_out));
+
+  return 0;
+}

--- a/tests/unit/test_aoti_rename.py
+++ b/tests/unit/test_aoti_rename.py
@@ -1,0 +1,192 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Boundary-rename validation + CLI plumbing for ``neml2-compile``.
+
+Fast, compile-free coverage of the shallow boundary-rename feature:
+
+* :func:`neml2.cli.aoti_export._validate_renames` -- the fail-fast validator
+  (unknown name, duplicate boundary name, non-promoted parameter, identity
+  drop, unknown namespace).
+* the ``neml2-compile`` CLI surface -- ``ORIG:NEW`` parsing and the
+  ``--model``-only restriction (rejecting ``--rename-* + --driver``).
+
+The end-to-end metadata + numerical round-trip (which requires a real AOTI
+compile) lives in ``tests/aoti/test_rename.py``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+
+import pytest
+
+from neml2.cli.aoti_export import _validate_renames
+
+# --------------------------------------------------------------------------- #
+# _validate_renames                                                           #
+# --------------------------------------------------------------------------- #
+
+_IN = ["strain", "temperature"]
+_OUT = ["stress"]
+_PARAM = ["elasticity.E", "elasticity.nu"]
+
+
+def _validate(renames):
+    return _validate_renames(renames, input_names=_IN, output_names=_OUT, param_names=_PARAM)
+
+
+def test_validate_renames_none_and_empty():
+    empty = {"inputs": {}, "outputs": {}, "parameters": {}}
+    assert _validate(None) == empty
+    assert _validate({}) == empty
+
+
+def test_validate_renames_normalizes_each_namespace():
+    out = _validate(
+        {
+            "inputs": {"strain": "eps"},
+            "outputs": {"stress": "sig"},
+            "parameters": {"elasticity.E": "youngs"},
+        }
+    )
+    assert out == {
+        "inputs": {"strain": "eps"},
+        "outputs": {"stress": "sig"},
+        "parameters": {"elasticity.E": "youngs"},
+    }
+
+
+def test_validate_renames_drops_identity():
+    # A no-op rename (boundary == original) is dropped so the metadata stays lean.
+    assert _validate({"outputs": {"stress": "stress"}})["outputs"] == {}
+
+
+def test_validate_renames_unknown_input_raises():
+    with pytest.raises(ValueError, match=r"Renamed input name\(s\) not found.*nope"):
+        _validate({"inputs": {"nope": "x"}})
+
+
+def test_validate_renames_unknown_output_raises():
+    with pytest.raises(ValueError, match=r"Renamed output name\(s\) not found"):
+        _validate({"outputs": {"missing": "x"}})
+
+
+def test_validate_renames_non_promoted_parameter_raises():
+    # Only promoted-parameter qnames are valid rename targets.
+    with pytest.raises(ValueError, match=r"Renamed parameter name\(s\) not found"):
+        _validate({"parameters": {"elasticity.G": "shear"}})
+
+
+def test_validate_renames_collision_with_sibling_raises():
+    # Renaming one input onto another input's (unrenamed) name collides.
+    with pytest.raises(ValueError, match=r"duplicate boundary name.*temperature"):
+        _validate({"inputs": {"strain": "temperature"}})
+
+
+def test_validate_renames_collision_between_two_new_names_raises():
+    with pytest.raises(ValueError, match=r"duplicate boundary name"):
+        _validate({"inputs": {"strain": "same", "temperature": "same"}})
+
+
+def test_validate_renames_unknown_namespace_raises():
+    with pytest.raises(ValueError, match=r"Unknown rename namespace"):
+        _validate({"bogus": {"a": "b"}})
+
+
+# --------------------------------------------------------------------------- #
+# CLI parsing + --model-only restriction                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_parse_rename_pairs():
+    from neml2.cli.aoti_compile import _build_arg_parser, _renames_from_args
+
+    args = _build_arg_parser().parse_args(
+        [
+            "x.i",
+            "--model",
+            "m",
+            "--rename-input",
+            "strain:eps",
+            "--rename-output",
+            "stress:sig",
+            "--rename-parameter",
+            "elasticity.E:youngs",
+        ]
+    )
+    assert _renames_from_args(args) == {
+        "inputs": {"strain": "eps"},
+        "outputs": {"stress": "sig"},
+        "parameters": {"elasticity.E": "youngs"},
+    }
+
+
+def test_cli_parse_rename_qualified_param_splits_on_first_colon():
+    # A qualified promoted-parameter name uses dots; only the first ':' separates.
+    from neml2.cli.aoti_compile import _parse_rename_pairs
+
+    assert _parse_rename_pairs(["sub.model.E:youngs"], "--rename-parameter") == {
+        "sub.model.E": "youngs"
+    }
+
+
+@pytest.mark.parametrize("spec", ["nocolon", "strain:", ":eps", ""])
+def test_cli_parse_rename_malformed_raises(spec):
+    from neml2.cli.aoti_compile import _parse_rename_pairs
+
+    with pytest.raises(ValueError):
+        _parse_rename_pairs([spec], "--rename-input")
+
+
+def test_cli_parse_rename_duplicate_orig_raises():
+    from neml2.cli.aoti_compile import _parse_rename_pairs
+
+    with pytest.raises(ValueError, match=r"duplicate rename"):
+        _parse_rename_pairs(["strain:a", "strain:b"], "--rename-input")
+
+
+def _main_stderr(argv):
+    """Run ``neml2-compile`` main, returning (SystemExit code, stderr)."""
+    from neml2.cli.aoti_compile import main
+
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf), pytest.raises(SystemExit) as exc:
+        main(argv)
+    return exc.value.code, buf.getvalue()
+
+
+def test_cli_rename_with_driver_errors():
+    # Renaming is only supported in --model mode; --driver must be rejected before
+    # any compile work (so the nonexistent input path is never reached).
+    code, err = _main_stderr(["x.i", "--driver", "d", "--rename-input", "strain:eps"])
+    assert code == 2
+    assert "only supported with --model" in err
+
+
+def test_cli_rename_malformed_token_errors():
+    code, err = _main_stderr(["x.i", "--model", "m", "--rename-output", "bad_token"])
+    assert code == 2
+    assert "--rename-output" in err

--- a/tests/unit/test_compile_interactive.py
+++ b/tests/unit/test_compile_interactive.py
@@ -100,6 +100,23 @@ def test_argv_promoted_and_derivatives_repeat():
     assert [argv[k + 1] for k, t in enumerate(argv) if t == "-d"] == ["stress:strain", ":"]
 
 
+def test_argv_renames_repeat():
+    state = FormState(
+        name="m",
+        devices=("cpu",),
+        rename_inputs=("strain:eps",),
+        rename_outputs=("stress:sig",),
+        rename_parameters=("elasticity.E:youngs", "elasticity.nu:poisson"),
+    )
+    argv = build_compile_argv(state)
+    assert [argv[k + 1] for k, t in enumerate(argv) if t == "--rename-input"] == ["strain:eps"]
+    assert [argv[k + 1] for k, t in enumerate(argv) if t == "--rename-output"] == ["stress:sig"]
+    assert [argv[k + 1] for k, t in enumerate(argv) if t == "--rename-parameter"] == [
+        "elasticity.E:youngs",
+        "elasticity.nu:poisson",
+    ]
+
+
 def test_argv_example_shape_and_dynamic_batch_tristate():
     def mk(dynamic_batch: bool | None) -> FormState:
         return FormState(
@@ -139,6 +156,17 @@ def test_argv_load_repeat_and_empty_output_dir_omitted():
             example_shape=("strain=(2;100)",),
             dynamic_batch=False,
             load=("ext.py",),
+        ),
+        # Model target with boundary renames -- the built argv must parse cleanly.
+        FormState(
+            input_file="in.i",
+            target="model",
+            name="elasticity",
+            devices=("cpu",),
+            promoted=("elasticity.E",),
+            rename_inputs=("strain:eps",),
+            rename_outputs=("stress:sig",),
+            rename_parameters=("elasticity.E:youngs",),
         ),
     ],
 )
@@ -320,14 +348,15 @@ def test_wizard_flow_builds_and_runs_expected_argv(monkeypatch):
     from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
 
     # Prompt answers in flow order (input file comes from the CLI, not a prompt):
-    # target, name, promote, derivatives?, devices, dtype, output dir, uniform
-    # example shape?, uniform value, dynamic batch, then the review menu's action.
+    # target, name, promote, derivatives?, rename?, devices, dtype, output dir,
+    # uniform example shape?, uniform value, dynamic batch, then the review action.
     fake = _FakeQuestionary(
         [
             "model",
             "elasticity",
             ["E"],
             False,
+            False,  # rename any boundary variables?
             ["cpu", "cuda"],
             "float32",
             "out",
@@ -366,7 +395,7 @@ def test_wizard_example_shape_customize_per_variable(monkeypatch):
     pytest.importorskip("questionary")
     from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
 
-    # target, name, derivatives?, devices, dtype, output, uniform?(No),
+    # target, name, derivatives?, rename?, devices, dtype, output, uniform?(No),
     # customize-which, strain=, temperature=, dynamic, review -> run.
     # (No "promote" prompt: promotable is empty.)
     fake = _FakeQuestionary(
@@ -374,6 +403,7 @@ def test_wizard_example_shape_customize_per_variable(monkeypatch):
             "model",
             "m",
             False,
+            False,  # rename any boundary variables?
             ["cpu"],
             "float64",
             "./aoti",
@@ -413,8 +443,10 @@ def test_wizard_example_shape_uniform(monkeypatch):
     pytest.importorskip("questionary")
     from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
 
+    # target, name, derivatives?, rename?, devices, dtype, output, uniform?, value,
+    # dynamic, run. (No promote prompt: promotable is empty.)
     fake = _FakeQuestionary(
-        ["model", "m", False, ["cpu"], "float64", "./aoti", True, "(4,)", True, "run"]
+        ["model", "m", False, False, ["cpu"], "float64", "./aoti", True, "(4,)", True, "run"]
     )
     monkeypatch.setattr(wiz, "questionary", fake)
     monkeypatch.setattr(
@@ -437,7 +469,8 @@ def test_wizard_derivatives_cross_product(monkeypatch):
     from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
 
     # target, name, promote, derivatives? -> yes, outputs, inputs, round-menu ->
-    # done, devices, dtype, output, uniform?(yes), uniform "", dynamic, review -> run.
+    # done, rename? -> no, devices, dtype, output, uniform?(yes), uniform "",
+    # dynamic, review -> run.
     fake = _FakeQuestionary(
         [
             "model",
@@ -447,6 +480,7 @@ def test_wizard_derivatives_cross_product(monkeypatch):
             ["stress"],  # outputs
             ["strain", "E"],  # w.r.t. inputs (incl. promoted param)
             "done",  # round menu -> finish
+            False,  # rename any boundary variables?
             ["cpu"],
             "float64",
             "./aoti",
@@ -469,6 +503,89 @@ def test_wizard_derivatives_cross_product(monkeypatch):
     argv = captured["argv"]
     dpairs = [argv[k + 1] for k, t in enumerate(argv) if t == "-d"]
     assert dpairs == ["stress:strain", "stress:E"]
+
+
+def test_wizard_collects_renames(monkeypatch):
+    """Accepting the rename step and typing new names for a chosen input / output /
+    promoted parameter yields the three --rename-* flags."""
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    # target, name, promote, derivatives?(no), rename?(yes),
+    #   rename-inputs [strain] -> "eps",
+    #   rename-outputs [stress] -> "sig",
+    #   rename-params [E] -> "youngs",
+    # devices, dtype, output, uniform?(yes), value, dynamic, run.
+    fake = _FakeQuestionary(
+        [
+            "model",
+            "m",
+            ["E"],  # promote E (so it can be renamed)
+            False,  # derivatives?
+            True,  # rename any boundary variables?
+            ["strain"],  # rename which inputs
+            "eps",  # strain ->
+            ["stress"],  # rename which outputs
+            "sig",  # stress ->
+            ["E"],  # rename which promoted parameters
+            "youngs",  # E ->
+            ["cpu"],
+            "float64",
+            "./aoti",
+            True,
+            "",
+            True,
+            "run",
+        ]
+    )
+    monkeypatch.setattr(wiz, "questionary", fake)
+    monkeypatch.setattr(
+        wiz,
+        "_introspect",
+        lambda *a, **k: IntrospectionForm(promotable=["E"], outputs=["stress"], inputs=["strain"]),
+    )
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setattr(wiz, "run_compile", lambda argv: captured.update(argv=argv) or 0)
+
+    assert wiz.run_wizard(input_file=str(_FIXTURE)) == 0
+    argv = captured["argv"]
+    assert argv[argv.index("--rename-input") + 1] == "strain:eps"
+    assert argv[argv.index("--rename-output") + 1] == "stress:sig"
+    assert argv[argv.index("--rename-parameter") + 1] == "E:youngs"
+
+
+def test_ask_renames_decline_and_cancel(monkeypatch):
+    """_ask_renames: declining the gate returns empty maps; cancelling returns None;
+    an unavailable-introspection call leaves the current selection unchanged."""
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    intro = IntrospectionForm(promotable=["E"], outputs=["stress"], inputs=["strain"])
+    # Decline the gate -> all-empty maps.
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([False]))
+    assert wiz._ask_renames(intro, ("E",), {}) == {"inputs": {}, "outputs": {}, "parameters": {}}
+    # Cancel the gate -> None.
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([None]))
+    assert wiz._ask_renames(intro, ("E",), {}) is None
+    # No introspection -> keep current unchanged (no prompt consumed).
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([]))
+    current = {"inputs": {"strain": "eps"}, "outputs": {}, "parameters": {}}
+    assert wiz._ask_renames(None, (), current) == current
+
+
+def test_wizard_rename_skipped_for_driver_target(monkeypatch):
+    """The rename field is a no-op (no prompt) when the target is a driver."""
+    pytest.importorskip("questionary")
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    # An empty answer script would raise if the branch tried to prompt.
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([]))
+    state = wiz._default_state()
+    state["target"] = "driver"
+    state["name"] = "driver"
+    state["rename"] = {"inputs": {"strain": "eps"}, "outputs": {}, "parameters": {}}
+    assert wiz._ask_field("rename", str(_FIXTURE), state, {}) is True
+    assert state["rename"] == {"inputs": {}, "outputs": {}, "parameters": {}}
 
 
 def test_ask_derivatives_edit_add_clear(monkeypatch):
@@ -506,12 +623,14 @@ def test_wizard_edit_back_does_not_crash(monkeypatch):
     pytest.importorskip("questionary")
     from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
 
-    # ... linear (uniform example) ..., review -> edit, edit-field -> back, review -> run.
+    # ... linear (deriv no, rename no, uniform example) ..., review -> edit,
+    # edit-field -> back, review -> run.
     fake = _FakeQuestionary(
         [
             "model",
             "m",
-            False,
+            False,  # derivatives?
+            False,  # rename?
             ["cpu"],
             "float64",
             "./aoti",
@@ -613,9 +732,22 @@ def test_compile_interactive_missing_questionary_hint(monkeypatch, capsys):
 # sequence is deterministic for the scripted flows below.
 _WIZ_INTRO = IntrospectionForm(promotable=["E"], outputs=["stress"], inputs=["strain"])
 # Linear-pass answers (one per prompt) for that intro, with a uniform example
-# shape: target, name, promote, derivatives?, devices, dtype, output, uniform?,
-# uniform value, dynamic batch.
-_LINEAR_OK = ["model", "elasticity", ["E"], False, ["cpu"], "float64", "./aoti", True, "", True]
+# shape: target, name, promote, derivatives?, rename?, devices, dtype, output,
+# uniform?, uniform value, dynamic batch. (The rename step in the decline path is
+# a single confirm answered False.)
+_LINEAR_OK = [
+    "model",
+    "elasticity",
+    ["E"],
+    False,
+    False,
+    ["cpu"],
+    "float64",
+    "./aoti",
+    True,
+    "",
+    True,
+]
 
 
 def _patch_intro(monkeypatch, wiz, intro=_WIZ_INTRO):
@@ -682,7 +814,8 @@ def test_run_wizard_review_validate_problem_then_quit(monkeypatch):
     from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
 
     # devices = [] -> validate_state flags it -> "run" loops back -> "quit".
-    answers = ["model", "elasticity", ["E"], False, [], "float64", "./aoti", True, "", True]
+    # (deriv no, rename no, then devices [].)
+    answers = ["model", "elasticity", ["E"], False, False, [], "float64", "./aoti", True, "", True]
     monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([*answers, "run", "quit"]))
     _patch_intro(monkeypatch, wiz)
     monkeypatch.setattr(wiz, "run_compile", lambda argv: 0)  # must NOT be called

--- a/tests/unit/test_sub_batch_aoti_meta.py
+++ b/tests/unit/test_sub_batch_aoti_meta.py
@@ -41,25 +41,24 @@ Pins the structural contract between the Python writer
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from neml2.cli.aoti_export import AOTI_META_SCHEMA_VERSION, _var_infos
 from neml2.types import Scalar
 
 # ---------- schema_version constant ----------
 
 
-def test_schema_version_constant():
-    """v7 adds parameter derivatives `d(output)/d(parameter)`: a `parameter_derivatives`
-    array of `(out, param)` pairs, per-segment param-Jacobian / param-VJP graphs (forward,
-    single-`ImplicitUpdate`, and composed), and a `param_base_shape` field per promoted
-    parameter. Promoted parameters enter the value / jvp / jacobian / param-Jacobian /
-    param-VJP graphs as per-batch `(B, *param_base)` inputs, so a batched (per-batch-element)
-    parameter flows through and yields per-element derivatives (param_vjp sums over the batch
-    only for an unbatched/global parameter), matching eager. (v6 made derivative graphs
-    opt-in; v5 carried per-variable ``base_shape``; v4 de-baked the solver config.) The C++
-    loader mirrors this constant and refuses any other value, so a stale cache surfaces
-    immediately with a clear ``regenerate via neml2-compile`` message instead of a cryptic
-    missing-field error."""
-    assert AOTI_META_SCHEMA_VERSION == 7
+def test_schema_version_matches_dependencies_yaml():
+    """The exported constant tracks the single source of truth in
+    ``scripts/dependencies.yaml`` (kept in sync by ``scripts/dep_manager.py``);
+    the C++ loader mirrors the same value and refuses any other, so a stale
+    cache surfaces with a clear ``regenerate via neml2-compile`` message."""
+    import yaml
+
+    repo_root = Path(__file__).resolve().parents[2]
+    deps = yaml.safe_load((repo_root / "scripts" / "dependencies.yaml").read_text())
+    assert AOTI_META_SCHEMA_VERSION == int(deps["aoti"]["schema_version"])
 
 
 # ---------- _var_infos default behaviour (no sub-batch) ----------

--- a/tests/unit/test_sub_batch_aoti_meta.py
+++ b/tests/unit/test_sub_batch_aoti_meta.py
@@ -53,12 +53,18 @@ def test_schema_version_matches_dependencies_yaml():
     """The exported constant tracks the single source of truth in
     ``scripts/dependencies.yaml`` (kept in sync by ``scripts/dep_manager.py``);
     the C++ loader mirrors the same value and refuses any other, so a stale
-    cache surfaces with a clear ``regenerate via neml2-compile`` message."""
-    import yaml
+    cache surfaces with a clear ``regenerate via neml2-compile`` message.
+
+    Parsed with a regex rather than PyYAML: ``yaml`` is a build/dev-tool
+    dependency (``dep_manager``), not part of the runtime test environment.
+    ``aoti.schema_version`` is the only ``schema_version`` key in the file."""
+    import re
 
     repo_root = Path(__file__).resolve().parents[2]
-    deps = yaml.safe_load((repo_root / "scripts" / "dependencies.yaml").read_text())
-    assert AOTI_META_SCHEMA_VERSION == int(deps["aoti"]["schema_version"])
+    text = (repo_root / "scripts" / "dependencies.yaml").read_text()
+    m = re.search(r'^\s*schema_version:\s*"?(\d+)"?', text, re.MULTILINE)
+    assert m is not None, "schema_version not found in scripts/dependencies.yaml"
+    assert AOTI_META_SCHEMA_VERSION == int(m.group(1))
 
 
 # ---------- _var_infos default behaviour (no sub-batch) ----------


### PR DESCRIPTION
## What

`neml2-compile` can now rename **input variables, output variables, and promoted parameters** at the exported model's boundary, so downstream consumers (a MOOSE app, an external C++ solver, a Python pipeline) can use their own naming conventions instead of adapting to NEML2's authored names.

The rename is **shallow**: only the names reported at the artifact interface change — the inputs/outputs a caller passes and reads, the promoted-parameter names in `named_parameters()`, and the keys of every `forward` / `jvp` / `jacobian` / `param_jacobian` / `param_vjp` result. The compiled `.pt2` graphs and all internal wiring keep the original authored names, so a rename is a pure relabel with identical values.

## Usage

```bash
neml2-compile input.i --model my_model \
  --rename-input strain:eps --rename-output stress:sig \
  -p elasticity.E --rename-parameter elasticity.E:youngs -d :
```

Each flag is `ORIG:NEW` and repeatable. The interactive wizard (`-i`) offers an optional rename step in parity with the flags.

## Design

- **Scope:** the AOTI/compiled routes — `py-aoti`, `cpp-aoti`, `cpp-dispatch` (all read `_meta.json`). The eager routes run the un-exported model and have no compile step to carry a rename map, so they keep the authored names — a documented parity asymmetry (like the existing "cpp-eager is plain-batch only").
- **CLI:** `--rename-input` / `--rename-output` / `--rename-parameter`, validated fail-fast (unknown name, duplicate boundary name, non-promoted parameter). Restricted to `--model` mode; combining with `--driver` is rejected (the bundled `[Drivers]` block is wired to the original names).
- **Metadata:** a new top-level `boundary_aliases` object (`{inputs|outputs|parameters: {orig: new}}`), written only when a rename is active. Per-variable `name` fields stay original — the loader reads them as internal identity and applies the alias only at the public surface.
- **Runtime:** the C++ `neml2::aoti::Model` **facade** is the single translation point. `Impl` and all segment / `state` / `dstate` machinery stay original-name; the facade re-keys at the interface, gated on `_has_aliases` so the unrenamed common path is byte-identical and zero-copy. `_named_parameters` is stored boundary-keyed (the multi-device dispatcher slot-assigns into `named_parameters()` and `_resolve_param` reads it back through the same key), while `_param_base_shapes` stays original with a boundary-keyed view for the public accessor. `DispatchedModel` and the pybind binding inherit renaming with **zero** changes; the py-aoti shim keys its specs by the boundary names.
- **Schema:** bumped `aoti.schema_version` 7 → 8 via `dep_manager` (canonical value lives only in `dependencies.yaml`). Dropped the version-history docstring and taught `dep_manager` to recognize `//` annotations so the C++ `kSupportedSchemaVersion` is now auto-managed rather than hand-synced.

## Testing

- **Unit** (`tests/unit/test_aoti_rename.py`): validator (unknown/duplicate/non-promoted/namespace) + CLI `ORIG:NEW` parsing + the `--model`-only guard.
- **Wizard** (`tests/unit/test_compile_interactive.py`): argv builder, full-flow collection, decline/cancel, driver-mode skip.
- **AOTI end-to-end** (`tests/aoti/test_rename.py`): compile renamed vs plain; assert boundary names on `input_spec`/`output_spec`/`named_parameters` and that `forward`/`jvp`/`jacobian`/`param_jacobian`/`param_vjp`/`set_parameter` accept/return the renamed keys with values **numerically identical** to the unrenamed compile.
- **C++ dispatcher** (`tests/cpp/test_dispatcher_rename.cpp` + fixture): a renamed artifact reports boundary names on both `Model` and `DispatchedModel`, with dispatch parity across chunk sizes.

Full unit suite (658) + existing derivative-selection AOTI tests pass; the non-renamed path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
