### PR TITLE
Add MinMapComplementarity hard-switch KKT condition

### DIFF
--- a/.claude/skills/add-model/SKILL.md
+++ b/.claude/skills/add-model/SKILL.md
@@ -90,6 +90,19 @@ class MyHardening(Model):
 - **Don't form the Jacobian; push the tangent.** The action receives a
   tangent of the input type and returns a tangent of the output type,
   in typed-wrapper algebra. The framework accumulates over seed leaves.
+- **Apply the local map to `V`; don't materialize a coefficient and
+  multiply.** The action exists so you can operate on the incoming
+  tangent directly. Scaling by a value that is *already* an operand is
+  fine (`lambda V: K * V` for `h = K * ep`). What to avoid is
+  reconstructing the local derivative as a standalone tensor and then
+  doing `coeff * V` — especially for piecewise / selection maps. For a
+  hard switch `r = where(mask, ta, tb)`, thread the *same* `where` onto
+  the tangent: `lambda V: where(mask, sa * V, Scalar.zeros_like(V))`,
+  **not** `m = where(mask, one, zero); dr = sa * m; lambda V: dr * V`.
+  The direct form is cheaper, reuses the primal's mask (so primal and
+  Jacobian can't diverge), and keeps the branch structure explicit. Use
+  `Scalar.zeros_like(V)` for the vanishing branch — it inherits `V`'s K
+  (seed) layout so `where`'s K-less mask broadcasts over it.
 - **Docstrings must be ASCII** (the `test_syntax_cli` ASCII guard
   rejects em-dashes, Greek letters, math symbols). Save those for
   comments.

--- a/doc/content/modules/phase_field_fracture.md
+++ b/doc/content/modules/phase_field_fracture.md
@@ -52,8 +52,18 @@ $$
 f + \dot{d} - \sqrt{f^2 + \dot{d}^2} = 0,
 $$
 
-which can be solved for $d$ with a standard Newton iteration. The stress
-is obtained from the same potential by differentiation,
+which can be solved for $d$ with a standard Newton iteration.
+
+:::{note}
+The same complementarity conditions can instead be enforced with the
+hard-switch minimum map $\min(-f, \dot{d}) = 0$
+([](models-MinMapComplementarity)), which is piecewise-linear and usually
+converges more robustly than the smooth Fischer–Burmeister residual (see
+the [consistent-plasticity discussion](solid_mechanics/plasticity.md) for
+the trade-off). Swap the `type` in the `Fish_Burm` block below to try it.
+:::
+
+The stress is obtained from the same potential by differentiation,
 
 $$
 \mathbf{S} = \frac{\partial \psi}{\partial \mathbf{E}}.

--- a/doc/content/modules/solid_mechanics/plasticity.md
+++ b/doc/content/modules/solid_mechanics/plasticity.md
@@ -37,9 +37,12 @@ step:
   itself as an explicit function of the yield function.
 
 These pieces are typically glued together by [](models-ComposedModel)
-and closed by either [](models-FBComplementarity) (consistent
-plasticity) or a Perzyna-style rate equation (viscoplasticity), then
-wrapped in [](models-ImplicitUpdate) for the implicit return map. A
+and closed by a complementarity condition (consistent plasticity) or a
+Perzyna-style rate equation (viscoplasticity), then wrapped in
+[](models-ImplicitUpdate) for the implicit return map. For consistent
+plasticity the recommended closure is the hard-switch
+[](models-MinMapComplementarity); [](models-FBComplementarity) is a
+smooth alternative (see below). A
 closed-form radial-return path is also available for the
 J2-elastic-perfectly-plastic case via
 [](models-LinearIsotropicElasticJ2TrialStressUpdate); see the
@@ -58,15 +61,29 @@ where $f^p$ is the yield function and $\gamma$ is the consistency parameter.
 
 ### Consistent (rate-independent) plasticity
 
-NEML2 enforces the KKT conditions by recasting them as the smooth
-Fischer-Burmeister complementarity residual, which the nonlinear
-solver drives to its convergence tolerance:
+NEML2 enforces the KKT conditions by recasting them as a single
+complementarity residual that the nonlinear solver drives to its
+convergence tolerance. The recommended form is the *minimum map*, a hard
+switch that reduces to whichever condition is active:
+
+$$
+r = \min(\dot{\gamma},\, -f^p),
+$$
+
+implemented by [](models-MinMapComplementarity) with `a_inequality = 'LE'`.
+Being piecewise-linear, it gives semismooth-Newton / active-set behavior
+that converges robustly in return mapping.
+
+An alternative is the smooth Fischer-Burmeister residual,
 
 $$
 r = \dot{\gamma} - f^p - \sqrt{\dot{\gamma}^{\,2} + {f^p}^{\,2}},
 $$
 
-implemented by [](models-FBComplementarity) with `a_inequality = 'LE'`.
+implemented by [](models-FBComplementarity) with the same
+`a_inequality = 'LE'`. It is differentiable everywhere but strongly
+nonlinear near the origin, which can slow Newton convergence; prefer the
+minimum map unless a globally smooth residual is specifically required.
 
 :::{note}
 "Consistent" plasticity is often called rate-*independent*. Rate
@@ -135,7 +152,7 @@ The input file below assembles a fully implicit return-map for elastic-plastic
 behaviour with both isotropic and kinematic hardening: linear-elastic
 stress-strain, [](models-VoceIsotropicHardening) isotropic hardening,
 [](models-LinearKinematicHardening) back stress, associative $J_2$ flow, and
-the Fischer-Burmeister consistency condition.
+the minimum-map consistency condition.
 
 ```{literalinclude} ../../../../tests/regression/solid_mechanics/rate_independent_plasticity/isokinharden/model.i
 :language: ini
@@ -169,8 +186,8 @@ the Fischer-Burmeister consistency condition.
   the rates into the residuals `plastic_strain_residual`,
   `kinematic_plastic_strain_residual`,
   `equivalent_plastic_strain_residual`.
-- **Consistency** — `[consistency]` ([](models-FBComplementarity)) closes
-  the system with the Fischer-Burmeister residual between `yield_function`
+- **Consistency** — `[consistency]` ([](models-MinMapComplementarity)) closes
+  the system with the minimum-map residual between `yield_function`
   and `flow_rate`.
 - **Return map** — `[surface]` composes every residual-producing piece into
   one model. `NonlinearSystem` solves for

--- a/neml2/models/common/MinMapComplementarity.py
+++ b/neml2/models/common/MinMapComplementarity.py
@@ -1,0 +1,129 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Hard-switch (minimum-map) KKT complementarity condition."""
+
+from __future__ import annotations
+
+from ...factory import register_neml2_object
+from ...schema import HitSchema, input, option, output
+from ...types import Scalar, lt, where
+from ..chain_rule import ChainRuleDict
+from ..model import Model
+
+
+@register_neml2_object("MinMapComplementarity")
+class MinMapComplementarity(Model):
+    r"""KKT complementarity condition enforced with the *minimum map*.
+
+    The complementarity conditions $a \ge 0, b \ge 0, ab = 0$ are equivalent to
+    the single scalar equation
+    $$r = \min(a, b) = 0.$$
+    The residual is piecewise-linear: it equals whichever of the two arguments
+    is currently smaller, a hard switch that gives semismooth-Newton /
+    active-set behavior and converges robustly in return mapping. The switch is
+    selected per batch entry with ``where`` (no Python branching), so the model
+    lowers through AOTI and runs on GPU; the trade-off is a piecewise-constant
+    Jacobian that is non-smooth at the switch $a = b$.
+
+    The sign of each argument follows its declared inequality: ``LE`` enforces
+    $\le 0$ (coefficient $-1$) and ``GE`` enforces $\ge 0$ (coefficient $+1$),
+    so the enforced residual is $r = \min(s_a\, a,\; s_b\, b)$.
+    """
+
+    hit = HitSchema(
+        input("a", Scalar, "First condition", attr="_a"),
+        input("b", Scalar, "Second condition", attr="_b"),
+        # Renaming the output (e.g. ``complementarity = 'd_residual'``) lets the
+        # host NonlinearSystem's ``<unknown>_residual`` inference wire this leaf
+        # up as a residual out of the box.
+        output(
+            "complementarity",
+            Scalar,
+            "The minimum-map complementarity condition",
+            attr="_residual",
+        ),
+        option(
+            "a_inequality",
+            str,
+            "Type of the inequality for the first variable a.",
+            default="LE",
+            attr="_a_inequality",
+        ),
+        option(
+            "b_inequality",
+            str,
+            "Type of inequality for the second variable b.",
+            default="GE",
+            attr="_b_inequality",
+        ),
+    )
+
+    _a: str
+    _b: str
+    _residual: str
+    _a_inequality: str
+    _b_inequality: str
+    _sa: float
+    _sb: float
+
+    def __post_init__(self) -> None:
+        if self._a_inequality not in ("LE", "GE") or self._b_inequality not in ("LE", "GE"):
+            raise ValueError("MinMapComplementarity inequality must be 'LE' or 'GE'")
+        # Sign convention: LE → -, GE → + on each term.
+        self._sa = -1.0 if self._a_inequality == "LE" else 1.0
+        self._sb = -1.0 if self._b_inequality == "LE" else 1.0
+
+    def forward(  # type: ignore[override]
+        self,
+        a: Scalar,
+        b: Scalar,
+        v: ChainRuleDict | None = None,
+    ) -> Scalar | tuple[Scalar, ChainRuleDict]:
+        sa, sb = self._sa, self._sb
+        ta = sa * a
+        tb = sb * b
+        # ``lt`` is strict, so a tie (ta == tb, measure zero) resolves to the
+        # b-branch; the primal and Jacobian below share this single mask so the
+        # returned Jacobian is exactly the derivative of the selected branch.
+        mask = lt(ta, tb)
+        r = where(mask, ta, tb)  # r = min(sa * a, sb * b)
+        if v is None:
+            return r
+        # The residual equals whichever branch is active, so each input's
+        # tangent passes straight through (times its sign) on its own branch and
+        # vanishes on the other. Apply the same hard switch directly to the
+        # incoming tangent V rather than forming a coefficient and multiplying.
+        return r, self.apply_chain_rule(
+            v,
+            self._residual,
+            {
+                self._a: lambda V, m=mask: where(m, sa * V, Scalar.zeros_like(V)),
+                self._b: lambda V, m=mask: where(m, Scalar.zeros_like(V), sb * V),
+            },
+            output=r,
+        )
+
+
+__all__ = ["MinMapComplementarity"]

--- a/neml2/models/common/__init__.py
+++ b/neml2/models/common/__init__.py
@@ -92,6 +92,7 @@ from .LinearCombination import ScalarLinearCombination, SR2LinearCombination
 from .LinearExtrapolationPredictor import LinearExtrapolationPredictor
 from .LinearInterpolation import ScalarLinearInterpolation
 from .MacaulaySplit import MacaulaySplit
+from .MinMapComplementarity import MinMapComplementarity
 from .MixedControlSetup import MixedControlSetup
 from .ParameterToVariable import (
     MillerIndexParameterToVariable,
@@ -141,6 +142,7 @@ __all__ = [
     "HermiteSmoothStep",
     "IrreversibleScalar",
     "MacaulaySplit",
+    "MinMapComplementarity",
     "ConstantExtrapolationPredictor",
     "LinearExtrapolationPredictor",
     "MillerIndexConstantParameter",

--- a/tests/models/common/MinMapComplementarity.i
+++ b/tests/models/common/MinMapComplementarity.i
@@ -1,0 +1,22 @@
+# Hard-switch (minimum-map) counterpart of common/FBComplementarity.i.
+# Uses the production sign config (a: LE, b: GE): r = min(-a, b).
+# At a=3.1, b=2.5 -> min(-3.1, 2.5) = -3.1 (a-branch active, far from the kink
+# so the finite-difference Jacobian check sees the exact analytic dr/da=-1).
+[Drivers]
+  [unit]
+    type = ModelUnitTest
+    model = 'model'
+    input_Scalar_names = 'a b'
+    input_Scalar_values = '3.1 2.5'
+    output_Scalar_names = 'complementarity'
+    output_Scalar_values = '-3.1'
+  []
+[]
+
+[Models]
+  [model]
+    type = MinMapComplementarity
+    a_inequality = 'LE'
+    b_inequality = 'GE'
+  []
+[]

--- a/tests/regression/solid_mechanics/rate_independent_plasticity/gurson/model.i
+++ b/tests/regression/solid_mechanics/rate_independent_plasticity/gurson/model.i
@@ -110,7 +110,7 @@
     variable = 'equivalent_plastic_strain'
   []
   [consistency]
-    type = FBComplementarity
+    type = MinMapComplementarity
     a = 'yield_function'
     a_inequality = 'LE'
     b = 'flow_rate'

--- a/tests/regression/solid_mechanics/rate_independent_plasticity/isoharden/model.i
+++ b/tests/regression/solid_mechanics/rate_independent_plasticity/isoharden/model.i
@@ -92,7 +92,7 @@
     variable = 'plastic_strain'
   []
   [consistency]
-    type = FBComplementarity
+    type = MinMapComplementarity
     a = 'yield_function'
     a_inequality = 'LE'
     b = 'flow_rate'

--- a/tests/regression/solid_mechanics/rate_independent_plasticity/isokinharden/model.i
+++ b/tests/regression/solid_mechanics/rate_independent_plasticity/isokinharden/model.i
@@ -110,7 +110,7 @@
     variable = 'plastic_strain'
   []
   [consistency]
-    type = FBComplementarity
+    type = MinMapComplementarity
     a = 'yield_function'
     a_inequality = 'LE'
     b = 'flow_rate'

--- a/tests/regression/solid_mechanics/rate_independent_plasticity/kinharden/model.i
+++ b/tests/regression/solid_mechanics/rate_independent_plasticity/kinharden/model.i
@@ -97,7 +97,7 @@
     variable = 'plastic_strain'
   []
   [consistency]
-    type = FBComplementarity
+    type = MinMapComplementarity
     a = 'yield_function'
     a_inequality = 'LE'
     b = 'flow_rate'

--- a/tests/regression/solid_mechanics/rate_independent_plasticity/perfect/model.i
+++ b/tests/regression/solid_mechanics/rate_independent_plasticity/perfect/model.i
@@ -79,7 +79,7 @@
     variable = 'plastic_strain'
   []
   [consistency]
-    type = FBComplementarity
+    type = MinMapComplementarity
     a = 'yield_function'
     a_inequality = 'LE'
     b = 'flow_rate'

--- a/tests/regression/solid_mechanics/rate_independent_plasticity/perfect_temperature/model.i
+++ b/tests/regression/solid_mechanics/rate_independent_plasticity/perfect_temperature/model.i
@@ -100,7 +100,7 @@
     variable = 'plastic_strain'
   []
   [consistency]
-    type = FBComplementarity
+    type = MinMapComplementarity
     a = 'yield_function'
     a_inequality = 'LE'
     b = 'flow_rate'

--- a/tests/regression/solid_mechanics/rate_independent_plasticity/radial_return/model.i
+++ b/tests/regression/solid_mechanics/rate_independent_plasticity/radial_return/model.i
@@ -174,7 +174,7 @@
     variable = 'kinematic_plastic_strain'
   []
   [consistency]
-    type = FBComplementarity
+    type = MinMapComplementarity
     a = 'yield_function'
     a_inequality = 'LE'
     b = 'flow_rate'

--- a/tests/verification/solid_mechanics/rate_independent/perfect.i
+++ b/tests/verification/solid_mechanics/rate_independent/perfect.i
@@ -86,7 +86,7 @@
     variable = 'plastic_strain'
   []
   [consistency]
-    type = FBComplementarity
+    type = MinMapComplementarity
     a = 'yield_function'
     a_inequality = 'LE'
     b = 'flow_rate'

--- a/tests/verification/solid_mechanics/rate_independent/voceiso.i
+++ b/tests/verification/solid_mechanics/rate_independent/voceiso.i
@@ -99,7 +99,7 @@
     variable = 'plastic_strain'
   []
   [consistency]
-    type = FBComplementarity
+    type = MinMapComplementarity
     a = 'yield_function'
     a_inequality = 'LE'
     b = 'flow_rate'

--- a/tests/verification/solid_mechanics/rate_independent/voceisolinkin.i
+++ b/tests/verification/solid_mechanics/rate_independent/voceisolinkin.i
@@ -117,7 +117,7 @@
     variable = 'plastic_strain'
   []
   [consistency]
-    type = FBComplementarity
+    type = MinMapComplementarity
     a = 'yield_function'
     a_inequality = 'LE'
     b = 'flow_rate'


### PR DESCRIPTION
## Summary

Adds `MinMapComplementarity`, a **hard-switch** reformulation of KKT loading/unloading using the *minimum map*:

$$r = \min(s_a\,a,\; s_b\,b) = 0$$

This is an alternative to the smooth Fischer–Burmeister residual (`FBComplementarity`). FB is differentiable everywhere but strongly nonlinear near the origin, which degrades Newton convergence in real mechanics simulations. The minimum map is piecewise-linear, giving semismooth-Newton / active-set behavior that converges far more robustly in return mapping. The per-batch branch is selected with `where` (no Python branching), so it lowers through AOTI and runs on GPU. It keeps the same sign flexibility as FB (`a_inequality`/`b_inequality`, `LE`/`GE`), so it is a drop-in `type` swap.

## What's included

- **New leaf** `neml2/models/common/MinMapComplementarity.py` (+ registration, + `tests/models/common/MinMapComplementarity.i`).
- **Chain rule operates directly on the tangent.** The action threads the *same* `where` mask onto `V` — `where(mask, s * V, Scalar.zeros_like(V))` — rather than materializing a derivative coefficient and doing `c * V`. Reusing the primal's mask guarantees the Jacobian can't diverge from the primal. This convention is now documented as a hard rule in the `/add-model` skill.
- **Migration** of the rate-independent plasticity **regression (7)** and **verification (3)** scenarios to the hard switch.
- **Docs**: `plasticity.md` now recommends the hard switch as the default consistency closure (FB kept as the smooth alternative with the trade-off spelled out); `phase_field_fracture.md` gets a cross-linked note.

## Migration: no regressions observed

All 10 migrated scenarios **pass against the existing FB-pinned gold with no gold regeneration** — both NCP functions drive the same residual to the Newton tolerance (`1e-10`), comfortably inside the regression compare tolerance (`rtol=1e-5, atol=1e-8`), so the hard switch reproduces the FB converged state. `km_flow/*`, phase-field fracture, and unit fixtures are intentionally left on FB (candidates for a later migration).

## Verification

| Check | Result |
| --- | --- |
| New unit test (value + FD Jacobian) | ✅ |
| `neml2-syntax` registration + schema | ✅ |
| AOTI compile smoke (`where`/`lt` lowers) | ✅ |
| pre-commit (ruff, copyright, nmhit-format) | ✅ |
| Full regression | ✅ 57 passed |
| Full verification | ✅ 24 passed |
| All model unit tests | ✅ 177 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)