### PR TITLE
neml2-compile: artifact planning, per-file progress, and parallel segment compilation

### DIFF
--- a/doc/content/references/aoti_packages.md
+++ b/doc/content/references/aoti_packages.md
@@ -90,6 +90,17 @@ that device. The stub points at the `<name>/` folder via an absolute
 `<artifact_path>/<device>/<name>_meta.json` for the device it runs on
 (see [The HIT stub](#the-hit-stub)).
 
+The full set of files a compile will write — every `.pt2`, each
+per-device `<name>_meta.json`, and the `<name>_aoti.i` stub — can be
+enumerated ahead of time, without compiling, via
+`neml2.cli.aoti_export.plan_export_artifacts`. `neml2-compile` prints
+`[k/N]` progress against that count as each file lands. For a
+multi-segment model (see the segment table below), the `_seg{i}`
+segments are independent and can be compiled concurrently with
+`neml2-compile -j N` (a spawn process pool); the emitted artifacts and
+metadata are identical to a serial compile. Single-segment models ignore
+`-j`.
+
 Inside each `<device>/` subfolder, a forward single-segment model emits
 the metadata plus a value graph and an optional JVP graph:
 

--- a/doc/content/references/pipeline.md
+++ b/doc/content/references/pipeline.md
@@ -152,6 +152,23 @@ inputs from that map. The shared map plus topological order is
 what lets a multi-segment artifact present a single forward
 contract to the loader.
 
+The segments are coupled **only** at runtime, through that state map;
+their compiles are independent. `neml2-compile -j N` therefore compiles
+up to `N` segments concurrently in a spawn process pool — each worker
+re-derives its assigned segment from the input file (live models can't
+cross the process boundary), and the per-segment metadata is reassembled
+in segment order so the resulting `_meta.json` is identical to a serial
+run. Only a multi-segment model (a `ComposedModel` containing an
+`ImplicitUpdate`) benefits; a single-segment model ignores `-j`. With
+`--device cuda` each worker initializes its own CUDA context and invokes
+the CUDA compiler, so watch memory when raising `N`.
+
+The set of segments — and every file the compile will produce — can be
+enumerated ahead of time, without compiling, via
+`neml2.cli.aoti_export.plan_export_artifacts`. `neml2-compile` uses it to
+size the `[k/N]` per-file progress it prints as each `.pt2`, the
+`_meta.json`, and the `_aoti.i` stub is written.
+
 ## Stage 7 — Trace, lower, package
 
 Each segment routes through the project's `torch.export` adapter — a

--- a/neml2/cli/_compile_interactive.py
+++ b/neml2/cli/_compile_interactive.py
@@ -65,7 +65,23 @@ class FormState:
     rename_parameters: tuple[str, ...] = ()
     example_shape: tuple[str, ...] = ()  # raw --example-batch-shape entries
     dynamic_batch: bool | None = None  # None => emit neither flag
+    jobs: int = 1  # parallel compile processes (-j); 1 == serial
     load: tuple[str, ...] = ()  # --load extension modules
+
+
+@dataclass(frozen=True)
+class PlanSummary:
+    """The segment / artifact breakdown shown before choosing a process count.
+
+    ``segments`` is one ``(index, kind, basename, artifacts)`` tuple per compiled
+    segment; ``files`` is every file the compile will generate (each segment's
+    ``.pt2`` graphs, the ``_meta.json``, and the ``_aoti.i`` stub). Computed by
+    :func:`plan_summary` from the same planner the real compile uses, so the
+    preview matches what is produced.
+    """
+
+    segments: list[tuple[int, str, str, tuple[str, ...]]] = field(default_factory=list)
+    files: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -126,6 +142,11 @@ def build_compile_argv(state: FormState) -> list[str]:
 
     if state.dtype:
         argv += ["--dtype", state.dtype]
+
+    # Only emit -j when parallel; the default (serial, 1) is the CLI default, so
+    # omitting it keeps the previewed command clean.
+    if state.jobs > 1:
+        argv += ["-j", str(state.jobs)]
 
     for name in state.promoted:
         argv += ["-p", name]
@@ -193,7 +214,42 @@ def validate_state(state: FormState) -> list[str]:
         problems.append(f"A {state.target} name is required.")
     if not state.devices:
         problems.append("Select at least one device.")
+    if state.jobs < 1:
+        problems.append("Number of processes (-j) must be >= 1.")
     return problems
+
+
+def plan_summary(state: FormState) -> PlanSummary:
+    """Enumerate the segments + files a compile of *state* would generate.
+
+    Resolves a ``--driver`` target to its model, then runs the same
+    :func:`neml2.cli.aoti_export.plan_export_artifacts` planner the real compile
+    uses -- no ``.pt2`` is produced, so this is cheap (one model load + structural
+    analysis). Renames and the example batch shape are intentionally omitted: they
+    change neither the segment structure nor the artifact filenames, and skipping
+    them avoids spurious validation errors from a half-entered rename. The set is
+    device-independent, so it is planned on ``cpu``. Raises if the model can't be
+    loaded / planned; the caller (wizard) presents that as a muted note.
+    """
+    from .aoti_compile import driver_target_model  # noqa: PLC0415
+    from .aoti_export import plan_export_artifacts  # noqa: PLC0415
+
+    model_name = (
+        driver_target_model(Path(state.input_file), state.name)
+        if state.target == "driver"
+        else state.name
+    )
+    plan = plan_export_artifacts(
+        state.input_file,
+        model_name,
+        device="cpu",
+        promoted=list(state.promoted),
+        derivatives=tuple(state.derivatives),
+        dynamic_batch=state.dynamic_batch,
+    )
+    segments = [(s.index, s.kind, s.basename, tuple(s.predicted_artifacts)) for s in plan.segments]
+    files = (*plan.artifacts, f"{model_name}_aoti.i")
+    return PlanSummary(segments=segments, files=files)
 
 
 def list_section_entries(path: str | Path, section: str) -> list[tuple[str, str]]:
@@ -235,10 +291,12 @@ def list_driver_names(path: str | Path) -> list[str]:
 __all__ = [
     "FormState",
     "IntrospectionForm",
+    "PlanSummary",
     "build_compile_argv",
     "preview_command",
     "introspection_to_form",
     "validate_state",
+    "plan_summary",
     "list_section_entries",
     "list_model_names",
     "list_driver_names",

--- a/neml2/cli/_compile_wizard.py
+++ b/neml2/cli/_compile_wizard.py
@@ -55,9 +55,11 @@ import questionary
 from ._compile_interactive import (
     FormState,
     IntrospectionForm,
+    PlanSummary,
     build_compile_argv,
     introspection_to_form,
     list_section_entries,
+    plan_summary,
     preview_command,
     validate_state,
 )
@@ -75,6 +77,7 @@ _FIELDS: list[tuple[str, str]] = [
     ("output_dir", "Output dir"),
     ("example_shape", "Example batch shape"),
     ("dynamic_batch", "Dynamic batch"),
+    ("jobs", "Processes"),
 ]
 
 # Distinct sentinel for the edit menu's "back" choice. A questionary ``Choice``
@@ -102,6 +105,8 @@ _HELP: dict[str, str] = {
     "sub-batch axes, e.g. (2;100). Blank = default.",
     "dynamic_batch": "Let the leading batch dimension vary at runtime (vs. pinned to "
     "the example shape).",
+    "jobs": "How many segments to compile in parallel (spawn processes). Shows the "
+    "segments first; only a multi-segment model benefits.",
 }
 
 
@@ -191,6 +196,7 @@ def _default_state() -> dict:
         "output_dir": "./aoti",
         "example_shape": (),  # tuple of raw `--example-batch-shape` entries
         "dynamic_batch": True,
+        "jobs": 1,
     }
 
 
@@ -320,7 +326,72 @@ def _ask_field(field: str, input_file: str, state: dict, cache: dict) -> bool:
         state["dynamic_batch"] = bool(v)
         return True
 
+    if field == "jobs":
+        return _ask_jobs(input_file, state)
+
     raise ValueError(f"unknown field {field!r}")  # pragma: no cover -- defensive
+
+
+def _positive_int(text: str) -> bool | str:
+    """Questionary validator: accept a string that parses to an int >= 1."""
+    try:
+        return int(text.strip()) >= 1 or "Enter an integer >= 1."
+    except ValueError:
+        return "Enter an integer >= 1."
+
+
+def _print_segment_plan(summary: PlanSummary) -> None:
+    """Show the segments a compile will emit + the total file count."""
+    questionary.print(f"\nSegments to compile ({len(summary.segments)}):", style="bold")
+    for index, kind, basename, artifacts in summary.segments:
+        questionary.print(f"  [{index}] {kind:<8} {basename}")
+        questionary.print(f"        {', '.join(artifacts)}", style="fg:ansibrightblack")
+    questionary.print(
+        f"  + {len(summary.files)} file(s) total (incl. metadata + stub)", style="italic"
+    )
+
+
+def _ask_jobs(input_file: str, state: dict) -> bool:
+    """Show the segment plan, then ask how many processes to compile with.
+
+    A single-segment model has nothing to parallelize, so we note that and pin
+    ``jobs=1`` without prompting. Otherwise the count is capped for display at the
+    segment count (extra workers just idle)."""
+    try:
+        summary: PlanSummary | None = plan_summary(_form_state(input_file, state, ()))
+    except Exception as exc:  # noqa: BLE001
+        questionary.print(f"(could not compute the segment plan: {exc})", style="fg:ansired")
+        summary = None
+
+    n_seg = len(summary.segments) if summary else 0
+    if summary:
+        _print_segment_plan(summary)
+
+    if n_seg <= 1:
+        questionary.print(
+            "(single segment -- parallel compilation is not applicable; using 1 process)",
+            style="italic",
+        )
+        state["jobs"] = 1
+        return True
+
+    v = questionary.text(
+        f"Parallel compile processes (1 = serial; up to {n_seg} segments run concurrently):",
+        default=str(state.get("jobs", 1)),
+        validate=_positive_int,
+    ).ask()
+    if v is None:
+        return False
+    # Clamp to the segment count: extra processes would only sit idle (one task
+    # per segment), so the previewed -j reflects the useful maximum.
+    requested = max(1, int(v.strip()))
+    state["jobs"] = min(requested, n_seg)
+    if requested > n_seg:
+        questionary.print(
+            f"(capped at {n_seg}: there are only {n_seg} segments to compile)",
+            style="italic",
+        )
+    return True
 
 
 def _ask_example_shape(input_file: str, state: dict, cache: dict) -> bool:
@@ -447,6 +518,7 @@ def _form_state(input_file: str, state: dict, initial_load: tuple[str, ...]) -> 
         rename_parameters=_specs("parameters"),
         example_shape=tuple(state["example_shape"]),
         dynamic_batch=state["dynamic_batch"],
+        jobs=int(state.get("jobs", 1)),
         load=tuple(initial_load),
     )
 
@@ -472,6 +544,7 @@ def _print_review(fs: FormState) -> None:
         ("Output dir", fs.output_dir),
         ("Example shape", ", ".join(fs.example_shape) or "(none)"),
         ("Dynamic batch", "yes" if fs.dynamic_batch else "no"),
+        ("Processes", f"{fs.jobs} (serial)" if fs.jobs == 1 else f"{fs.jobs} (parallel)"),
     ]
     for label, value in rows:
         questionary.print(f"  {label:<14} {value}")

--- a/neml2/cli/aoti_compile.py
+++ b/neml2/cli/aoti_compile.py
@@ -132,6 +132,21 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Floating-point dtype for the artifact (baked at export time).",
     )
     parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "Compile independent segments in parallel using up to N worker "
+            "processes (spawn). Default 1 (serial). Only a multi-segment model "
+            "(a ComposedModel containing an ImplicitUpdate) benefits; "
+            "single-segment models ignore N, and N is capped at the number of "
+            "segments (one task per segment). With --device cuda each worker "
+            "spawns its own CUDA context and invokes nvcc -- watch memory."
+        ),
+    )
+    parser.add_argument(
         "-p",
         "--parameter",
         action="append",
@@ -244,6 +259,8 @@ def compile_and_emit_stub(
     renames: dict[str, dict[str, str]] | None = None,
     pre: tuple[str, ...] = (),
     additional_args: tuple[str, ...] = (),
+    jobs: int = 1,
+    progress_cb=None,
 ) -> Path:
     """Compile + emit stub in one call; return the stub path.
 
@@ -256,6 +273,10 @@ def compile_and_emit_stub(
     The intermediate ``model_name`` and the layout (``<output_dir>/<model>/<device>/``
     artifacts + a standalone ``<output_dir>/<model>_aoti.i`` stub) live entirely
     inside this function -- callers just run the returned stub path.
+
+    *jobs* (> 1) compiles independent segments concurrently; *progress_cb*, if
+    given, is invoked with the bare filename of every generated file (each
+    ``.pt2``, the ``_meta.json``, and finally the ``_aoti.i`` stub).
     """
     # Local import keeps the module import-light when only the helpers
     # below are needed.
@@ -288,6 +309,8 @@ def compile_and_emit_stub(
         renames=renames,
         pre=pre,
         additional_args=additional_args,
+        jobs=jobs,
+        progress_cb=progress_cb,
     )
     stub_path = output_dir / f"{model_name}_aoti.i"
     emit_aoti_stub(
@@ -297,6 +320,8 @@ def compile_and_emit_stub(
         stub_path,
         keep_drivers=(driver is not None),
     )
+    if progress_cb is not None:
+        progress_cb(stub_path.name)
     return stub_path
 
 
@@ -668,10 +693,51 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
+    if args.jobs < 1:
+        parser.error("--jobs must be >= 1")
+
     # One complete artifact per device, each in its own device-named subfolder
     # (<model>/cpu/, <model>/cuda/). De-dupe while preserving order so
     # `--device cpu cpu` doesn't compile twice.
     devices = list(dict.fromkeys(args.device))
+
+    # Enumerate every file the compile will generate so progress can report
+    # [k/N]. The artifact set is device-independent, so a single plan (on cpu, to
+    # avoid initializing CUDA in the parent) sizes the whole multi-device run;
+    # the trailing +1 is the standalone `_aoti.i` stub emitted once at the end.
+    from neml2.cli.aoti_export import plan_export_artifacts  # noqa: PLC0415
+
+    try:
+        plan = plan_export_artifacts(
+            input_path,
+            model_name,
+            device="cpu",
+            promoted=set(args.parameter),
+            example_batch_shape=example_batch_shape,
+            dynamic_batch=args.dynamic_batch,
+            derivatives=tuple(args.derivative),
+            renames=renames,
+            additional_args=tuple(additional_args),
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error planning '{model_name}': {exc}", file=sys.stderr)
+        return 1
+    total_files = plan.total * len(devices) + 1  # per-device artifacts + the stub
+
+    _progress = {"k": 0}
+
+    def progress_cb(name: str) -> None:
+        _progress["k"] += 1
+        print(f"[{_progress['k']}/{total_files}] {name}", file=sys.stderr)
+
+    if args.jobs > 1 and "cuda" in devices:
+        print(
+            f"neml2-compile: warning: -j{args.jobs} with --device cuda spawns "
+            f"{args.jobs} worker processes, each initializing its own CUDA context "
+            "and invoking nvcc; watch GPU/host memory (consider -j1 for cuda).",
+            file=sys.stderr,
+        )
+
     compiled: list[tuple[str, Path]] = []
     meta: dict = {}
     for device in devices:
@@ -690,6 +756,8 @@ def main(argv: list[str] | None = None) -> int:
                 derivatives=tuple(args.derivative),
                 renames=renames,
                 additional_args=tuple(additional_args),
+                jobs=args.jobs,
+                progress_cb=progress_cb,
             )
         except Exception as exc:  # noqa: BLE001
             print(f"Error compiling '{model_name}' for {device}: {exc}", file=sys.stderr)
@@ -709,6 +777,7 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as exc:  # noqa: BLE001
         print(f"Error emitting stub: {exc}", file=sys.stderr)
         return 1
+    progress_cb(stub_path.name)
 
     n_promoted = len(args.parameter)
     bake_note = "fully baked" if n_promoted == 0 else f"{n_promoted} promoted parameter(s)"

--- a/neml2/cli/aoti_export.py
+++ b/neml2/cli/aoti_export.py
@@ -58,7 +58,8 @@ CLI
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from math import prod
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -1550,6 +1551,20 @@ def _build_example_inputs(
     return tuple(examples)
 
 
+def _report(progress_cb: Callable[[str], None] | None, name: str) -> None:
+    """Fire the per-file progress callback for a just-generated artifact, if set.
+
+    *name* is the bare filename (``<basename>.pt2`` / ``<model>_meta.json`` /
+    ``<model>_aoti.i``) the caller just wrote. The single-argument callback is
+    threaded from :func:`export_model_for_aoti` (and the CLI) so every generated
+    file -- ``.pt2``, ``.json``, and ``.i`` -- is reported through one channel.
+    ``None`` (the default everywhere) is a no-op, preserving the silent library
+    behavior.
+    """
+    if progress_cb is not None:
+        progress_cb(name)
+
+
 def _compile_forward_segment(
     model,
     pkg_basename: str,
@@ -1561,6 +1576,7 @@ def _compile_forward_segment(
     shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] | None = None,
     dynamic_batch: bool = True,
     selected_pairs: set[tuple[str, str]] | None = None,
+    progress_cb: Callable[[str], None] | None = None,
 ) -> tuple[str, list[dict], list[dict], str | None, list[str], list[dict] | None]:
     """Compile a single forward-shape model to ``<pkg_basename>.pt2`` plus,
     when derivatives are requested, ``<pkg_basename>_jvp.pt2`` carrying the
@@ -1609,6 +1625,7 @@ def _compile_forward_segment(
 
     pkg_name = f"{pkg_basename}.pt2"
     compile_model(exportable, example_inputs, output_dir / pkg_name, dynamic_batch_dim=dynamic_dim)
+    _report(progress_cb, pkg_name)
 
     jvp_pkg_name: str | None = None
     jacobian_pairs: list[dict] | None = None
@@ -1649,6 +1666,7 @@ def _compile_forward_segment(
             compile_model(
                 jvp_module, example_inputs, output_dir / jvp_pkg_name, dynamic_batch_dim=dynamic_dim
             )
+        _report(progress_cb, jvp_pkg_name)
         # Per-(out_var, in_var) pair metadata in the SAME order the JVP
         # module emits trailing tensors: rows-outer (output_spec order),
         # cols-inner (structural inputs in input_spec order).
@@ -1828,6 +1846,7 @@ def _compile_param_jacobian(
     selected_param_pairs: set[tuple[str, str]],
     shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] | None = None,
     dynamic_batch: bool = True,
+    progress_cb: Callable[[str], None] | None = None,
 ) -> tuple[str, list[dict]]:
     """Compile the parameter-Jacobian graph to ``<pkg_basename>_pjac.pt2``.
 
@@ -1883,6 +1902,7 @@ def _compile_param_jacobian(
     _compile_param_derivative_graph(
         module, example_inputs, output_dir / pkg_name, dynamic_batch_dim=dynamic_dim
     )
+    _report(progress_cb, pkg_name)
 
     # Per-(out_var, param) metadata in the SAME order the module emits blocks:
     # outputs outer (output_spec order), promoted params inner (input_spec order).
@@ -1913,6 +1933,7 @@ def _compile_param_vjp(
     selected_params: set[str],
     shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] | None = None,
     dynamic_batch: bool = True,
+    progress_cb: Callable[[str], None] | None = None,
 ) -> tuple[str, list[str], list[str]]:
     """Compile the parameter VJP / adjoint graph to ``<pkg_basename>_pvjp.pt2``.
 
@@ -1974,94 +1995,9 @@ def _compile_param_vjp(
     _compile_param_derivative_graph(
         module, example_inputs, output_dir / pkg_name, dynamic_batch_dim=dynamic_dim
     )
+    _report(progress_cb, pkg_name)
 
     return pkg_name, list(module.param_names), list(out_spec)
-
-
-def _export_forward(
-    model,
-    model_name: str,
-    output_dir: Path,
-    device: str,
-    *,
-    promoted_qnames: set[str],
-    promoted_snapshots: dict[str, torch.Tensor],
-    shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] | None = None,
-    dynamic_batch: bool = True,
-    derivatives: set[tuple[str, str]] | None = None,
-    param_derivatives: set[tuple[str, str]] | None = None,
-) -> dict:
-    """Export a forward-shape model as a single-segment composed artifact.
-
-    *derivatives* is the resolved master ``(out, in)`` pair set (empty = no
-    derivative graph). For a single forward segment the master pairs *are* the
-    segment-local pairs, so they pass straight through as ``selected_pairs``.
-    """
-    (
-        pkg_name,
-        in_infos,
-        out_infos,
-        jvp_pkg_name,
-        param_inputs,
-        jacobian_pairs,
-    ) = _compile_forward_segment(
-        model,
-        model_name,
-        output_dir,
-        device,
-        promoted_qnames=promoted_qnames,
-        promoted_snapshots=promoted_snapshots,
-        shapes=shapes,
-        dynamic_batch=dynamic_batch,
-        selected_pairs=derivatives if derivatives is not None else set(),
-    )
-    seg = {
-        "kind": "forward",
-        "package": pkg_name,
-        "inputs": _segment_var_infos(in_infos),
-        "outputs": _segment_var_infos(out_infos),
-        "param_inputs": param_inputs,
-    }
-    if jvp_pkg_name is not None:
-        seg["jvp_package"] = jvp_pkg_name
-        seg["jacobian_pairs"] = jacobian_pairs
-    if param_derivatives:
-        pjac_pkg, param_jac_pairs = _compile_param_jacobian(
-            model,
-            model_name,
-            output_dir,
-            device,
-            promoted_qnames=promoted_qnames,
-            promoted_snapshots=promoted_snapshots,
-            selected_param_pairs=param_derivatives,
-            shapes=shapes,
-            dynamic_batch=dynamic_batch,
-        )
-        seg["param_jacobian_package"] = pjac_pkg
-        seg["param_jacobian_pairs"] = param_jac_pairs
-        # Also emit the adjoint (VJP) graph -- dL/d(param) for a loss defined by
-        # output cotangents -- the cheaper form for many-parameter optimization.
-        pvjp_pkg, pvjp_params, pvjp_outputs = _compile_param_vjp(
-            model,
-            model_name,
-            output_dir,
-            device,
-            promoted_qnames=promoted_qnames,
-            promoted_snapshots=promoted_snapshots,
-            selected_params={p for (_, p) in param_derivatives},
-            shapes=shapes,
-            dynamic_batch=dynamic_batch,
-        )
-        seg["param_vjp_package"] = pvjp_pkg
-        seg["param_vjp_params"] = pvjp_params
-        seg["param_vjp_outputs"] = pvjp_outputs
-    return {
-        "schema_version": AOTI_META_SCHEMA_VERSION,
-        "type": "composed",
-        "inputs": in_infos,
-        "outputs": out_infos,
-        "segments": [seg],
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -2082,6 +2018,7 @@ def _compile_implicit_segment(
     promoted_qnames: set[str] | None = None,
     promoted_snapshots: dict[str, torch.Tensor] | None = None,
     selected_param_pairs: set[tuple[str, str]] | None = None,
+    progress_cb: Callable[[str], None] | None = None,
 ) -> dict:
     """Compile an ImplicitUpdate to ``<pkg_basename>_rhs.pt2`` + ``_step.pt2``
     (+ ``_ift.pt2`` when *emit_ift*) (+ ``_pift.pt2`` when *selected_param_pairs*)
@@ -2236,7 +2173,9 @@ def _compile_implicit_segment(
     uses_ad = _model_uses_request_ad(system.model)
     _compile_jac = _compile_param_derivative_graph if uses_ad else compile_model
     compile_model(rhs, example_inputs, output_dir / rhs_name, dynamic_batch_dim=dynamic_dim)
+    _report(progress_cb, rhs_name)
     _compile_jac(step, example_inputs, output_dir / step_name, dynamic_batch_dim=dynamic_dim)
+    _report(progress_cb, step_name)
     # Per-(unknown, given) pair metadata for the IFT graph. The IFT emits one
     # block per variable pair (via AssembledMatrix.disassemble), in
     # ift.emitted_pairs() order, so the C++ runtime composes them against
@@ -2260,6 +2199,7 @@ def _compile_implicit_segment(
             for (u, g) in ift.emitted_pairs()
         ]
         _compile_jac(ift, example_inputs, output_dir / ift_name, dynamic_batch_dim=dynamic_dim)
+        _report(progress_cb, ift_name)
 
     # Per-(unknown, param) parameter-Jacobian graph (ParamIFT). Emits one dense
     # ``du/dθ`` block per requested ``(unknown, param)`` pair, in
@@ -2282,6 +2222,7 @@ def _compile_implicit_segment(
         _compile_param_derivative_graph(
             pift, pift_example_inputs, output_dir / pift_name, dynamic_batch_dim=dynamic_dim
         )
+        _report(progress_cb, pift_name)
 
     # Per-variable infos retained at the segment level as the source of
     # truth for the C++ runtime's per-variable state map (predictor
@@ -2354,75 +2295,12 @@ def _compile_implicit_segment(
         compile_model(
             pred_exportable, pred_inputs, output_dir / pred_name, dynamic_batch_dim=dynamic_dim
         )
+        _report(progress_cb, pred_name)
         seg["predictor_package"] = pred_name
         seg["predictor_inputs"] = _segment_var_infos(pred.input_spec)
         seg["predictor_outputs"] = _segment_var_infos(pred.output_spec)
 
     return seg
-
-
-def _export_implicit(
-    model,
-    inner,
-    model_name: str,
-    output_dir: Path,
-    device: str,
-    *,
-    promoted_qnames: set[str],
-    promoted_snapshots: dict[str, torch.Tensor] | None = None,
-    shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] | None = None,
-    dynamic_batch: bool = True,
-    derivatives: set[tuple[str, str]] | None = None,
-    param_derivatives: set[tuple[str, str]] | None = None,
-) -> dict:
-    """Export an ImplicitUpdate as a single-segment composed artifact.
-
-    Promoted parameters living inside the residual are threaded through the
-    segment's graphs (schema v7); ``promoted_qnames`` also filters the metadata's
-    master ``inputs``.
-
-    *derivatives* is the resolved master ``(out, in)`` pair set; the single
-    implicit segment emits its IFT graph iff any structural pair was requested
-    (the IFT couples every given to every unknown). *param_derivatives* is the
-    resolved master ``(out, param)`` pair set; the segment emits its ParamIFT
-    graph iff any was requested. For a single ImplicitUpdate the outputs are the
-    unknowns, so both map to local pairs by a direct filter.
-    """
-    master_pairs = derivatives or set()
-    param_pairs = param_derivatives or set()
-    sys = inner.system
-    selected_ift_pairs = {
-        (o, i) for (o, i) in master_pairs if o in sys.unknown_names and i in sys.given_names
-    }
-    # Local (unknown, param) pairs: the output is an unknown and the "input" is a
-    # promoted parameter inside the residual.
-    selected_param_pairs = {
-        (o, p) for (o, p) in param_pairs if o in sys.unknown_names and p in promoted_qnames
-    }
-    seg = _compile_implicit_segment(
-        inner,
-        model_name,
-        output_dir,
-        device,
-        shapes=shapes,
-        dynamic_batch=dynamic_batch,
-        emit_ift=bool(selected_ift_pairs),
-        selected_ift_pairs=selected_ift_pairs,
-        promoted_qnames=promoted_qnames,
-        promoted_snapshots=promoted_snapshots,
-        selected_param_pairs=selected_param_pairs,
-    )
-    structural_in = _structural_inputs(model.input_spec, promoted_qnames)
-    in_sb = {n: sub for n, (_, sub) in (shapes or {}).items() if sub}
-    # Output labels mirror unknowns' labels (each output is an unknown that
-    # inherits sub_batch_labels from its history input via _solve).
-    return {
-        "schema_version": AOTI_META_SCHEMA_VERSION,
-        "type": "composed",
-        "inputs": _var_infos(structural_in, sub_batch_shapes=in_sb),
-        "outputs": _var_infos(model.output_spec),
-        "segments": [{"kind": "implicit", **seg}],
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -2481,51 +2359,71 @@ def _partition_into_segments(model):
     return segments
 
 
-def _export_composed(
-    model,
-    model_name: str,
-    output_dir: Path,
-    device: str,
-    *,
-    promoted_qnames: set[str],
-    promoted_snapshots: dict[str, torch.Tensor],
-    shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] | None = None,
-    dynamic_batch: bool = True,
-    derivatives: set[tuple[str, str]] | None = None,
-    param_derivatives: set[tuple[str, str]] | None = None,
-) -> dict:
-    """Export a ComposedModel containing ImplicitUpdate children as multiple
-    .pt2 artifacts.
+@dataclass
+class _Reachability:
+    """Per-segment dependency reachability for the derivative-graph prune.
 
-    Each non-implicit run of leaves becomes one forward segment .pt2; each
-    ImplicitUpdate becomes the standard rhs/step (+ optional predictor) set.
-    The C++ ``AOTIModel`` orchestrates the segments in order.
-
-    *derivatives* is the resolved master ``(out, in)`` pair set. Forward
-    segments emit only the local pairs that lie on a dependency path between a
-    requested master input and a requested master output (a forward segment with
-    no such pair emits no derivative graph); an implicit segment emits its IFT
-    graph iff it lies on any requested path. Correctness gate: a local pair is
-    kept whenever its row reaches a requested output AND its column is reachable
-    from a requested input — never dropping a pair that carries a requested
-    sensitivity. Empty *derivatives* → no derivative graphs anywhere.
-
-    *param_derivatives* is the resolved master ``(out, param)`` pair set for
-    parameters promoted inside the segments (the multi-segment parameter
-    Jacobian). A promoted parameter enters the dataflow at its OWN segment's
-    outputs (forward: ``param_jacobian`` graph; implicit: ``ParamIFT`` graph),
-    and its sensitivity must then PROPAGATE through every downstream segment to
-    the requested master output. So each segment additionally compiles its jvp /
-    IFT propagation graph for any local pair whose column carries a requested
-    parameter sensitivity (``param_reach``) and whose row reaches a requested
-    output -- the C++ ``_param_jacobian_dstate`` carrier composes the direct
-    (param-graph) and indirect (jvp/IFT) contributions segment by segment.
+    ``reach[V]`` = master (structural) inputs that can flow into V; ``canreach
+    [V]`` = master outputs V can reach; ``param_reach[V]`` = requested promoted
+    params whose sensitivity reaches V. Each segment is modelled as "every
+    output depends on every input" (the all-pairs internal Jacobian; an implicit
+    segment's IFT couples every given to every unknown) -- the correct
+    conservative data-flow model. The ``keep_*`` predicates decide, per local
+    ``(out, in)`` / ``(out, param)`` pair, whether that block must be compiled.
+    Built once by :func:`_segment_reachability` and shared by both the planner
+    (artifact prediction) and the executor (which pairs to emit) so the two can
+    never drift.
     """
-    from ..models.common import ComposedModel, ImplicitUpdate
 
-    segments = _partition_into_segments(model)
-    master_pairs = derivatives or set()
-    param_pairs = param_derivatives or set()
+    segments: list
+    seg_input_sets: list[set[str]]
+    seg_output_sets: list[set[str]]
+    downstream_demands: list[set[str]]
+    seg_direct_params: list[set[str]]
+    master_outs: set[str]
+    reach: dict[str, set[str]]
+    canreach: dict[str, set[str]]
+    param_reach: dict[str, set[str]]
+    master_pairs: set[tuple[str, str]]
+    param_pairs: set[tuple[str, str]]
+
+    def keep_local_pair(self, o: str, i: str) -> bool:
+        """A local pair ``(o, i)`` carries a requested master sensitivity iff its
+        column is reachable from a requested input AND its row reaches a
+        requested output."""
+        return any(
+            (i_m in self.reach.get(i, ())) and (o_m in self.canreach.get(o, ()))
+            for (o_m, i_m) in self.master_pairs
+        )
+
+    def keep_param_prop(self, o: str, i: str) -> bool:
+        """A jvp / IFT local pair ``(o, i)`` must be compiled when its column
+        ``i`` carries a requested parameter sensitivity needed at a requested
+        output reachable from ``o``."""
+        return any(
+            (p in self.param_reach.get(i, ())) and (o_m in self.canreach.get(o, ()))
+            for (o_m, p) in self.param_pairs
+        )
+
+    def keep_param_pair(self, o: str, p: str) -> bool:
+        """A direct param-graph pair ``(o, p)``: keep when ``o`` reaches a
+        requested master output paired with parameter ``p``."""
+        return any(o_m in self.canreach.get(o, ()) for (o_m, pp) in self.param_pairs if pp == p)
+
+
+def _segment_reachability(
+    model,
+    segments,
+    promoted_qnames: set[str],
+    master_pairs: set[tuple[str, str]],
+    param_pairs: set[tuple[str, str]],
+) -> _Reachability:
+    """Compute the :class:`_Reachability` bundle for a partitioned composed model.
+
+    Factored out of the old ``_export_composed`` so the planner and executor
+    share one copy of the reachability math (single source of truth -- no drift
+    between predicted and produced derivative graphs).
+    """
     requested_params = {p for (_, p) in param_pairs}
 
     # Each segment's ComposedModel wrapper would otherwise hide variables that
@@ -2558,14 +2456,6 @@ def _export_composed(
             downstream_demands[i] |= inputs_j
     master_outs = set(model.output_spec)
 
-    # --- Dependency reachability for the per-segment derivative prune ---
-    # ``reach[V]`` = master (structural) inputs that can flow into V; ``canreach
-    # [V]`` = master outputs V can reach. Each segment is modelled as "every
-    # output depends on every input" (the all-pairs internal Jacobian; an
-    # implicit segment's IFT couples every given to every unknown), which is the
-    # correct conservative data-flow model. A local pair (o, i) carries a
-    # requested master sensitivity (o_m, i_m) iff ``i_m ∈ reach[i]`` and
-    # ``o_m ∈ canreach[o]`` — keep it iff that holds for some requested pair.
     structural_master_in = set(_structural_inputs(model.input_spec, promoted_qnames))
     reach: dict[str, set[str]] = {i: {i} for i in structural_master_in}
     for sin, sout in zip(seg_input_sets, seg_output_sets, strict=True):
@@ -2582,16 +2472,9 @@ def _export_composed(
         for x in sin:
             canreach[x] = canreach.get(x, set()) | reachable
 
-    def _keep_local_pair(o: str, i: str) -> bool:
-        return any(
-            (i_m in reach.get(i, ())) and (o_m in canreach.get(o, ()))
-            for (o_m, i_m) in master_pairs
-        )
-
-    # --- Parameter reachability for the multi-segment param Jacobian ---
     # Which requested promoted parameters live directly in each segment (after
-    # promotion + _rebuild_after_promotion, the qname appears in that
-    # segment's model.input_spec).
+    # promotion + _rebuild_after_promotion, the qname appears in that segment's
+    # model.input_spec).
     def _seg_direct_params(payload: object) -> set[str]:
         if isinstance(payload, list):
             return {p for p in requested_params for leaf in payload if p in leaf.input_spec}
@@ -2602,150 +2485,675 @@ def _export_composed(
     # ``param_reach[V]`` = requested promoted params whose sensitivity reaches V.
     # Forward pass mirroring ``reach``: a segment's outputs inherit the union of
     # its inputs' param_reach (indirect) plus the params promoted directly in
-    # that segment (direct, conservative all-outputs model -- same all-pairs
-    # assumption ``reach`` uses).
+    # that segment (direct, conservative all-outputs model).
     param_reach: dict[str, set[str]] = {}
     for sin, sout, direct in zip(seg_input_sets, seg_output_sets, seg_direct_params, strict=True):
-        flowed: set[str] = set(direct)
+        flowed = set(direct)
         for x in sin:
             flowed |= param_reach.get(x, set())
         for o in sout:
             param_reach[o] = param_reach.get(o, set()) | flowed
 
-    def _keep_param_prop(o: str, i: str) -> bool:
-        """A jvp / IFT local pair (o, i) must be compiled when its column ``i``
-        carries a requested parameter sensitivity needed at a requested output
-        reachable from ``o``."""
-        return any(
-            (p in param_reach.get(i, ())) and (o_m in canreach.get(o, ()))
-            for (o_m, p) in param_pairs
+    return _Reachability(
+        segments=segments,
+        seg_input_sets=seg_input_sets,
+        seg_output_sets=seg_output_sets,
+        downstream_demands=downstream_demands,
+        seg_direct_params=seg_direct_params,
+        master_outs=master_outs,
+        reach=reach,
+        canreach=canreach,
+        param_reach=param_reach,
+        master_pairs=master_pairs,
+        param_pairs=param_pairs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model preparation (the shared setup prelude)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PreparedExport:
+    """The result of :func:`_prepare_export` -- a model made ready to compile,
+    plus every resolved option a segment compile / plan needs.
+
+    Deterministic in ``(input file, options, device)``: the same inputs always
+    yield the same bundle, which is what lets a spawned worker re-derive its
+    assigned segment from scratch (:func:`_compile_segment_worker`) instead of
+    receiving an unpicklable live ``nn.Module`` from the parent.
+    """
+
+    model: Model
+    promoted_qnames: set[str]
+    promoted_snapshots: dict[str, torch.Tensor]
+    origin: dict[str, str]
+    promoted_base_shapes: dict[str, tuple[int, ...]]
+    resolved_shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]]
+    dynamic_batch: bool
+    master_pairs: set[tuple[str, str]]
+    param_pairs: set[tuple[str, str]]
+    boundary_aliases: dict[str, dict[str, str]]
+    structural_input_names: list[str]
+
+
+def _prepare_export(
+    hit_path: str | Path,
+    model_name: str,
+    *,
+    device: str = "cpu",
+    promoted: set[str] | list[str] | tuple[str, ...] = (),
+    example_batch_shape: dict[str, str] | str | None = None,
+    dynamic_batch: bool | None = None,
+    derivatives: Sequence[str] = (),
+    renames: dict[str, dict[str, str]] | None = None,
+    pre: Sequence[str] = (),
+    additional_args: tuple[str, ...] = (),
+) -> _PreparedExport:
+    """Load a model and run the full pre-compile prelude, returning a
+    :class:`_PreparedExport`.
+
+    This is the setup shared by every export path: it loads the model, wraps a
+    bare forward leaf in a ``ComposedModel`` (so promoted names live in the eager
+    namespace), resolves example shapes, promotes parameters + rebuilds the
+    spec-caching containers, resolves ``-d`` derivative specs, validates boundary
+    renames, freezes leftover parameters to buffers, checks baked-shape
+    conflicts, and seeds every implicit sub-batch layout. No ``.pt2`` is
+    produced -- the expensive ``compile_model`` calls happen later, in
+    :func:`_execute_segment_plan`.
+
+    ``device`` is threaded through because :func:`_seed_implicit_subbatch` builds
+    device-resident stand-in tensors; the bundle is therefore device-specific and
+    must be rebuilt per device (never cached across devices).
+    """
+    from ..factory import load_input
+    from ..models.common import ComposedModel
+
+    factory = load_input(hit_path, pre=pre, additional_args=additional_args)
+    model = factory.get_model(model_name)
+
+    # Wrap a bare (non-composed) forward leaf up-front -- BEFORE promotion -- so
+    # promoted parameter names live in the SAME namespace the eager runtime
+    # reports. ImplicitUpdate / composed-with-implicit models keep their dedicated
+    # export path + namespace; an already-composed model is left untouched.
+    if not isinstance(model, ComposedModel) and not _contains_implicit(model):
+        model = ComposedModel([model])
+
+    # Resolve example-batch-shape declarations: kwarg wins, then HIT [Settings],
+    # then the (2,)/uniform default.
+    settings_shapes, settings_dyn = _read_settings(factory)
+    if isinstance(example_batch_shape, str):
+        declared = {"*": example_batch_shape}
+    elif isinstance(example_batch_shape, dict):
+        declared = dict(example_batch_shape)
+    else:
+        declared = settings_shapes
+    if dynamic_batch is None:
+        dynamic_batch = settings_dyn
+    resolved_shapes = _resolve_example_shapes(model.input_spec, declared)
+
+    # Validate / resolve promoted names against the live model BEFORE any
+    # ComposedModel wrapping. Snapshot the initial values now too.
+    promoted_set = set(promoted)
+    promoted_names, origin = _validate_promoted(model, promoted_set)
+    promoted_snapshots = _snapshot_promoted(model, promoted_names)
+
+    # Route each promoted parameter through the leaf's PromotedParam machinery.
+    promo_info = _promote_parameters(model, promoted_names)
+    promoted_qnames = set(promoted_names)
+    promoted_base_shapes = {q: tuple(cls.BASE_SHAPE) for q, (cls, _h, _l) in promo_info.items()}
+
+    # Rebuild every spec-caching container so promoted parameters route correctly.
+    if promoted_names:
+        model = _rebuild_after_promotion(model)
+
+    # Resolve -d/--derivative specs into the master (out, in) / (out, param) pairs.
+    structural_input_names = list(_structural_inputs(model.input_spec, promoted_qnames))
+    master_pairs, param_pairs = _resolve_derivative_specs(
+        derivatives,
+        list(model.output_spec),
+        structural_input_names,
+        param_names=sorted(promoted_qnames),
+    )
+
+    # Validate + normalize boundary renames against the post-promotion namespaces.
+    boundary_aliases = _validate_renames(
+        renames,
+        input_names=structural_input_names,
+        output_names=list(model.output_spec),
+        param_names=sorted(promoted_qnames),
+    )
+
+    # Freeze any remaining nn.Parameter to a persistent buffer so torch.export
+    # bakes it into the graph instead of lifting it as a graph input.
+    _freeze_remaining_parameters_to_buffers(model)
+
+    # Catch baked-parameter shape conflicts before torch.export does.
+    if dynamic_batch:
+        _validate_baked_against_shapes(model, resolved_shapes, promoted_qnames)
+
+    # Populate per-variable sub_batch_shape on every inner ModelNonlinearSystem.
+    _seed_implicit_subbatch(model, resolved_shapes, device)
+
+    return _PreparedExport(
+        model=model,
+        promoted_qnames=promoted_qnames,
+        promoted_snapshots=promoted_snapshots,
+        origin=origin,
+        promoted_base_shapes=promoted_base_shapes,
+        resolved_shapes=resolved_shapes,
+        dynamic_batch=dynamic_batch,
+        master_pairs=master_pairs,
+        param_pairs=param_pairs,
+        boundary_aliases=boundary_aliases,
+        structural_input_names=structural_input_names,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Segment planning + execution
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SegmentPlan:
+    """One compilable segment: what it is, what it will emit, and how to build it.
+
+    ``predicted_artifacts`` (ordered ``.pt2`` filenames) is picklable and is the
+    only field a spawned worker needs from the parent (for the progress
+    denominator). The execution fields (``seg_model`` / ``impl_model`` /
+    ``selected_*``) hold live objects used only in-process by
+    :func:`_execute_segment_plan`; a worker rebuilds them by re-running the
+    planner on its own re-derived model.
+    """
+
+    index: int
+    kind: str  # "forward" | "implicit"
+    basename: str
+    predicted_artifacts: list[str]
+    single_forward_pvjp: bool = False
+    seg_model: object = None
+    impl_model: object = None
+    selected_pairs: set[tuple[str, str]] | None = None
+    selected_param_pairs: set[tuple[str, str]] | None = None
+    selected_ift_pairs: set[tuple[str, str]] | None = None
+
+
+def _predict_forward_artifacts(
+    basename: str,
+    selected_pairs: set[tuple[str, str]] | None,
+    selected_param_pairs: set[tuple[str, str]] | None,
+    *,
+    single_forward_pvjp: bool,
+) -> list[str]:
+    """Ordered ``.pt2`` names a forward segment emits -- mirrors, in emission
+    order, the ``compile_model`` calls in :func:`_compile_forward_segment` (+ the
+    param-Jacobian / VJP helpers). The pvjp graph is emitted ONLY for the lone
+    forward segment of a forward-only model (``single_forward_pvjp``)."""
+    arts = [f"{basename}.pt2"]
+    # jvp: emitted when pairs are None (all) or a non-empty selection.
+    if selected_pairs is None or len(selected_pairs) > 0:
+        arts.append(f"{basename}_jvp.pt2")
+    if selected_param_pairs:
+        arts.append(f"{basename}_pjac.pt2")
+        if single_forward_pvjp:
+            arts.append(f"{basename}_pvjp.pt2")
+    return arts
+
+
+def _predict_implicit_artifacts(
+    basename: str,
+    *,
+    emit_ift: bool,
+    emit_pift: bool,
+    has_predictor: bool,
+) -> list[str]:
+    """Ordered ``.pt2`` names an implicit segment emits -- mirrors, in emission
+    order, the ``compile_model`` calls in :func:`_compile_implicit_segment`."""
+    arts = [f"{basename}_rhs.pt2", f"{basename}_step.pt2"]
+    if emit_ift:
+        arts.append(f"{basename}_ift.pt2")
+    if emit_pift:
+        arts.append(f"{basename}_pift.pt2")
+    if has_predictor:
+        arts.append(f"{basename}_predictor.pt2")
+    return arts
+
+
+def _plan_segments(prepared: _PreparedExport, model_name: str) -> list[_SegmentPlan]:
+    """Partition *prepared*'s model into an ordered list of :class:`_SegmentPlan`.
+
+    Unifies all three model shapes -- forward-only (one forward segment named
+    ``model_name``), a single ``ImplicitUpdate`` (one implicit segment named
+    ``model_name``), and a ``ComposedModel`` containing implicit children (one
+    segment per partition, named ``model_name_seg{i}``). The derivative-graph
+    selection uses the shared :func:`_segment_reachability`, so the predicted
+    artifacts exactly match what :func:`_execute_segment_plan` will produce.
+    """
+    from ..models.common import ComposedModel, ImplicitUpdate
+
+    model = prepared.model
+    promoted_qnames = prepared.promoted_qnames
+    master_pairs = prepared.master_pairs
+    param_pairs = prepared.param_pairs
+    inner = model
+
+    # Single ImplicitUpdate: one implicit segment. For a single ImplicitUpdate
+    # the outputs are the unknowns, so master pairs map to local pairs directly.
+    if isinstance(inner, ImplicitUpdate):
+        isys = inner.system
+        selected_ift_pairs = {
+            (o, i) for (o, i) in master_pairs if o in isys.unknown_names and i in isys.given_names
+        }
+        selected_param_pairs = {
+            (o, p) for (o, p) in param_pairs if o in isys.unknown_names and p in promoted_qnames
+        }
+        arts = _predict_implicit_artifacts(
+            model_name,
+            emit_ift=bool(selected_ift_pairs),
+            emit_pift=bool(selected_param_pairs),
+            has_predictor=inner.predictor is not None,
         )
+        return [
+            _SegmentPlan(
+                index=0,
+                kind="implicit",
+                basename=model_name,
+                predicted_artifacts=arts,
+                impl_model=inner,
+                selected_ift_pairs=selected_ift_pairs,
+                selected_param_pairs=selected_param_pairs,
+            )
+        ]
 
-    def _keep_param_pair(o: str, p: str) -> bool:
-        """A direct param-graph pair (o, p): keep when ``o`` reaches a requested
-        master output paired with parameter ``p``."""
-        return any(o_m in canreach.get(o, ()) for (o_m, pp) in param_pairs if pp == p)
+    # ComposedModel containing ImplicitUpdate children: one segment per partition.
+    if _contains_implicit(inner):
+        segments = _partition_into_segments(model)
+        reach = _segment_reachability(model, segments, promoted_qnames, master_pairs, param_pairs)
+        plans: list[_SegmentPlan] = []
+        for i, (kind, payload) in enumerate(segments):
+            basename = f"{model_name}_seg{i}"
+            if kind == "forward":
+                # Wrap the segment's leaves in a fresh ComposedModel so the
+                # dependency resolver derives its specs from the leaves' own
+                # specs. (.to(device) is deferred to _compile_forward_segment.)
+                assert isinstance(payload, list)
+                needed = (reach.master_outs | reach.downstream_demands[i]) & reach.seg_output_sets[
+                    i
+                ]
+                extra = sorted(needed)
+                seg_model = ComposedModel(payload, additional_outputs=extra)
+                seg_struct_in = _structural_inputs(seg_model.input_spec, promoted_qnames)
+                seg_selected = {
+                    (o, si)
+                    for o in seg_model.output_spec
+                    for si in seg_struct_in
+                    if reach.keep_local_pair(o, si) or reach.keep_param_prop(o, si)
+                }
+                seg_param_pairs = {
+                    (o, p)
+                    for o in seg_model.output_spec
+                    for p in reach.seg_direct_params[i]
+                    if reach.keep_param_pair(o, p)
+                }
+                arts = _predict_forward_artifacts(
+                    basename, seg_selected, seg_param_pairs, single_forward_pvjp=False
+                )
+                plans.append(
+                    _SegmentPlan(
+                        index=i,
+                        kind="forward",
+                        basename=basename,
+                        predicted_artifacts=arts,
+                        seg_model=seg_model,
+                        selected_pairs=seg_selected,
+                        selected_param_pairs=seg_param_pairs,
+                    )
+                )
+            else:
+                impl_model = payload
+                assert isinstance(impl_model, ImplicitUpdate)
+                isys = impl_model.system
+                selected_ift_pairs = {
+                    (u, g)
+                    for u in isys.unknown_names
+                    for g in isys.given_names
+                    if reach.keep_local_pair(u, g) or reach.keep_param_prop(u, g)
+                }
+                selected_param_pairs = {
+                    (u, p)
+                    for u in isys.unknown_names
+                    for p in reach.seg_direct_params[i]
+                    if reach.keep_param_pair(u, p)
+                }
+                arts = _predict_implicit_artifacts(
+                    basename,
+                    emit_ift=bool(selected_ift_pairs),
+                    emit_pift=bool(selected_param_pairs),
+                    has_predictor=impl_model.predictor is not None,
+                )
+                plans.append(
+                    _SegmentPlan(
+                        index=i,
+                        kind="implicit",
+                        basename=basename,
+                        predicted_artifacts=arts,
+                        impl_model=impl_model,
+                        selected_ift_pairs=selected_ift_pairs,
+                        selected_param_pairs=selected_param_pairs,
+                    )
+                )
+        return plans
 
-    seg_metas: list[dict] = []
-    for i, (kind, payload) in enumerate(segments):
-        basename = f"{model_name}_seg{i}"
-        if kind == "forward":
-            # Wrap the segment's leaves in a fresh ComposedModel so the
-            # dependency resolver can derive its input/output specs from the
-            # leaves' own specs. Reusing the master's _plan would tangle the
-            # segment's spec with the master's outer wiring.
-            assert isinstance(payload, list)
-            needed = (master_outs | downstream_demands[i]) & seg_output_sets[i]
-            extra = sorted(needed)
-            seg_model = ComposedModel(payload, additional_outputs=extra).to(device)
-            # Local jvp pairs to emit: kept for input derivatives (on a path
-            # between a requested master input and output) OR for parameter
-            # propagation (column carries a requested param sensitivity needed at
-            # a reachable output). Empty -> no jvp graph.
-            seg_struct_in = _structural_inputs(seg_model.input_spec, promoted_qnames)
-            seg_selected = {
-                (o, i)
-                for o in seg_model.output_spec
-                for i in seg_struct_in
-                if _keep_local_pair(o, i) or _keep_param_prop(o, i)
-            }
-            (
-                pkg_name,
-                in_infos,
-                out_infos,
-                jvp_pkg_name,
-                param_inputs,
-                jacobian_pairs,
-            ) = _compile_forward_segment(
-                seg_model,
-                basename,
+    # Forward-only: a single forward segment. For one forward segment the master
+    # pairs ARE the segment-local pairs, so they pass straight through.
+    arts = _predict_forward_artifacts(
+        model_name, master_pairs, param_pairs, single_forward_pvjp=True
+    )
+    return [
+        _SegmentPlan(
+            index=0,
+            kind="forward",
+            basename=model_name,
+            predicted_artifacts=arts,
+            seg_model=model,
+            selected_pairs=master_pairs,
+            selected_param_pairs=param_pairs,
+            single_forward_pvjp=True,
+        )
+    ]
+
+
+def _execute_segment_plan(
+    plan: _SegmentPlan,
+    prepared: _PreparedExport,
+    output_dir: Path,
+    device: str,
+    progress_cb: Callable[[str], None] | None = None,
+) -> dict:
+    """Compile one segment's ``.pt2`` graphs and return its metadata dict.
+
+    The single execution path shared by the serial loop and the process worker.
+    Mirrors the per-segment bodies of the former ``_export_forward`` /
+    ``_export_implicit`` / ``_export_composed``.
+    """
+    promoted_qnames = prepared.promoted_qnames
+    promoted_snapshots = prepared.promoted_snapshots
+    shapes = prepared.resolved_shapes
+    dynamic_batch = prepared.dynamic_batch
+
+    if plan.kind == "forward":
+        (
+            pkg_name,
+            in_infos,
+            out_infos,
+            jvp_pkg_name,
+            param_inputs,
+            jacobian_pairs,
+        ) = _compile_forward_segment(
+            plan.seg_model,
+            plan.basename,
+            output_dir,
+            device,
+            promoted_qnames=promoted_qnames,
+            promoted_snapshots=promoted_snapshots,
+            shapes=shapes,
+            dynamic_batch=dynamic_batch,
+            selected_pairs=plan.selected_pairs,
+            progress_cb=progress_cb,
+        )
+        seg_entry: dict = {
+            "kind": "forward",
+            "package": pkg_name,
+            "inputs": _segment_var_infos(in_infos),
+            "outputs": _segment_var_infos(out_infos),
+            "param_inputs": param_inputs,
+        }
+        if jvp_pkg_name is not None:
+            seg_entry["jvp_package"] = jvp_pkg_name
+            seg_entry["jacobian_pairs"] = jacobian_pairs
+        if plan.selected_param_pairs:
+            pjac_pkg, pjac_pairs = _compile_param_jacobian(
+                plan.seg_model,
+                plan.basename,
                 output_dir,
                 device,
                 promoted_qnames=promoted_qnames,
                 promoted_snapshots=promoted_snapshots,
+                selected_param_pairs=plan.selected_param_pairs,
                 shapes=shapes,
                 dynamic_batch=dynamic_batch,
-                selected_pairs=seg_selected,
+                progress_cb=progress_cb,
             )
-            seg_entry = {
-                "kind": "forward",
-                "package": pkg_name,
-                "inputs": _segment_var_infos(in_infos),
-                "outputs": _segment_var_infos(out_infos),
-                "param_inputs": param_inputs,
-            }
-            if jvp_pkg_name is not None:
-                seg_entry["jvp_package"] = jvp_pkg_name
-                seg_entry["jacobian_pairs"] = jacobian_pairs
-            # Direct parameter Jacobian for params promoted in THIS segment, for
-            # (out, param) pairs reaching a requested master output.
-            seg_param_pairs = {
-                (o, p)
-                for o in seg_model.output_spec
-                for p in seg_direct_params[i]
-                if _keep_param_pair(o, p)
-            }
-            if seg_param_pairs:
-                pjac_pkg, pjac_pairs = _compile_param_jacobian(
-                    seg_model,
-                    basename,
+            seg_entry["param_jacobian_package"] = pjac_pkg
+            seg_entry["param_jacobian_pairs"] = pjac_pairs
+            # The single-forward path also emits the adjoint (VJP) graph -- the
+            # cheaper form for many-parameter optimization. Composed forward
+            # segments do NOT (only the direct param-Jacobian propagates).
+            if plan.single_forward_pvjp:
+                pvjp_pkg, pvjp_params, pvjp_outputs = _compile_param_vjp(
+                    plan.seg_model,
+                    plan.basename,
                     output_dir,
                     device,
                     promoted_qnames=promoted_qnames,
                     promoted_snapshots=promoted_snapshots,
-                    selected_param_pairs=seg_param_pairs,
+                    selected_params={p for (_, p) in plan.selected_param_pairs},
                     shapes=shapes,
                     dynamic_batch=dynamic_batch,
+                    progress_cb=progress_cb,
                 )
-                seg_entry["param_jacobian_package"] = pjac_pkg
-                seg_entry["param_jacobian_pairs"] = pjac_pairs
-            seg_metas.append(seg_entry)
-        else:
-            # payload is the ImplicitUpdate leaf.
-            impl_model = payload
-            assert isinstance(impl_model, ImplicitUpdate)
-            # Local (unknown, given) IFT pairs on a requested dependency path:
-            # the given reachable from a requested master input AND the unknown
-            # reaching a requested master output. Drives both whether to emit the
-            # IFT graph and which per-pair blocks it emits.
-            isys = impl_model.system
-            selected_ift_pairs = {
-                (u, g)
-                for u in isys.unknown_names
-                for g in isys.given_names
-                if _keep_local_pair(u, g) or _keep_param_prop(u, g)
-            }
-            # Direct ParamIFT pairs for params promoted in THIS implicit segment.
-            selected_param_pairs = {
-                (u, p)
-                for u in isys.unknown_names
-                for p in seg_direct_params[i]
-                if _keep_param_pair(u, p)
-            }
-            seg = _compile_implicit_segment(
-                impl_model,
-                basename,
-                output_dir,
-                device,
-                shapes=shapes,
-                dynamic_batch=dynamic_batch,
-                emit_ift=bool(selected_ift_pairs),
-                selected_ift_pairs=selected_ift_pairs,
-                promoted_qnames=promoted_qnames,
-                promoted_snapshots=promoted_snapshots,
-                selected_param_pairs=selected_param_pairs,
-            )
-            seg_metas.append({"kind": "implicit", **seg})
+                seg_entry["param_vjp_package"] = pvjp_pkg
+                seg_entry["param_vjp_params"] = pvjp_params
+                seg_entry["param_vjp_outputs"] = pvjp_outputs
+        return seg_entry
 
-    structural_in = _structural_inputs(model.input_spec, promoted_qnames)
-    in_sb = {n: sub for n, (_, sub) in (shapes or {}).items() if sub}
-    return {
-        "schema_version": AOTI_META_SCHEMA_VERSION,
-        "type": "composed",
-        "inputs": _var_infos(structural_in, sub_batch_shapes=in_sb),
-        "outputs": _var_infos(model.output_spec),
-        "segments": seg_metas,
-    }
+    # implicit
+    seg = _compile_implicit_segment(
+        plan.impl_model,
+        plan.basename,
+        output_dir,
+        device,
+        shapes=shapes,
+        dynamic_batch=dynamic_batch,
+        emit_ift=bool(plan.selected_ift_pairs),
+        selected_ift_pairs=plan.selected_ift_pairs,
+        promoted_qnames=promoted_qnames,
+        promoted_snapshots=promoted_snapshots,
+        selected_param_pairs=plan.selected_param_pairs,
+        progress_cb=progress_cb,
+    )
+    return {"kind": "implicit", **seg}
+
+
+@dataclass
+class _ExportPlan:
+    """What a compile of ``(hit_path, model_name, options)`` on one device will
+    generate, without compiling.
+
+    ``artifacts`` is the flat, ordered list of every generated filename for the
+    device -- the ``.pt2`` graphs of each segment followed by the
+    ``<model>_meta.json``. ``.total`` is the count the CLI uses for the ``[k/N]``
+    progress denominator (the standalone ``<model>_aoti.i`` stub is a CLI-level
+    concern added on top).
+    """
+
+    artifacts: list[str]
+    segments: list[_SegmentPlan]
+
+    @property
+    def total(self) -> int:
+        return len(self.artifacts)
+
+
+def plan_export_artifacts(
+    hit_path: str | Path,
+    model_name: str,
+    *,
+    device: str = "cpu",
+    promoted: set[str] | list[str] | tuple[str, ...] = (),
+    example_batch_shape: dict[str, str] | str | None = None,
+    dynamic_batch: bool | None = None,
+    derivatives: Sequence[str] = (),
+    renames: dict[str, dict[str, str]] | None = None,
+    pre: Sequence[str] = (),
+    additional_args: tuple[str, ...] = (),
+) -> _ExportPlan:
+    """Enumerate the files a compile will generate, WITHOUT compiling.
+
+    Runs the same prelude + segment planning :func:`export_model_for_aoti` uses,
+    then returns the ordered list of every generated filename for *device* (each
+    segment's ``.pt2`` graphs, then ``<model_name>_meta.json``). No
+    ``compile_model`` is called, so this is cheap (one model load + structural
+    analysis). Primarily drives the ``[k/N]`` progress denominator; also useful
+    for programmatic inspection of a model's segment structure. The artifact set
+    is device-independent, so a single call (e.g. ``device="cpu"``) suffices to
+    size a multi-device compile.
+    """
+    prepared = _prepare_export(
+        hit_path,
+        model_name,
+        device=device,
+        promoted=promoted,
+        example_batch_shape=example_batch_shape,
+        dynamic_batch=dynamic_batch,
+        derivatives=derivatives,
+        renames=renames,
+        pre=pre,
+        additional_args=additional_args,
+    )
+    plans = _plan_segments(prepared, model_name)
+    artifacts: list[str] = []
+    for plan in plans:
+        artifacts.extend(plan.predicted_artifacts)
+    artifacts.append(f"{model_name}_meta.json")
+    return _ExportPlan(artifacts=artifacts, segments=plans)
+
+
+# ---------------------------------------------------------------------------
+# Parallel segment compilation (process pool)
+# ---------------------------------------------------------------------------
+
+#: Sentinel enqueued by the parent to tell the progress-drainer thread to exit.
+_PROGRESS_SENTINEL = "__neml2_progress_done__"
+
+#: Per-worker handle to the shared progress queue (set by :func:`_worker_init`).
+#: A module global because ``ProcessPoolExecutor`` cannot pass a Manager queue as
+#: a per-task argument -- it must arrive via the pool ``initializer``.
+_worker_progress_queue = None
+
+
+def _worker_init(queue) -> None:
+    """Pool ``initializer``: stash the shared progress queue in the worker."""
+    global _worker_progress_queue
+    _worker_progress_queue = queue
+
+
+def _compile_segment_worker(args) -> tuple[int, dict]:
+    """Worker entry: re-derive the model from the input file and compile ONE
+    segment. Everything in *args* is picklable (paths, strings, an options dict,
+    and the segment index); no live ``nn.Module`` crosses the process boundary.
+    Per-``.pt2`` progress is streamed back to the parent through the shared queue.
+    """
+    hit_path, model_name, output_dir, device, export_opts, seg_index = args
+    prepared = _prepare_export(hit_path, model_name, device=device, **export_opts)
+    plans = _plan_segments(prepared, model_name)
+    plan = plans[seg_index]
+    queue = _worker_progress_queue
+    cb = (lambda name: queue.put(name)) if queue is not None else None
+    seg_meta = _execute_segment_plan(plan, prepared, Path(output_dir), device, progress_cb=cb)
+    return seg_index, seg_meta
+
+
+def _compile_segments_parallel(
+    hit_path: str | Path,
+    model_name: str,
+    output_dir: Path,
+    device: str,
+    export_opts: dict,
+    plans: list[_SegmentPlan],
+    jobs: int,
+    progress_cb: Callable[[str], None] | None,
+) -> list[dict]:
+    """Compile independent segments concurrently in a spawn process pool.
+
+    Each segment is compiled by a worker that re-derives it from *hit_path* +
+    *export_opts* (workers can't receive live modules). Segment metadata is
+    reassembled in SEGMENT ORDER regardless of completion order, so the resulting
+    ``_meta.json`` is identical to a serial (``jobs=1``) run. Per-``.pt2``
+    progress from workers is forwarded to *progress_cb* by a drainer thread.
+
+    The worker pool is sized at ``min(jobs, len(plans))`` -- there is one task per
+    segment, so requesting more processes than segments would only spawn idle
+    interpreters. Granularity is per-segment: a worker compiles all of one
+    segment's ``.pt2`` graphs sequentially.
+    """
+    import concurrent.futures as cf
+    import multiprocessing as mp
+    import threading
+
+    ctx = mp.get_context("spawn")
+    # One task per segment -> never spawn more workers than segments.
+    workers = max(1, min(jobs, len(plans)))
+
+    manager = None
+    queue = None
+    drainer = None
+    initializer = None
+    initargs: tuple = ()
+    if progress_cb is not None:
+        manager = ctx.Manager()
+        queue = manager.Queue()
+        initializer = _worker_init
+        initargs = (queue,)
+
+        def _drain() -> None:
+            while True:
+                item = queue.get()
+                if item == _PROGRESS_SENTINEL:
+                    break
+                progress_cb(item)
+
+        drainer = threading.Thread(target=_drain, daemon=True)
+        drainer.start()
+
+    n = len(plans)
+    results: dict[int, dict] = {}
+    hit_s = str(hit_path)
+    out_s = str(output_dir)
+    try:
+        with cf.ProcessPoolExecutor(
+            max_workers=workers, mp_context=ctx, initializer=initializer, initargs=initargs
+        ) as ex:
+            futs = {
+                ex.submit(
+                    _compile_segment_worker,
+                    (hit_s, model_name, out_s, device, export_opts, i),
+                ): i
+                for i in range(n)
+            }
+            for fut in cf.as_completed(futs):
+                i = futs[fut]
+                try:
+                    idx, seg_meta = fut.result()
+                except Exception as exc:  # noqa: BLE001
+                    ex.shutdown(cancel_futures=True)
+                    plan = plans[i]
+                    raise RuntimeError(
+                        f"neml2-compile: segment {plan.index} ({plan.kind}, "
+                        f"{plan.basename}) failed: {exc}"
+                    ) from exc
+                results[idx] = seg_meta
+    finally:
+        if queue is not None:
+            queue.put(_PROGRESS_SENTINEL)
+        if drainer is not None:
+            drainer.join()
+        if manager is not None:
+            manager.shutdown()
+
+    return [results[i] for i in range(n)]
 
 
 # ---------------------------------------------------------------------------
@@ -2767,6 +3175,8 @@ def export_model_for_aoti(
     renames: dict[str, dict[str, str]] | None = None,
     pre: Sequence[str] = (),
     additional_args: tuple[str, ...] = (),
+    jobs: int = 1,
+    progress_cb: Callable[[str], None] | None = None,
 ) -> dict:
     """Export a native NEML2 model to ``.pt2`` artifacts for AOTI C++ consumption.
 
@@ -2839,206 +3249,122 @@ def export_model_for_aoti(
         Trailing HIT override tokens appended to the parser's *post* list
         (e.g. ``"Models/elasticity/E:=210000"``). Path-style overrides only;
         for variable substitution use *pre*.
+    jobs:
+        Number of worker processes for parallel segment compilation. ``1``
+        (default) compiles serially (behavior-identical to before this option).
+        ``> 1`` compiles independent segments concurrently in a spawn process
+        pool -- effective only for a multi-segment model (a ``ComposedModel``
+        containing an ``ImplicitUpdate``); single-segment models ignore it. The
+        resulting ``_meta.json`` is identical to a serial run (segment metadata
+        is reassembled in segment order regardless of completion order).
+    progress_cb:
+        Optional callback invoked with the bare filename of each generated file
+        as it is written -- every ``.pt2`` graph and the ``<model>_meta.json``.
+        The CLI passes a printer that renders ``[k/N] <name>`` progress. ``None``
+        (default) is silent. Under ``jobs > 1`` the callback still fires per
+        ``.pt2`` (forwarded from workers), then once for the metadata.
 
     Returns
     -------
     dict
         The metadata dictionary (same content as the written JSON).
     """
-    from ..factory import load_input
-    from ..models.common import ComposedModel, ImplicitUpdate
-
     output_dir = Path(output_dir).resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    factory = load_input(hit_path, pre=pre, additional_args=additional_args)
-    model = factory.get_model(model_name)
-
-    # Wrap a bare (non-composed) forward leaf in ComposedModel up-front -- BEFORE
-    # promotion -- so promoted parameter names live in the SAME namespace the eager
-    # runtime reports (ComposedModel([leaf]) gives ``model.E`` for a leaf named
-    # ``model``), giving byte-identical parameter naming across the cpp-aoti and
-    # cpp-eager routes. The forward export already wraps a bare leaf for tracing
-    # (see ``_export_forward``), so the exported graph is unchanged -- this only
-    # moves the wrap ahead of name validation/promotion so ``-p`` / the recorded
-    # metadata / ``named_parameters()`` keys are the qualified ``model.E``.
-    # ImplicitUpdate (and composed-with-implicit) models keep their dedicated
-    # export path + namespace; an already-composed model is left untouched (its
-    # parameters are already qualified by their child-leaf names).
-    if not isinstance(model, ComposedModel) and not _contains_implicit(model):
-        model = ComposedModel([model])
-
-    # Resolve example-batch-shape declarations: CLI/Python kwarg wins, then
-    # HIT [Settings], then the (2,)/uniform default. The full per-input map
-    # is what every downstream helper consumes.
-    settings_shapes, settings_dyn = _read_settings(factory)
-    if isinstance(example_batch_shape, str):
-        declared = {"*": example_batch_shape}
-    elif isinstance(example_batch_shape, dict):
-        declared = dict(example_batch_shape)
-    else:
-        declared = settings_shapes
-    if dynamic_batch is None:
-        dynamic_batch = settings_dyn
-    resolved_shapes = _resolve_example_shapes(model.input_spec, declared)
-
-    # Validate / resolve promoted names against the live model BEFORE any
-    # ComposedModel wrapping (which would shift the qualified-name namespace).
-    # Snapshot the initial values now too -- those go into the metadata so
-    # the C++ side can populate `named_parameters()` at construction.
-    promoted_set = set(promoted)
-    promoted_names, origin = _validate_promoted(model, promoted_set)
-    promoted_snapshots = _snapshot_promoted(model, promoted_names)
-
-    # Now route each promoted parameter through the leaf's PromotedParam machinery
-    # (delete the static slot, add `_promoted_params[local] = PromotedParam(input_name=
-    # qname, ...)`, append qname to holder's input_spec). Any ComposedModel
-    # wrap downstream picks the new inputs up via dependency resolution and
-    # the call boundary's `_coerce_to_input_type` wraps raw tensors in the
-    # right TensorWrapper before handing them to the leaf's forward, which
-    # reads via `_get_param` from the *promoted_params pack.
-    promo_info = _promote_parameters(model, promoted_names)
-    promoted_qnames = set(promoted_names)
-    # Natural base shape (BASE_SHAPE) per promoted parameter, from its typed-wrapper
-    # class. The C++ runtime uses it to split a (possibly batched) stored parameter
-    # ``(*pbatch, *base)`` into batch vs base; it equals the snapshot's full shape
-    # only for an unbatched parameter.
-    promoted_base_shapes = {q: tuple(cls.BASE_SHAPE) for q, (cls, _h, _l) in promo_info.items()}
-
-    # Rebuild every spec-caching container (ComposedModel / Normality /
-    # ImplicitUpdate residual) so the promoted parameters route correctly through
-    # the graph. No-op when nothing was promoted.
-    if promoted_names:
-        model = _rebuild_after_promotion(model)
-
-    # Resolve -d/--derivative specs into the master (out, in) pair set, against
-    # the post-promotion outputs + structural inputs (promoted parameters never
-    # appear in the Jacobian). Empty => no derivative graphs are compiled.
-    structural_input_names = list(_structural_inputs(model.input_spec, promoted_qnames))
-    master_pairs, param_pairs = _resolve_derivative_specs(
-        derivatives,
-        list(model.output_spec),
-        structural_input_names,
-        param_names=sorted(promoted_qnames),
+    # Run the full pre-compile prelude (load, wrap, promote, resolve derivatives /
+    # renames, freeze, seed) once. Deterministic in (input, options, device) so a
+    # spawned worker can reproduce the exact same segments.
+    prepared = _prepare_export(
+        hit_path,
+        model_name,
+        device=device,
+        promoted=promoted,
+        example_batch_shape=example_batch_shape,
+        dynamic_batch=dynamic_batch,
+        derivatives=derivatives,
+        renames=renames,
+        pre=pre,
+        additional_args=additional_args,
     )
+    model = prepared.model
 
-    # Validate + normalize boundary renames against the post-promotion boundary
-    # namespaces (structural inputs, outputs, promoted parameters). Fails fast
-    # here -- before the expensive graph compile -- on an unknown or colliding
-    # name. Shallow: only the interface names change; the graphs keep the
-    # original authored names.
-    boundary_aliases = _validate_renames(
-        renames,
-        input_names=structural_input_names,
-        output_names=list(model.output_spec),
-        param_names=sorted(promoted_qnames),
-    )
+    # Plan the segments (cheap, structural). All three model shapes -- forward,
+    # single ImplicitUpdate, composed-with-implicit -- flow through one planner so
+    # the artifacts predicted for progress exactly match what is produced.
+    plans = _plan_segments(prepared, model_name)
 
-    # ``request_AD`` controls HOW a leaf's derivatives are computed (reverse-mode
-    # autodiff embedded in the chain rule); ``-d`` still controls WHETHER any are
-    # compiled, exactly as for an analytic model. So a value-only export of
-    # a request_AD model compiles no derivative graph (and needs no
-    # ``trace_autograd_ops``); the author's win is never hand-writing the chain
-    # rule, not implicit ``-d`` selection.
-
-    # Freeze any remaining nn.Parameter to a persistent buffer so torch.export
-    # bakes it into the graph instead of lifting it as a graph input. Promoted
-    # entries are already gone from _parameters so they're skipped naturally.
-    _freeze_remaining_parameters_to_buffers(model)
-
-    # Catch baked-parameter shape conflicts before torch.export does — the
-    # NEML2-side message names the param, the conflicting input, and the
-    # three available resolutions; torch.export's "you marked batch as
-    # dynamic but specialized it to N" message names neither.
-    if dynamic_batch:
-        _validate_baked_against_shapes(model, resolved_shapes, promoted_qnames)
-
-    # Populate per-variable ``sub_batch_shape`` on every inner
-    # ``ModelNonlinearSystem`` from the resolved per-variable shapes so the
-    # Schur/Block export path traces with the correct per-sub-batch-site
-    # layout. The compile path no longer reaches into [Drivers] for this.
-    _seed_implicit_subbatch(model, resolved_shapes, device)
-
-    inner = model
-
-    # Parameter derivatives d(out)/d(param) are supported for forward-only models
-    # (single forward segment), a single ImplicitUpdate (ParamIFT -- schema v7),
-    # and composed models containing an ImplicitUpdate (the multi-segment carrier
-    # composes du/dθ across forward + implicit segments -- schema v7+). No guard
-    # left to raise here.
-    if isinstance(inner, ImplicitUpdate):
-        meta = _export_implicit(
-            model,
-            inner,
-            model_name,
-            output_dir,
-            device,
-            promoted_qnames=promoted_qnames,
-            promoted_snapshots=promoted_snapshots,
-            shapes=resolved_shapes,
-            dynamic_batch=dynamic_batch,
-            derivatives=master_pairs,
-            param_derivatives=param_pairs,
-        )
-    elif _contains_implicit(inner):
-        meta = _export_composed(
-            model,
-            model_name,
-            output_dir,
-            device,
-            promoted_qnames=promoted_qnames,
-            promoted_snapshots=promoted_snapshots,
-            shapes=resolved_shapes,
-            dynamic_batch=dynamic_batch,
-            derivatives=master_pairs,
-            param_derivatives=param_pairs,
+    # Execute: serial (default) or, for a multi-segment model with jobs > 1, in a
+    # spawn process pool where each worker re-derives its segment from the file.
+    if jobs > 1 and len(plans) > 1:
+        # Pass the ORIGINAL options (not the post-prepare derived values) so each
+        # worker's _prepare_export re-derives from byte-identical inputs.
+        export_opts = {
+            "promoted": sorted(set(promoted)),
+            "example_batch_shape": example_batch_shape,
+            "dynamic_batch": dynamic_batch,
+            "derivatives": tuple(derivatives),
+            "renames": renames,
+            "pre": tuple(pre),
+            "additional_args": tuple(additional_args),
+        }
+        seg_metas = _compile_segments_parallel(
+            hit_path, model_name, output_dir, device, export_opts, plans, jobs, progress_cb
         )
     else:
-        meta = _export_forward(
-            model,
-            model_name,
-            output_dir,
-            device,
-            promoted_qnames=promoted_qnames,
-            promoted_snapshots=promoted_snapshots,
-            shapes=resolved_shapes,
-            dynamic_batch=dynamic_batch,
-            derivatives=master_pairs,
-            param_derivatives=param_pairs,
-        )
+        seg_metas = [
+            _execute_segment_plan(plan, prepared, output_dir, device, progress_cb=progress_cb)
+            for plan in plans
+        ]
+
+    # Assemble the top-level metadata envelope (identical across all three shapes).
+    structural_in = _structural_inputs(model.input_spec, prepared.promoted_qnames)
+    in_sb = {n: sub for n, (_, sub) in (prepared.resolved_shapes or {}).items() if sub}
+    meta: dict = {
+        "schema_version": AOTI_META_SCHEMA_VERSION,
+        "type": "composed",
+        "inputs": _var_infos(structural_in, sub_batch_shapes=in_sb),
+        "outputs": _var_infos(model.output_spec),
+        "segments": seg_metas,
+    }
 
     # v2 top-level additions: device + dtype are baked into the artifact;
     # parameters records the promoted set with initial values.
     meta["device"] = device
     meta["dtype"] = dtype
-    meta["parameters"] = _parameter_infos(promoted_snapshots, origin, promoted_base_shapes, device)
+    meta["parameters"] = _parameter_infos(
+        prepared.promoted_snapshots, prepared.origin, prepared.promoted_base_shapes, device
+    )
     # Master (out, in) derivative pairs the artifact supports, in deterministic
     # (output-order, input-order) order so the runtime iterates rows/cols
     # consistently. Empty => no derivative graphs (jvp/jacobian raise).
     out_order = {n: k for k, n in enumerate(model.output_spec)}
-    in_order = {n: k for k, n in enumerate(structural_input_names)}
+    in_order = {n: k for k, n in enumerate(prepared.structural_input_names)}
     meta["derivatives"] = [
         [o, i]
         for (o, i) in sorted(
-            master_pairs, key=lambda p: (out_order.get(p[0], 0), in_order.get(p[1], 0))
+            prepared.master_pairs, key=lambda p: (out_order.get(p[0], 0), in_order.get(p[1], 0))
         )
     ]
     # Master (out, param) parameter-derivative pairs the artifact supports, in
     # deterministic (output-order, param-name) order. Empty => no param-jacobian
     # graph (the runtime parameter-Jacobian accessor raises).
     meta["parameter_derivatives"] = [
-        [o, p] for (o, p) in sorted(param_pairs, key=lambda x: (out_order.get(x[0], 0), x[1]))
+        [o, p]
+        for (o, p) in sorted(prepared.param_pairs, key=lambda x: (out_order.get(x[0], 0), x[1]))
     ]
     # Boundary renames (shallow): remap only the names reported at the artifact's
     # interface. Absent => the interface uses the original authored names. Only
     # namespaces with an actual rename are written, so a fully-baked artifact is
     # unchanged.
-    active_aliases = {ns: m for ns, m in boundary_aliases.items() if m}
+    active_aliases = {ns: m for ns, m in prepared.boundary_aliases.items() if m}
     if active_aliases:
         meta["boundary_aliases"] = active_aliases
 
-    _write_meta(output_dir / f"{model_name}_meta.json", meta)
+    meta_name = f"{model_name}_meta.json"
+    _write_meta(output_dir / meta_name, meta)
+    _report(progress_cb, meta_name)
     return meta
 
 
-__all__ = ["export_model_for_aoti", "AOTI_META_SCHEMA_VERSION"]
+__all__ = ["export_model_for_aoti", "plan_export_artifacts", "AOTI_META_SCHEMA_VERSION"]

--- a/tests/aoti/test_compile_cli.py
+++ b/tests/aoti/test_compile_cli.py
@@ -37,11 +37,17 @@ compile.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+
+import pytest
 
 from neml2.cli.aoti_compile import compile_and_emit_stub, main
 
 _INPUT = Path(__file__).parent / "forward_single" / "model.i"
+# A ComposedModel containing an ImplicitUpdate -> partitions into 3 segments
+# (forward / implicit / forward), the shape that exercises parallel compilation.
+_COMPOSED_INPUT = Path(__file__).parent / "composed_param" / "model.i"
 
 
 def test_main_emits_standalone_stub_and_per_device_folder(tmp_path):
@@ -73,3 +79,102 @@ def test_main_input_not_found(tmp_path):
 def test_main_unknown_model(tmp_path):
     # export fails resolving the model -> main catches it and returns 1.
     assert main([str(_INPUT), "--model", "does_not_exist", "--output-dir", str(tmp_path)]) == 1
+
+
+def test_main_rejects_bad_jobs(tmp_path):
+    # --jobs < 1 is a usage error (argparse SystemExit via parser.error).
+    with pytest.raises(SystemExit):
+        main([str(_INPUT), "--model", "model", "--output-dir", str(tmp_path), "-j", "0"])
+
+
+# ---------------------------------------------------------------------------
+# Artifact-plan drift guard: what plan_export_artifacts predicts must equal what
+# a real compile actually generates -- .pt2 graphs + meta.json (+ the .i stub at
+# the CLI level). This is the single check that keeps the emit-order predictors
+# in lockstep with the compile_model call sites.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("inp", "model", "derivs"),
+    [
+        (_INPUT, "model", ()),
+        (_INPUT, "model", (":",)),
+        (_COMPOSED_INPUT, "model", ()),
+        (_COMPOSED_INPUT, "model", (":",)),
+    ],
+    ids=["forward", "forward+d", "composed", "composed+d"],
+)
+def test_planned_equals_produced(tmp_path, inp, model, derivs):
+    from neml2.cli.aoti_export import export_model_for_aoti, plan_export_artifacts
+
+    predicted = plan_export_artifacts(inp, model, derivatives=derivs).artifacts
+    reported: list[str] = []
+    export_model_for_aoti(inp, model, tmp_path, derivatives=derivs, progress_cb=reported.append)
+
+    on_disk = {p.name for p in tmp_path.iterdir() if p.is_file()}
+    # Ordered prediction matches the ordered progress stream (serial run) ...
+    assert reported == predicted
+    # ... and the exact set of files on disk (.pt2 graphs + the meta.json).
+    assert set(predicted) == on_disk
+
+
+def test_planned_equals_produced_includes_stub(tmp_path):
+    """At the CLI level the standalone ``_aoti.i`` stub is generated too; the
+    progress stream ends with it and the file exists on disk."""
+    reported: list[str] = []
+    stub = compile_and_emit_stub(_INPUT, tmp_path, model="model", progress_cb=reported.append)
+    assert stub.exists()
+    assert reported[-1] == "model_aoti.i"
+    # The stub is the last generated file, after every .pt2 and the meta.json.
+    assert reported == ["model.pt2", "model_meta.json", "model_aoti.i"]
+
+
+# ---------------------------------------------------------------------------
+# Parallel segment compilation
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_matches_serial(tmp_path):
+    """Compiling a multi-segment model with jobs>1 must yield byte-identical
+    metadata and the same set of artifacts as a serial (jobs=1) compile --
+    segment metadata is reassembled in segment order regardless of completion
+    order."""
+    from neml2.cli.aoti_export import export_model_for_aoti
+
+    serial_dir = tmp_path / "serial"
+    parallel_dir = tmp_path / "parallel"
+    serial_dir.mkdir()
+    parallel_dir.mkdir()
+
+    meta_serial = export_model_for_aoti(_COMPOSED_INPUT, "model", serial_dir, jobs=1)
+    # jobs (8) intentionally exceeds the segment count (3) -- the pool is capped at
+    # the number of segments, so this must still match the serial output exactly.
+    meta_parallel = export_model_for_aoti(_COMPOSED_INPUT, "model", parallel_dir, jobs=8)
+
+    # Metadata identical (order-insensitive JSON compare).
+    assert json.dumps(meta_serial, sort_keys=True) == json.dumps(meta_parallel, sort_keys=True)
+    # Same artifacts on disk (compare names, not .pt2 bytes -- Inductor output
+    # can differ trivially run-to-run).
+    serial_files = {p.name for p in serial_dir.iterdir() if p.is_file()}
+    parallel_files = {p.name for p in parallel_dir.iterdir() if p.is_file()}
+    assert serial_files == parallel_files
+
+
+def test_jobs_ignored_for_single_segment(tmp_path):
+    """A single-segment (forward-only) model has nothing to parallelize; jobs>1
+    falls back to the serial path and produces identical output."""
+    from neml2.cli.aoti_export import export_model_for_aoti
+
+    j1_dir = tmp_path / "j1"
+    j4_dir = tmp_path / "j4"
+    j1_dir.mkdir()
+    j4_dir.mkdir()
+
+    meta_j1 = export_model_for_aoti(_INPUT, "model", j1_dir, jobs=1)
+    meta_j4 = export_model_for_aoti(_INPUT, "model", j4_dir, jobs=4)
+
+    assert json.dumps(meta_j1, sort_keys=True) == json.dumps(meta_j4, sort_keys=True)
+    assert {p.name for p in j1_dir.iterdir() if p.is_file()} == {
+        p.name for p in j4_dir.iterdir() if p.is_file()
+    }

--- a/tests/unit/test_aoti_export.py
+++ b/tests/unit/test_aoti_export.py
@@ -138,6 +138,114 @@ def test_resolve_derivative_specs_grammar_and_errors():
         _resolve_derivative_specs(["stress:E"], outs, ins)
 
 
+# ---------------------------------------------------------------------------
+# Artifact planning (plan_export_artifacts + the emit-order predictors).
+# Cheap: no compile -- pure structural analysis. The drift-guard test in
+# tests/aoti/test_compile_cli.py checks these predictions against what an actual
+# compile produces.
+# ---------------------------------------------------------------------------
+
+_COMPOSED_I = _TESTS_ROOT / "aoti/composed_param/model.i"
+
+
+def test_predict_forward_artifacts_emit_order():
+    """The forward predictor mirrors, in emission order, the compile_model calls
+    in _compile_forward_segment (+ the param-Jacobian / VJP helpers)."""
+    from neml2.cli.aoti_export import _predict_forward_artifacts
+
+    # Value only (no derivative pairs selected).
+    assert _predict_forward_artifacts("m", set(), set(), single_forward_pvjp=True) == ["m.pt2"]
+    # Value + jvp when input pairs are selected.
+    assert _predict_forward_artifacts("m", {("y", "x")}, set(), single_forward_pvjp=True) == [
+        "m.pt2",
+        "m_jvp.pt2",
+    ]
+    # ``None`` selection means "all pairs" -> jvp emitted.
+    assert _predict_forward_artifacts("m", None, set(), single_forward_pvjp=False) == [
+        "m.pt2",
+        "m_jvp.pt2",
+    ]
+    # The pvjp graph is emitted ONLY for the lone forward segment of a
+    # forward-only model (single_forward_pvjp=True).
+    assert _predict_forward_artifacts(
+        "m", {("y", "x")}, {("y", "p")}, single_forward_pvjp=True
+    ) == ["m.pt2", "m_jvp.pt2", "m_pjac.pt2", "m_pvjp.pt2"]
+    # A composed forward segment with the same selection emits pjac but NOT pvjp.
+    assert _predict_forward_artifacts(
+        "m_seg0", {("y", "x")}, {("y", "p")}, single_forward_pvjp=False
+    ) == ["m_seg0.pt2", "m_seg0_jvp.pt2", "m_seg0_pjac.pt2"]
+
+
+def test_predict_implicit_artifacts_emit_order():
+    """The implicit predictor mirrors the compile_model calls in
+    _compile_implicit_segment: rhs, step, then optional ift/pift/predictor."""
+    from neml2.cli.aoti_export import _predict_implicit_artifacts
+
+    assert _predict_implicit_artifacts(
+        "m", emit_ift=False, emit_pift=False, has_predictor=False
+    ) == ["m_rhs.pt2", "m_step.pt2"]
+    assert _predict_implicit_artifacts("m", emit_ift=True, emit_pift=True, has_predictor=True) == [
+        "m_rhs.pt2",
+        "m_step.pt2",
+        "m_ift.pt2",
+        "m_pift.pt2",
+        "m_predictor.pt2",
+    ]
+
+
+def test_plan_export_artifacts_forward():
+    """A forward-only model plans one forward segment named after the model,
+    with the meta.json last."""
+    from neml2.cli.aoti_export import plan_export_artifacts
+
+    plan = plan_export_artifacts(_ELASTICITY_I, "model")
+    assert [s.kind for s in plan.segments] == ["forward"]
+    assert plan.artifacts == ["model.pt2", "model_meta.json"]
+
+    plan_d = plan_export_artifacts(_ELASTICITY_I, "model", derivatives=[":"])
+    assert plan_d.artifacts == ["model.pt2", "model_jvp.pt2", "model_meta.json"]
+    assert plan_d.total == 3
+
+
+def test_plan_export_artifacts_single_implicit():
+    """A single ImplicitUpdate plans one implicit segment (rhs + step, + ift when
+    derivatives are requested), meta.json last."""
+    from neml2.cli.aoti_export import plan_export_artifacts
+
+    # This J2 return map carries a Predictor, so the plan includes its graph too
+    # (rhs, step, ift, predictor) -- exercising the has_predictor branch.
+    plan = plan_export_artifacts(_J2_NATIVE_I, "return_map", derivatives=[":"])
+    assert [s.kind for s in plan.segments] == ["implicit"]
+    assert plan.artifacts == [
+        "return_map_rhs.pt2",
+        "return_map_step.pt2",
+        "return_map_ift.pt2",
+        "return_map_predictor.pt2",
+        "return_map_meta.json",
+    ]
+
+
+def test_plan_export_artifacts_composed_multi_segment():
+    """A ComposedModel with an ImplicitUpdate plans one segment per partition,
+    named ``<model>_seg{i}``, with the meta.json as the final entry."""
+    from neml2.cli.aoti_export import plan_export_artifacts
+
+    plan = plan_export_artifacts(_COMPOSED_I, "model", derivatives=[":"])
+    assert [s.kind for s in plan.segments] == ["forward", "implicit", "forward"]
+    assert plan.artifacts == [
+        "model_seg0.pt2",
+        "model_seg0_jvp.pt2",
+        "model_seg1_rhs.pt2",
+        "model_seg1_step.pt2",
+        "model_seg1_ift.pt2",
+        "model_seg2.pt2",
+        "model_seg2_jvp.pt2",
+        "model_meta.json",
+    ]
+    # The meta.json is always the last generated file for the device.
+    assert plan.artifacts[-1] == "model_meta.json"
+
+
 @pytest.fixture(scope="session")
 def forward_export(tmp_path_factory):
     from neml2.cli.aoti_export import export_model_for_aoti

--- a/tests/unit/test_compile_interactive.py
+++ b/tests/unit/test_compile_interactive.py
@@ -140,6 +140,14 @@ def test_argv_load_repeat_and_empty_output_dir_omitted():
     assert [argv[k + 1] for k, t in enumerate(argv) if t == "--load"] == ["a.py", "b.py"]
 
 
+def test_argv_jobs_emitted_only_when_parallel():
+    # jobs == 1 (the serial default) is omitted to keep the previewed command clean.
+    assert "-j" not in build_compile_argv(FormState(name="m", devices=("cpu",), jobs=1))
+    # jobs > 1 emits `-j N`.
+    argv = build_compile_argv(FormState(name="m", devices=("cpu",), jobs=4))
+    assert argv[argv.index("-j") + 1] == "4"
+
+
 @pytest.mark.parametrize(
     "state",
     [
@@ -155,6 +163,7 @@ def test_argv_load_repeat_and_empty_output_dir_omitted():
             derivatives=("stress:strain",),
             example_shape=("strain=(2;100)",),
             dynamic_batch=False,
+            jobs=3,
             load=("ext.py",),
         ),
         # Model target with boundary renames -- the built argv must parse cleanly.
@@ -185,6 +194,7 @@ def test_argv_round_trips_through_real_parser(state):
     assert args.derivative == list(state.derivatives)
     assert args.example_batch_shape == list(state.example_shape)
     assert args.dynamic_batch is state.dynamic_batch
+    assert args.jobs == state.jobs
     assert args.load == list(state.load)
 
 
@@ -213,6 +223,58 @@ def test_validate_flags_nonexistent_input(tmp_path):
         FormState(input_file=str(tmp_path / "nope.i"), name="m", devices=("cpu",))
     )
     assert any("not found" in p for p in problems)
+
+
+def test_validate_flags_bad_jobs(tmp_path):
+    inp = tmp_path / "in.i"
+    inp.write_text("")
+    problems = validate_state(FormState(input_file=str(inp), name="m", devices=("cpu",), jobs=0))
+    assert any("-j" in p or "processes" in p.lower() for p in problems)
+
+
+# --------------------------------------------------------------------------- #
+# plan_summary -- the segment / artifact preview shown before choosing -j      #
+# --------------------------------------------------------------------------- #
+
+_TESTS_ROOT = Path(__file__).parent.parent
+_ELASTICITY_I = _TESTS_ROOT / "models/solid_mechanics/elasticity/LinearIsotropicElasticity.i"
+_COMPOSED_I = _TESTS_ROOT / "aoti/composed_param/model.i"
+
+
+def test_plan_summary_single_segment_forward():
+    import neml2  # noqa: F401 — registers models
+    from neml2.cli._compile_interactive import plan_summary
+
+    summary = plan_summary(
+        FormState(input_file=str(_ELASTICITY_I), target="model", name="model", devices=("cpu",))
+    )
+    # A forward-only model is one segment; the last generated file is the stub.
+    assert [(i, k) for (i, k, _b, _a) in summary.segments] == [(0, "forward")]
+    assert summary.files[-1] == "model_aoti.i"
+    assert "model_meta.json" in summary.files
+
+
+def test_plan_summary_composed_multi_segment():
+    import neml2  # noqa: F401 — registers models
+    from neml2.cli._compile_interactive import plan_summary
+
+    summary = plan_summary(
+        FormState(
+            input_file=str(_COMPOSED_I),
+            target="model",
+            name="model",
+            devices=("cpu",),
+            derivatives=(":",),
+        )
+    )
+    assert [(i, k) for (i, k, _b, _a) in summary.segments] == [
+        (0, "forward"),
+        (1, "implicit"),
+        (2, "forward"),
+    ]
+    # Every predicted artifact plus the meta + stub is enumerated, stub last.
+    assert summary.files[-1] == "model_aoti.i"
+    assert "model_seg1_ift.pt2" in summary.files
 
 
 def test_validate_ok_for_real_file():
@@ -933,3 +995,48 @@ def test_argv_builder_empty_optionals():
         FormState(input_file="", name="", output_dir="", devices=(), dtype="")
     )
     assert argv == []
+
+
+def test_ask_jobs_prompts_on_multi_segment(monkeypatch):
+    """A multi-segment model shows the segment plan and prompts for a process
+    count, consuming exactly one scripted answer."""
+    pytest.importorskip("questionary")
+    import neml2  # noqa: F401, PLC0415 — registers models
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary(["3"]))
+    state = wiz._default_state()
+    state["target"] = "model"
+    state["name"] = "model"
+    assert wiz._ask_field("jobs", str(_COMPOSED_I), state, {}) is True
+    assert state["jobs"] == 3
+
+
+def test_ask_jobs_single_segment_no_prompt(monkeypatch):
+    """A single-segment model pins jobs=1 without prompting -- the empty script
+    would raise StopIteration if a prompt were shown."""
+    pytest.importorskip("questionary")
+    import neml2  # noqa: F401, PLC0415 — registers models
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary([]))
+    state = wiz._default_state()
+    state["target"] = "model"
+    state["name"] = "model"
+    assert wiz._ask_field("jobs", str(_ELASTICITY_I), state, {}) is True
+    assert state["jobs"] == 1
+
+
+def test_ask_jobs_clamps_to_segment_count(monkeypatch):
+    """Requesting more processes than segments is clamped to the segment count
+    (the composed fixture has 3 segments)."""
+    pytest.importorskip("questionary")
+    import neml2  # noqa: F401, PLC0415 — registers models
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary(["99"]))
+    state = wiz._default_state()
+    state["target"] = "model"
+    state["name"] = "model"
+    assert wiz._ask_field("jobs", str(_COMPOSED_I), state, {}) is True
+    assert state["jobs"] == 3


### PR DESCRIPTION
## What

Three capabilities for `neml2-compile`'s AOTI export pipeline, plus interactive-wizard support.

### 1. Artifact planning (`plan_export_artifacts`)
Enumerates every file a compile *will* generate — each `.pt2` graph plus the `<model>_meta.json` — **without compiling** (one model load + structural analysis). Importable for programmatic inspection; primarily it sizes the progress denominator `N`.

### 2. Per-file progress
A single-arg `progress_cb(name)` threaded through the compile helpers (fired after each `.pt2`), the metadata write, and the stub write. The CLI prints `[k/N] <name>` covering `.pt2`, `.json`, **and** the `.i` stub:

```
[1/4] model.pt2
[2/4] model_jvp.pt2
[3/4] model_meta.json
[4/4] model_aoti.i
```

### 3. Parallel segment compilation (`-j/--jobs N`)
Independent segments compile concurrently in a **spawn** process pool. Workers re-derive their assigned segment from the input file (no live `nn.Module` crosses the process boundary), stream per-`.pt2` progress back via a `Manager` queue + drainer thread, and segment metadata is reassembled in segment order so `_meta.json` is **identical to a serial run**. Only a multi-segment model (a `ComposedModel` containing an `ImplicitUpdate`) benefits; single-segment models fall back to serial, and `N` is capped at the segment count (one task per segment). With `--device cuda`, each worker warns about its own CUDA context / nvcc.

### Interactive wizard
`neml2-compile --interactive` gains a **Processes** step that first shows the segment plan (via `plan_summary`), then asks the process count. Single-segment models pin `jobs=1` without prompting; over-requests are clamped to the segment count.

## Design (single source of truth)
Both artifact prediction and the real compile flow through **one** planner (`_plan_segments` → `_SegmentPlan`) and **one** executor (`_execute_segment_plan`), fed by a factored-out `_prepare_export` (the setup prelude) and `_segment_reachability` (the derivative-graph reachability analysis). The former `_export_forward` / `_export_implicit` / `_export_composed` collapse into this path — they produced an identical meta envelope. A drift-guard test asserts *predicted == produced*, keeping the emit-order predictors in lockstep with the `compile_model` call sites.

Process pool (not threads) is deliberate: `torch.export` is GIL-bound and Inductor holds process-global state (`trace_autograd_ops`); process-level parallel compiles are already how `pytest -n auto tests/aoti/` runs.

## Tests
- **Unit** (`tests/unit/test_aoti_export.py`): emit-order predictors, `meta.json`-last ordering, the pvjp single-forward asymmetry, and full `plan_export_artifacts` wiring for forward / single-implicit / composed.
- **AOTI** (`tests/aoti/test_compile_cli.py`): drift guard (`predicted == produced == on-disk`, incl. `.json`/`.i`); parallel equivalence (`jobs=1` vs over-provisioned `jobs=8` → identical `_meta.json` + file set); single-segment fallback; `--jobs 0` usage error.
- **Wizard** (`tests/unit/test_compile_interactive.py`): `-j` argv emission, jobs validation, `plan_summary` on single/multi-segment models, parser round-trip, and both `_ask_jobs` branches (prompt on multi-segment, no-prompt on single, clamp `99 → 3`).

## Docs
`doc/content/references/pipeline.md` and `aoti_packages.md` document parallel segments, per-file progress, and `plan_export_artifacts` (deps referenced by name; no hardcoded versions).

## Notes
- `jobs=1` (default) is behavior-identical to before; the full `tests/unit/` suite (669) and all AOTI suites pass, ruff + pyright clean.
- Granularity is per-segment; per-`.pt2` parallelism (which would help single-segment implicit models) is left as possible future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)