### PR TITLE
neml2-compile: flatten -j across the (device × segment) grid + device-tagged progress

### DIFF
--- a/doc/content/references/aoti_packages.md
+++ b/doc/content/references/aoti_packages.md
@@ -94,12 +94,14 @@ The full set of files a compile will write — every `.pt2`, each
 per-device `<name>_meta.json`, and the `<name>_aoti.i` stub — can be
 enumerated ahead of time, without compiling, via
 `neml2.cli.aoti_export.plan_export_artifacts`. `neml2-compile` prints
-`[k/N]` progress against that count as each file lands. For a
-multi-segment model (see the segment table below), the `_seg{i}`
-segments are independent and can be compiled concurrently with
-`neml2-compile -j N` (a spawn process pool); the emitted artifacts and
-metadata are identical to a serial compile. Single-segment models ignore
-`-j`.
+`[k/N]` progress against that count as each file lands, tagging every
+per-device file with its device (e.g. `cpu/<name>_seg0.pt2`). The
+independent compile units — each `(device, segment)` pair — are flattened
+into one spawn process pool by `neml2-compile -j N`, so both axes
+parallelize together: a `--device cpu cuda` build of a two-segment model
+fully uses `-j 4`, and the emitted artifacts and metadata are identical to
+a serial compile. `N` is capped at the number of `(device, segment)` cells,
+so a single-segment single-device build ignores `-j`.
 
 Inside each `<device>/` subfolder, a forward single-segment model emits
 the metadata plus a value graph and an optional JVP graph:

--- a/doc/content/references/pipeline.md
+++ b/doc/content/references/pipeline.md
@@ -153,21 +153,26 @@ what lets a multi-segment artifact present a single forward
 contract to the loader.
 
 The segments are coupled **only** at runtime, through that state map;
-their compiles are independent. `neml2-compile -j N` therefore compiles
-up to `N` segments concurrently in a spawn process pool — each worker
-re-derives its assigned segment from the input file (live models can't
-cross the process boundary), and the per-segment metadata is reassembled
-in segment order so the resulting `_meta.json` is identical to a serial
-run. Only a multi-segment model (a `ComposedModel` containing an
-`ImplicitUpdate`) benefits; a single-segment model ignores `-j`. With
-`--device cuda` each worker initializes its own CUDA context and invokes
-the CUDA compiler, so watch memory when raising `N`.
+their compiles are independent. `neml2-compile -j N` therefore flattens
+the whole `(device × segment)` grid into a single spawn process pool of up
+to `N` workers — each worker re-derives its assigned segment from the input
+file (live models can't cross the process boundary), and the per-segment
+metadata is reassembled in segment order so each device's `_meta.json` is
+identical to a serial run. Because the grid spans devices, a
+`--device cpu cuda` build of a two-segment model saturates `-j 4` (and the
+devices compile concurrently); `N` is capped at the number of grid cells.
+Only work that actually partitions benefits — a single-segment model on one
+device has one cell, so `-j` is a no-op there. With `--device cuda` each
+worker initializes its own CUDA context and invokes the CUDA compiler, so a
+`cpu`-target and a `cuda`-target compile running at once share CPU cores;
+watch memory when raising `N`.
 
 The set of segments — and every file the compile will produce — can be
 enumerated ahead of time, without compiling, via
 `neml2.cli.aoti_export.plan_export_artifacts`. `neml2-compile` uses it to
-size the `[k/N]` per-file progress it prints as each `.pt2`, the
-`_meta.json`, and the `_aoti.i` stub is written.
+size the `[k/N]` per-file progress it prints as each `.pt2` and
+`_meta.json` (each tagged with its device, e.g. `cpu/model_seg0.pt2`) and
+the `_aoti.i` stub is written.
 
 ## Stage 7 — Trace, lower, package
 

--- a/neml2/cli/_compile_wizard.py
+++ b/neml2/cli/_compile_wizard.py
@@ -354,9 +354,10 @@ def _print_segment_plan(summary: PlanSummary) -> None:
 def _ask_jobs(input_file: str, state: dict) -> bool:
     """Show the segment plan, then ask how many processes to compile with.
 
-    A single-segment model has nothing to parallelize, so we note that and pin
-    ``jobs=1`` without prompting. Otherwise the count is capped for display at the
-    segment count (extra workers just idle)."""
+    ``neml2-compile`` flattens the ``(device × segment)`` grid into one pool, so
+    the useful maximum is ``#devices × #segments``. A build with a single grid
+    cell has nothing to parallelize, so we note that and pin ``jobs=1`` without
+    prompting; otherwise we clamp the chosen count to the grid size."""
     try:
         summary: PlanSummary | None = plan_summary(_form_state(input_file, state, ()))
     except Exception as exc:  # noqa: BLE001
@@ -364,31 +365,37 @@ def _ask_jobs(input_file: str, state: dict) -> bool:
         summary = None
 
     n_seg = len(summary.segments) if summary else 0
+    n_dev = max(1, len(state.get("devices", ())))
+    n_cells = n_seg * n_dev
     if summary:
         _print_segment_plan(summary)
+        if n_dev > 1:
+            questionary.print(
+                f"  × {n_dev} devices = {n_cells} independent compile task(s)", style="italic"
+            )
 
-    if n_seg <= 1:
+    if n_cells <= 1:
         questionary.print(
-            "(single segment -- parallel compilation is not applicable; using 1 process)",
+            "(one compile task -- parallel compilation is not applicable; using 1 process)",
             style="italic",
         )
         state["jobs"] = 1
         return True
 
     v = questionary.text(
-        f"Parallel compile processes (1 = serial; up to {n_seg} segments run concurrently):",
+        f"Parallel compile processes (1 = serial; up to {n_cells} tasks run concurrently):",
         default=str(state.get("jobs", 1)),
         validate=_positive_int,
     ).ask()
     if v is None:
         return False
-    # Clamp to the segment count: extra processes would only sit idle (one task
-    # per segment), so the previewed -j reflects the useful maximum.
+    # Clamp to the grid size: extra processes would only sit idle (one task per
+    # (device, segment) cell), so the previewed -j reflects the useful maximum.
     requested = max(1, int(v.strip()))
-    state["jobs"] = min(requested, n_seg)
-    if requested > n_seg:
+    state["jobs"] = min(requested, n_cells)
+    if requested > n_cells:
         questionary.print(
-            f"(capped at {n_seg}: there are only {n_seg} segments to compile)",
+            f"(capped at {n_cells}: there are only {n_cells} compile task(s))",
             style="italic",
         )
     return True

--- a/neml2/cli/aoti_compile.py
+++ b/neml2/cli/aoti_compile.py
@@ -53,7 +53,7 @@ import sys
 from pathlib import Path
 
 from ._extensions import add_load_argument, load_user_extensions
-from .aoti_export import export_model_for_aoti
+from .aoti_export import export_model_multidevice
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -738,31 +738,30 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
 
-    compiled: list[tuple[str, Path]] = []
-    meta: dict = {}
-    for device in devices:
-        device_dir = artifact_dir / device
-        device_dir.mkdir(parents=True, exist_ok=True)
-        try:
-            meta = export_model_for_aoti(
-                input_path,
-                model_name,
-                device_dir,
-                device=device,
-                dtype=args.dtype,
-                promoted=set(args.parameter),
-                example_batch_shape=example_batch_shape,
-                dynamic_batch=args.dynamic_batch,
-                derivatives=tuple(args.derivative),
-                renames=renames,
-                additional_args=tuple(additional_args),
-                jobs=args.jobs,
-                progress_cb=progress_cb,
-            )
-        except Exception as exc:  # noqa: BLE001
-            print(f"Error compiling '{model_name}' for {device}: {exc}", file=sys.stderr)
-            return 1
-        compiled.append((device, device_dir / f"{model_name}_meta.json"))
+    # Compile every device, parallelizing across the full (device x segment) grid
+    # (jobs bounds the workers across ALL cells, so multiple devices compile
+    # concurrently). progress_cb receives device-tagged names from the orchestrator.
+    try:
+        metas = export_model_multidevice(
+            input_path,
+            model_name,
+            artifact_dir,
+            devices,
+            dtype=args.dtype,
+            promoted=set(args.parameter),
+            example_batch_shape=example_batch_shape,
+            dynamic_batch=args.dynamic_batch,
+            derivatives=tuple(args.derivative),
+            renames=renames,
+            additional_args=tuple(additional_args),
+            jobs=args.jobs,
+            progress_cb=progress_cb,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error compiling '{model_name}': {exc}", file=sys.stderr)
+        return 1
+    compiled = [(device, artifact_dir / device / f"{model_name}_meta.json") for device in devices]
+    meta = next(iter(metas.values()))  # envelope is identical across devices
 
     # One standalone stub next to the artifact folder, pointing at it.
     stub_path = output_dir / f"{model_name}_aoti.i"

--- a/neml2/cli/aoti_export.py
+++ b/neml2/cli/aoti_export.py
@@ -3156,6 +3156,166 @@ def _compile_segments_parallel(
     return [results[i] for i in range(n)]
 
 
+def _finalize_device_meta(
+    prepared: _PreparedExport,
+    model_name: str,
+    device: str,
+    dtype: str,
+    seg_metas: list[dict],
+    output_dir: Path,
+    progress_cb: Callable[[str], None] | None = None,
+) -> dict:
+    """Assemble one device's top-level metadata envelope, write it, and report it.
+
+    The envelope is device-independent except for the recorded ``device`` (the
+    top-level field and each promoted parameter's ``device``), so a single
+    cpu-side *prepared* can finalize every device -- which is what lets the
+    multi-device grid path (:func:`export_model_multidevice`) prepare once on cpu
+    and still emit per-device metadata identical to a per-device compile.
+    """
+    model = prepared.model
+    structural_in = _structural_inputs(model.input_spec, prepared.promoted_qnames)
+    in_sb = {n: sub for n, (_, sub) in (prepared.resolved_shapes or {}).items() if sub}
+    meta: dict = {
+        "schema_version": AOTI_META_SCHEMA_VERSION,
+        "type": "composed",
+        "inputs": _var_infos(structural_in, sub_batch_shapes=in_sb),
+        "outputs": _var_infos(model.output_spec),
+        "segments": seg_metas,
+    }
+    # v2 top-level additions: device + dtype are baked into the artifact;
+    # parameters records the promoted set with initial values.
+    meta["device"] = device
+    meta["dtype"] = dtype
+    meta["parameters"] = _parameter_infos(
+        prepared.promoted_snapshots, prepared.origin, prepared.promoted_base_shapes, device
+    )
+    # Master (out, in) derivative pairs, in deterministic (output, input) order.
+    out_order = {n: k for k, n in enumerate(model.output_spec)}
+    in_order = {n: k for k, n in enumerate(prepared.structural_input_names)}
+    meta["derivatives"] = [
+        [o, i]
+        for (o, i) in sorted(
+            prepared.master_pairs, key=lambda p: (out_order.get(p[0], 0), in_order.get(p[1], 0))
+        )
+    ]
+    # Master (out, param) parameter-derivative pairs, in (output, param) order.
+    meta["parameter_derivatives"] = [
+        [o, p]
+        for (o, p) in sorted(prepared.param_pairs, key=lambda x: (out_order.get(x[0], 0), x[1]))
+    ]
+    # Boundary renames (shallow): only namespaces with an actual rename are written.
+    active_aliases = {ns: m for ns, m in prepared.boundary_aliases.items() if m}
+    if active_aliases:
+        meta["boundary_aliases"] = active_aliases
+
+    meta_name = f"{model_name}_meta.json"
+    _write_meta(output_dir / meta_name, meta)
+    _report(progress_cb, meta_name)
+    return meta
+
+
+def _compile_grid_worker(args) -> tuple[str, int, dict]:
+    """Worker for the multi-device grid: compile ONE ``(device, segment)`` cell.
+
+    Like :func:`_compile_segment_worker` but keyed by device -- it writes to that
+    device's artifact subfolder and tags its progress events with the device so
+    the parent can distinguish the same segment across devices. Everything in
+    *args* is picklable; the worker re-derives its segment from the input file.
+    """
+    hit_path, model_name, output_dir, device, export_opts, seg_index = args
+    prepared = _prepare_export(hit_path, model_name, device=device, **export_opts)
+    plans = _plan_segments(prepared, model_name)
+    plan = plans[seg_index]
+    queue = _worker_progress_queue
+    cb = (lambda name: queue.put(f"{device}/{name}")) if queue is not None else None
+    seg_meta = _execute_segment_plan(plan, prepared, Path(output_dir), device, progress_cb=cb)
+    return device, seg_index, seg_meta
+
+
+def _run_grid_pool(
+    hit_path: str | Path,
+    model_name: str,
+    artifact_dir: Path,
+    devices: list[str],
+    n_segments: int,
+    export_opts: dict,
+    jobs: int,
+    progress_cb: Callable[[str], None] | None,
+) -> dict[str, list[dict]]:
+    """Compile the full ``(device × segment)`` grid concurrently in a spawn pool.
+
+    Up to ``min(jobs, len(devices) * n_segments)`` workers run at once, so the two
+    parallelism axes (devices and segments) are flattened into one pool -- e.g.
+    two devices with two segments each fully use ``-j 4``. Returns
+    ``{device: [seg_meta in segment order]}``; per-``.pt2`` progress (device-tagged)
+    is forwarded to *progress_cb* by a drainer thread.
+    """
+    import concurrent.futures as cf
+    import multiprocessing as mp
+    import threading
+
+    ctx = mp.get_context("spawn")
+    tasks = [(device, i) for device in devices for i in range(n_segments)]
+    workers = max(1, min(jobs, len(tasks)))
+
+    manager = None
+    queue = None
+    drainer = None
+    initializer = None
+    initargs: tuple = ()
+    if progress_cb is not None:
+        manager = ctx.Manager()
+        queue = manager.Queue()
+        initializer = _worker_init
+        initargs = (queue,)
+
+        def _drain() -> None:
+            while True:
+                item = queue.get()
+                if item == _PROGRESS_SENTINEL:
+                    break
+                progress_cb(item)
+
+        drainer = threading.Thread(target=_drain, daemon=True)
+        drainer.start()
+
+    results: dict[tuple[str, int], dict] = {}
+    hit_s = str(hit_path)
+    try:
+        with cf.ProcessPoolExecutor(
+            max_workers=workers, mp_context=ctx, initializer=initializer, initargs=initargs
+        ) as ex:
+            futs = {}
+            for device, i in tasks:
+                out_s = str(Path(artifact_dir) / device)
+                futs[
+                    ex.submit(
+                        _compile_grid_worker,
+                        (hit_s, model_name, out_s, device, export_opts, i),
+                    )
+                ] = (device, i)
+            for fut in cf.as_completed(futs):
+                device, i = futs[fut]
+                try:
+                    d, idx, seg_meta = fut.result()
+                except Exception as exc:  # noqa: BLE001
+                    ex.shutdown(cancel_futures=True)
+                    raise RuntimeError(
+                        f"neml2-compile: segment {i} on device {device!r} failed: {exc}"
+                    ) from exc
+                results[(d, idx)] = seg_meta
+    finally:
+        if queue is not None:
+            queue.put(_PROGRESS_SENTINEL)
+        if drainer is not None:
+            drainer.join()
+        if manager is not None:
+            manager.shutdown()
+
+    return {device: [results[(device, i)] for i in range(n_segments)] for device in devices}
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -3287,7 +3447,6 @@ def export_model_for_aoti(
         pre=pre,
         additional_args=additional_args,
     )
-    model = prepared.model
 
     # Plan the segments (cheap, structural). All three model shapes -- forward,
     # single ImplicitUpdate, composed-with-implicit -- flow through one planner so
@@ -3317,54 +3476,129 @@ def export_model_for_aoti(
             for plan in plans
         ]
 
-    # Assemble the top-level metadata envelope (identical across all three shapes).
-    structural_in = _structural_inputs(model.input_spec, prepared.promoted_qnames)
-    in_sb = {n: sub for n, (_, sub) in (prepared.resolved_shapes or {}).items() if sub}
-    meta: dict = {
-        "schema_version": AOTI_META_SCHEMA_VERSION,
-        "type": "composed",
-        "inputs": _var_infos(structural_in, sub_batch_shapes=in_sb),
-        "outputs": _var_infos(model.output_spec),
-        "segments": seg_metas,
-    }
-
-    # v2 top-level additions: device + dtype are baked into the artifact;
-    # parameters records the promoted set with initial values.
-    meta["device"] = device
-    meta["dtype"] = dtype
-    meta["parameters"] = _parameter_infos(
-        prepared.promoted_snapshots, prepared.origin, prepared.promoted_base_shapes, device
+    return _finalize_device_meta(
+        prepared, model_name, device, dtype, seg_metas, output_dir, progress_cb=progress_cb
     )
-    # Master (out, in) derivative pairs the artifact supports, in deterministic
-    # (output-order, input-order) order so the runtime iterates rows/cols
-    # consistently. Empty => no derivative graphs (jvp/jacobian raise).
-    out_order = {n: k for k, n in enumerate(model.output_spec)}
-    in_order = {n: k for k, n in enumerate(prepared.structural_input_names)}
-    meta["derivatives"] = [
-        [o, i]
-        for (o, i) in sorted(
-            prepared.master_pairs, key=lambda p: (out_order.get(p[0], 0), in_order.get(p[1], 0))
+
+
+def export_model_multidevice(
+    hit_path: str | Path,
+    model_name: str,
+    artifact_dir: str | Path,
+    devices: Sequence[str],
+    *,
+    dtype: str = "float64",
+    promoted: set[str] | list[str] | tuple[str, ...] = (),
+    example_batch_shape: dict[str, str] | str | None = None,
+    dynamic_batch: bool | None = None,
+    derivatives: Sequence[str] = (),
+    renames: dict[str, dict[str, str]] | None = None,
+    pre: Sequence[str] = (),
+    additional_args: tuple[str, ...] = (),
+    jobs: int = 1,
+    progress_cb: Callable[[str], None] | None = None,
+) -> dict[str, dict]:
+    """Compile *model_name* for every device in *devices*, parallelizing across
+    the full ``(device × segment)`` grid.
+
+    Each device's artifacts land in ``artifact_dir/<device>/`` with its own
+    ``<model_name>_meta.json``; returns ``{device: meta}``. This is the CLI's
+    multi-device entry point: unlike calling :func:`export_model_for_aoti` once
+    per device (which parallelizes only that device's segments and runs devices
+    sequentially), *jobs* here bounds the workers across ALL ``(device, segment)``
+    pairs at once -- so e.g. two devices with two segments each saturate ``-j 4``,
+    and the devices compile concurrently.
+
+    *progress_cb* is invoked with a device-tagged ``"<device>/<filename>"`` for
+    every generated ``.pt2`` and ``_meta.json`` (so the same segment on different
+    devices is distinguishable). ``jobs`` is capped at the number of grid cells.
+    Single-device / ``jobs=1`` runs are behavior-identical to a per-device
+    :func:`export_model_for_aoti`.
+    """
+    artifact_dir = Path(artifact_dir).resolve()
+    devices = list(dict.fromkeys(devices))  # de-dupe, preserve order
+
+    def _dev_cb(device: str) -> Callable[[str], None] | None:
+        if progress_cb is None:
+            return None
+        cb = progress_cb  # bind non-None for the closure
+        return lambda name: cb(f"{device}/{name}")
+
+    def _prepare_on(device: str) -> _PreparedExport:
+        return _prepare_export(
+            hit_path,
+            model_name,
+            device=device,
+            promoted=promoted,
+            example_batch_shape=example_batch_shape,
+            dynamic_batch=dynamic_batch,
+            derivatives=derivatives,
+            renames=renames,
+            pre=pre,
+            additional_args=additional_args,
         )
-    ]
-    # Master (out, param) parameter-derivative pairs the artifact supports, in
-    # deterministic (output-order, param-name) order. Empty => no param-jacobian
-    # graph (the runtime parameter-Jacobian accessor raises).
-    meta["parameter_derivatives"] = [
-        [o, p]
-        for (o, p) in sorted(prepared.param_pairs, key=lambda x: (out_order.get(x[0], 0), x[1]))
-    ]
-    # Boundary renames (shallow): remap only the names reported at the artifact's
-    # interface. Absent => the interface uses the original authored names. Only
-    # namespaces with an actual rename are written, so a fully-baked artifact is
-    # unchanged.
-    active_aliases = {ns: m for ns, m in prepared.boundary_aliases.items() if m}
-    if active_aliases:
-        meta["boundary_aliases"] = active_aliases
 
-    meta_name = f"{model_name}_meta.json"
-    _write_meta(output_dir / meta_name, meta)
-    _report(progress_cb, meta_name)
-    return meta
+    # Plan once on cpu -- the segment structure is device-independent, and this
+    # keeps the parent from initializing CUDA (the workers own that).
+    prepared_cpu = _prepare_on("cpu")
+    plans = _plan_segments(prepared_cpu, model_name)
+    n = len(plans)
+    for device in devices:
+        (artifact_dir / device).mkdir(parents=True, exist_ok=True)
+
+    metas: dict[str, dict] = {}
+    if jobs > 1 and len(devices) * n > 1:
+        # Grid pool: workers re-derive each (device, segment) from picklable opts.
+        export_opts = {
+            "promoted": sorted(set(promoted)),
+            "example_batch_shape": example_batch_shape,
+            "dynamic_batch": dynamic_batch,
+            "derivatives": tuple(derivatives),
+            "renames": renames,
+            "pre": tuple(pre),
+            "additional_args": tuple(additional_args),
+        }
+        seg_by_dev = _run_grid_pool(
+            hit_path, model_name, artifact_dir, devices, n, export_opts, jobs, progress_cb
+        )
+        # The cpu-side prepared finalizes every device (envelope is device-
+        # independent apart from the recorded device fields).
+        for device in devices:
+            metas[device] = _finalize_device_meta(
+                prepared_cpu,
+                model_name,
+                device,
+                dtype,
+                seg_by_dev[device],
+                artifact_dir / device,
+                progress_cb=_dev_cb(device),
+            )
+    else:
+        # Serial: prepare per device (device-correct) and compile in order --
+        # behavior-identical to a per-device export_model_for_aoti.
+        for device in devices:
+            dev_dir = artifact_dir / device
+            prepared_d = _prepare_on(device)
+            plans_d = _plan_segments(prepared_d, model_name)
+            seg_metas = [
+                _execute_segment_plan(p, prepared_d, dev_dir, device, progress_cb=_dev_cb(device))
+                for p in plans_d
+            ]
+            metas[device] = _finalize_device_meta(
+                prepared_d,
+                model_name,
+                device,
+                dtype,
+                seg_metas,
+                dev_dir,
+                progress_cb=_dev_cb(device),
+            )
+    return metas
 
 
-__all__ = ["export_model_for_aoti", "plan_export_artifacts", "AOTI_META_SCHEMA_VERSION"]
+__all__ = [
+    "export_model_for_aoti",
+    "export_model_multidevice",
+    "plan_export_artifacts",
+    "AOTI_META_SCHEMA_VERSION",
+]

--- a/tests/aoti/test_compile_cli.py
+++ b/tests/aoti/test_compile_cli.py
@@ -178,3 +178,55 @@ def test_jobs_ignored_for_single_segment(tmp_path):
     assert {p.name for p in j1_dir.iterdir() if p.is_file()} == {
         p.name for p in j4_dir.iterdir() if p.is_file()
     }
+
+
+# ---------------------------------------------------------------------------
+# Multi-device grid orchestration (export_model_multidevice)
+# ---------------------------------------------------------------------------
+
+
+def test_multidevice_matches_single_device_export(tmp_path):
+    """A single-device grid run must produce metadata + artifacts byte-identical
+    to a direct per-device export_model_for_aoti (the CLI now routes through the
+    grid orchestrator, so this pins that they agree)."""
+    from neml2.cli.aoti_export import export_model_for_aoti, export_model_multidevice
+
+    direct_dir = tmp_path / "direct" / "cpu"
+    direct_dir.mkdir(parents=True)
+    grid_root = tmp_path / "grid"
+    grid_root.mkdir()
+
+    meta_direct = export_model_for_aoti(_COMPOSED_INPUT, "model", direct_dir, derivatives=[":"])
+    metas_grid = export_model_multidevice(
+        _COMPOSED_INPUT, "model", grid_root, ["cpu"], derivatives=[":"]
+    )
+
+    assert set(metas_grid) == {"cpu"}
+    assert json.dumps(metas_grid["cpu"], sort_keys=True) == json.dumps(meta_direct, sort_keys=True)
+    assert {p.name for p in (grid_root / "cpu").iterdir() if p.is_file()} == {
+        p.name for p in direct_dir.iterdir() if p.is_file()
+    }
+
+
+def test_multidevice_grid_parallel_matches_serial_and_tags_device(tmp_path):
+    """The grid pool (jobs>1) matches serial output and reports device-tagged
+    progress; over-provisioned jobs are capped at the grid size."""
+    from neml2.cli.aoti_export import export_model_multidevice
+
+    serial_dir = tmp_path / "s"
+    par_dir = tmp_path / "p"
+    serial_dir.mkdir()
+    par_dir.mkdir()
+
+    reported: list[str] = []
+    metas_serial = export_model_multidevice(_COMPOSED_INPUT, "model", serial_dir, ["cpu"], jobs=1)
+    metas_par = export_model_multidevice(
+        _COMPOSED_INPUT, "model", par_dir, ["cpu"], jobs=8, progress_cb=reported.append
+    )
+
+    assert json.dumps(metas_serial["cpu"], sort_keys=True) == json.dumps(
+        metas_par["cpu"], sort_keys=True
+    )
+    # Every reported generated file is device-tagged (single-device -> all "cpu/").
+    assert reported and all(name.startswith("cpu/") for name in reported)
+    assert "cpu/model_meta.json" in reported

--- a/tests/unit/test_compile_interactive.py
+++ b/tests/unit/test_compile_interactive.py
@@ -1028,8 +1028,8 @@ def test_ask_jobs_single_segment_no_prompt(monkeypatch):
 
 
 def test_ask_jobs_clamps_to_segment_count(monkeypatch):
-    """Requesting more processes than segments is clamped to the segment count
-    (the composed fixture has 3 segments)."""
+    """On one device, requesting more processes than segments is clamped to the
+    segment count (the composed fixture has 3 segments)."""
     pytest.importorskip("questionary")
     import neml2  # noqa: F401, PLC0415 — registers models
     from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
@@ -1040,3 +1040,35 @@ def test_ask_jobs_clamps_to_segment_count(monkeypatch):
     state["name"] = "model"
     assert wiz._ask_field("jobs", str(_COMPOSED_I), state, {}) is True
     assert state["jobs"] == 3
+
+
+def test_ask_jobs_clamps_to_grid_over_multiple_devices(monkeypatch):
+    """The clamp is the grid size #devices × #segments: 2 devices × 3 segments = 6
+    (computed from the chosen device list; no CUDA needed to plan)."""
+    pytest.importorskip("questionary")
+    import neml2  # noqa: F401, PLC0415 — registers models
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary(["99"]))
+    state = wiz._default_state()
+    state["target"] = "model"
+    state["name"] = "model"
+    state["devices"] = ("cpu", "cuda")
+    assert wiz._ask_field("jobs", str(_COMPOSED_I), state, {}) is True
+    assert state["jobs"] == 6
+
+
+def test_ask_jobs_single_segment_multi_device_prompts(monkeypatch):
+    """A single-segment model on TWO devices is still a 2-cell grid, so parallel
+    compilation applies and the wizard prompts (rather than pinning to 1)."""
+    pytest.importorskip("questionary")
+    import neml2  # noqa: F401, PLC0415 — registers models
+    from neml2.cli import _compile_wizard as wiz  # noqa: PLC2701, PLC0415
+
+    monkeypatch.setattr(wiz, "questionary", _FakeQuestionary(["2"]))
+    state = wiz._default_state()
+    state["target"] = "model"
+    state["name"] = "model"
+    state["devices"] = ("cpu", "cuda")
+    assert wiz._ask_field("jobs", str(_ELASTICITY_I), state, {}) is True
+    assert state["jobs"] == 2


### PR DESCRIPTION
Follow-up to #420. Addresses two limitations found while using `-j` with multiple devices.

## Problems

1. **`-j` couldn't span devices.** `main()` looped `--device` values *serially*, and each device's `export_model_for_aoti` capped workers at that device's segment count (`min(jobs, #segments)`). So `--device cpu cuda` on a 2-segment model could never use more than 2 of `-j 4`, and the two devices compiled one after another — even though there are 2×2 = 4 independent compile tasks.
2. **Progress didn't distinguish devices.** The `[k/N]` counter spanned devices but each line printed a bare filename, so `model_seg0.pt2` appeared once per device with no way to tell which.

## Changes

### Grid parallelism
New `export_model_multidevice()` orchestrator flattens the full `(device × segment)` grid into a **single** spawn process pool sized `min(jobs, #cells)`. Both axes parallelize together — `--device cpu cuda` on a 2-segment model saturates `-j 4`, and devices compile concurrently. Each device's `_meta.json` is reassembled in segment order, so it stays **byte-identical to a serial compile**. Planning happens once on cpu (no parent CUDA init; workers own their device). `N` is capped at the number of grid cells.

The CLI now routes through this orchestrator. `export_model_for_aoti` remains the unchanged single-device public API (used by `compile_and_emit_stub` / benchmark); the shared metadata assembly was factored into `_finalize_device_meta`, and `export_model_for_aoti`'s behavior is verified identical (`tests/unit/test_aoti_export.py`, 24 tests).

### Device-tagged progress
Every per-device file is now reported as `[k/N] <device>/<file>` (e.g. `cpu/model_seg0.pt2` vs `cuda/model_seg0.pt2`); the standalone `_aoti.i` stub stays bare.

```
[1/6] cpu/model_seg0.pt2
[2/6] cpu/model_seg1_rhs.pt2
[3/6] cpu/model_seg2.pt2        # out-of-order = real parallelism
[4/6] cpu/model_seg1_step.pt2
[5/6] cpu/model_meta.json
[6/6] model_aoti.i
```

### Interactive wizard
The `-j` prompt now caps at `#devices × #segments` (not just segments), and a single-segment model on multiple devices is still a multi-cell grid, so the wizard prompts instead of pinning `jobs=1`.

## Tests
- `test_multidevice_matches_single_device_export` — grid orchestrator output == direct `export_model_for_aoti` (metadata + files).
- `test_multidevice_grid_parallel_matches_serial_and_tags_device` — grid `jobs>1` matches serial, over-provisioned `-j` is capped, progress is device-tagged.
- Wizard: `test_ask_jobs_clamps_to_grid_over_multiple_devices` (2×3 → cap 6), `test_ask_jobs_single_segment_multi_device_prompts` (1 seg × 2 devices → prompts).
- Existing drift-guard / parallel-equivalence / single-segment-fallback tests unchanged and green.

Docs updated (`pipeline.md`, `aoti_packages.md`). ruff/pyright/pre-commit clean.

## Notes
- CUDA multi-device isn't CI-testable (no GPU), but the single-device grid path exercises the same pool/worker/regroup/finalize code and the workers are device-parametrized.
- Granularity remains per-segment; per-`.pt2` parallelism (which would help single-segment implicit models) is scoped as possible future work — the grid task tuple extends `(device, segment)` → `(device, segment, graph)` cleanly, but it requires decoupling metadata assembly from compilation in the compile helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)