### PR TITLE
Fix neml2-compile --load under -j N; pin torch in CI (v3.0.7)

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -308,12 +308,22 @@ jobs:
       - name: Smoke-test the built wheel
         # Install + import the wheel this cell just built. cibuildwheel's own
         # test-command only runs on tag releases, so this gives every
-        # (os, python) cell a basic packaging check on PRs too. pip resolves the
-        # runtime deps (torch / pyzag / nmhit) straight from pyproject.toml.
+        # (os, python) cell a basic packaging check on PRs too. Pin torch to the
+        # reference version BEFORE installing the wheel so pip's resolver keeps
+        # it (pyproject.toml leaves torch's upper bound open): the compat matrix
+        # is the one place that sweeps torch versions; this smoke test must stay
+        # reproducible and not drift onto every new PyTorch release.
         shell: bash
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            # dependencies: torch.version
+            python -m pip install torch==2.12.1 --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple
+          else
+            # dependencies: torch.version
+            python -m pip install torch==2.12.1
+          fi
           python -m pip install wheelhouse/*.whl
           python -c "import neml2; print(f'neml2 {neml2.__version__} loads from {neml2.__file__}')"
       - uses: actions/upload-artifact@v7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # dependencies: cmake.version_min
 cmake_minimum_required(VERSION 3.26.1)
 # dependencies: neml2.version
-project(NEML2 VERSION 3.0.6 LANGUAGES C CXX)
+project(NEML2 VERSION 3.0.7 LANGUAGES C CXX)
 
 # ----------------------------------------------------------------------------
 # Testing (enable_testing + ctest plumbing)

--- a/neml2/cli/aoti_compile.py
+++ b/neml2/cli/aoti_compile.py
@@ -280,6 +280,7 @@ def compile_and_emit_stub(
     renames: dict[str, dict[str, str]] | None = None,
     pre: tuple[str, ...] = (),
     additional_args: tuple[str, ...] = (),
+    load: tuple[str, ...] = (),
     jobs: int = 1,
     emit_stub: bool = True,
     progress_cb=None,
@@ -306,6 +307,11 @@ def compile_and_emit_stub(
     # Local import keeps the module import-light when only the helpers
     # below are needed.
     from neml2.cli.aoti_export import export_model_for_aoti  # noqa: PLC0415
+
+    # Register any user extensions in THIS process (needed for the serial path +
+    # driver_target_model lookup below); they are also forwarded to spawn workers
+    # via export_model_for_aoti(load=...) so jobs>1 resolves custom types too.
+    load_user_extensions(list(load))
 
     if (driver is None) == (model is None):
         raise ValueError("compile_and_emit_stub: pass exactly one of `driver` or `model`")
@@ -334,6 +340,7 @@ def compile_and_emit_stub(
         renames=renames,
         pre=pre,
         additional_args=additional_args,
+        load=load,
         jobs=jobs,
         progress_cb=progress_cb,
     )
@@ -768,6 +775,7 @@ def main(argv: list[str] | None = None) -> int:
             derivatives=tuple(args.derivative),
             renames=renames,
             additional_args=tuple(additional_args),
+            load=tuple(args.load),
             jobs=args.jobs,
             progress_cb=progress_cb,
         )

--- a/neml2/cli/aoti_export.py
+++ b/neml2/cli/aoti_export.py
@@ -58,6 +58,8 @@ CLI
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from math import prod
@@ -1027,8 +1029,35 @@ def _parameter_infos(
 
 
 def _write_meta(path: Path, meta: dict) -> None:
-    with open(path, "w") as f:
-        json.dump(meta, f, indent=2)
+    """Write ``metadata.json`` atomically and durably.
+
+    A reader -- notably the C++ ``aoti::Model`` loader, which opens
+    ``metadata.json`` immediately after this returns in the same process --
+    must never observe a partial or empty file. A plain ``open(path, "w")``
+    truncates to zero, then writes, leaving a window where the file exists at
+    zero bytes; on Windows (write-behind cache + a virus scanner touching the
+    freshly created file, amplified by the parallel ``-n auto`` test run) a
+    concurrent open then reads empty, and ``nlohmann::json::parse`` fails with
+    "attempting to parse an empty input". Write to a temp file in the same
+    directory, ``flush`` + ``fsync``, then ``os.replace`` (atomic on POSIX and
+    Windows) so the final name only ever appears with complete, durable content.
+    """
+    data = json.dumps(meta, indent=2)
+    # Same directory as the target so os.replace stays on one filesystem (atomic).
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        # Don't leave a stray temp file behind if the write/replace failed.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 # ---------------------------------------------------------------------------

--- a/neml2/cli/aoti_export.py
+++ b/neml2/cli/aoti_export.py
@@ -3072,6 +3072,26 @@ def _worker_init(queue) -> None:
     _worker_progress_queue = queue
 
 
+def _prepare_opts_in_worker(export_opts: dict) -> dict:
+    """Consume the worker-only ``load`` key from *export_opts* and return the
+    remaining ``_prepare_export`` kwargs.
+
+    ``--load`` user extensions are imported only in the *parent* process, but a
+    spawn worker starts a fresh interpreter and would fail to resolve any custom
+    ``@register_neml2_object`` type when it re-derives the model. Re-import them
+    here, before the model is loaded, so the factory can see them. The ``load``
+    entry is popped so it never reaches :func:`_prepare_export`, which takes no
+    such kwarg -- the returned dict is exactly ``_prepare_export``'s kwargs.
+    """
+    opts = dict(export_opts)
+    load = opts.pop("load", ())
+    if load:
+        from ._extensions import load_user_extensions  # noqa: PLC0415
+
+        load_user_extensions(list(load))
+    return opts
+
+
 def _compile_segment_worker(args) -> tuple[int, dict]:
     """Worker entry: re-derive the model from the input file and compile ONE
     segment. Everything in *args* is picklable (paths, strings, an options dict,
@@ -3079,6 +3099,7 @@ def _compile_segment_worker(args) -> tuple[int, dict]:
     Per-``.pt2`` progress is streamed back to the parent through the shared queue.
     """
     hit_path, model_name, output_dir, device, export_opts, seg_index = args
+    export_opts = _prepare_opts_in_worker(export_opts)
     prepared = _prepare_export(hit_path, model_name, device=device, **export_opts)
     plans = _plan_segments(prepared, model_name)
     plan = plans[seg_index]
@@ -3260,6 +3281,7 @@ def _compile_grid_worker(args) -> tuple[str, int, dict]:
     *args* is picklable; the worker re-derives its segment from the input file.
     """
     hit_path, model_name, output_dir, device, export_opts, seg_index = args
+    export_opts = _prepare_opts_in_worker(export_opts)
     prepared = _prepare_export(hit_path, model_name, device=device, **export_opts)
     plans = _plan_segments(prepared, model_name)
     plan = plans[seg_index]
@@ -3372,6 +3394,7 @@ def export_model_for_aoti(
     renames: dict[str, dict[str, str]] | None = None,
     pre: Sequence[str] = (),
     additional_args: tuple[str, ...] = (),
+    load: Sequence[str] = (),
     jobs: int = 1,
     progress_cb: Callable[[str], None] | None = None,
 ) -> dict:
@@ -3446,6 +3469,13 @@ def export_model_for_aoti(
         Trailing HIT override tokens appended to the parser's *post* list
         (e.g. ``"Models/elasticity/E:=210000"``). Path-style overrides only;
         for variable substitution use *pre*.
+    load:
+        User-extension paths (the ``--load`` CLI surface) to import before the
+        model is built, so their ``@register_neml2_object`` types resolve. The
+        caller is responsible for importing them in the current process; under
+        ``jobs > 1`` they are additionally forwarded to each spawn worker, which
+        re-imports them before re-deriving its segment (a fresh interpreter would
+        otherwise not see the custom types). Empty (default) = no extensions.
     jobs:
         Number of worker processes for parallel segment compilation. ``1``
         (default) compiles serially (behavior-identical to before this option).
@@ -3507,6 +3537,7 @@ def export_model_for_aoti(
             "renames": renames,
             "pre": tuple(pre),
             "additional_args": tuple(additional_args),
+            "load": tuple(load),
         }
         seg_metas = _compile_segments_parallel(
             hit_path, model_name, leaf, device, export_opts, plans, jobs, progress_cb
@@ -3537,6 +3568,7 @@ def export_model_multidevice(
     renames: dict[str, dict[str, str]] | None = None,
     pre: Sequence[str] = (),
     additional_args: tuple[str, ...] = (),
+    load: Sequence[str] = (),
     jobs: int = 1,
     progress_cb: Callable[[str], None] | None = None,
 ) -> dict:
@@ -3599,6 +3631,7 @@ def export_model_multidevice(
             "renames": renames,
             "pre": tuple(pre),
             "additional_args": tuple(additional_args),
+            "load": tuple(load),
         }
         seg_by_dev = _run_grid_pool(
             hit_path, model_name, artifact_dir, devices, dtype, n, export_opts, jobs, progress_cb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ build.targets = ["aoti", "eager", "pyneml2", "cpp_tests"]
 [project]
 name = "neml2"
 # dependencies: neml2.version
-version = "3.0.6"
+version = "3.0.7"
 authors = [
   { name = "Mark Messner", email = "messner@anl.gov" },
   { name = "Gary Hu", email = "thu@anl.gov" },
@@ -291,12 +291,19 @@ before-all = ""
 # links its static lib via Findnmhit), so -- unlike the pure-runtime pyzag -- it
 # must be installed before the build. pyzag stays out: repair_wheel.py reads the
 # pure-runtime deps from the freshly-built wheel's metadata after install.
+# torch is pinned (not left bare) so the published wheels compile against the
+# reference build_torch, not whatever PyTorch has most recently released.
+# dependencies: torch.version
 # dependencies: nmhit.version_min
 # dependencies: pybind11_stubgen.version_min
-before-build = "python -m pip install scikit-build-core ninja torch 'nmhit>=0.3.6' wheel pybind11-stubgen>=2.5.5"
+before-build = "python -m pip install scikit-build-core ninja torch==2.12.1 'nmhit>=0.3.6' wheel pybind11-stubgen>=2.5.5"
 
+# Pin torch here too: this is the release wheel's own test gate, so it must run
+# against the reference torch, not drift onto every new PyTorch release. The
+# compat matrix (.github/workflows/compat.yaml) is the one place torch is swept.
+# dependencies: torch.version
 # dependencies: pyzag.version
-test-requires = "pytest torch pyzag==1.1.4"
+test-requires = "pytest torch==2.12.1 pyzag==1.1.4"
 test-command = "pytest -v {project}/tests"
 
 [tool.cibuildwheel.linux]

--- a/scripts/dependencies.yaml
+++ b/scripts/dependencies.yaml
@@ -94,7 +94,7 @@ python:
 
 # ---- Project version ----
 neml2:
-  version: "3.0.6"
+  version: "3.0.7"
   files:
     - CMakeLists.txt
     - pyproject.toml

--- a/tests/aoti/test_compile_cli.py
+++ b/tests/aoti/test_compile_cli.py
@@ -39,6 +39,7 @@ compile.
 from __future__ import annotations
 
 import json
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -218,6 +219,160 @@ def test_jobs_ignored_for_single_segment(tmp_path):
         return names
 
     assert _artifact_names(j1_dir) == _artifact_names(j4_dir)
+
+
+# ---------------------------------------------------------------------------
+# --load user extensions under parallel (-j N) compilation
+# ---------------------------------------------------------------------------
+
+# An out-of-package Scalar leaf: its @register_neml2_object type is invisible to
+# the factory unless the module is imported via --load. Modeled on
+# tests/cpp/fixtures/ext_model.py.
+_EXT_MODEL_BODY = textwrap.dedent(
+    '''
+    """External (out-of-package) Scalar model for the --load + -j compile test."""
+
+    from __future__ import annotations
+
+    from neml2.factory import register_neml2_object
+    from neml2.models.chain_rule import ChainRuleDict
+    from neml2.models.model import Model
+    from neml2.schema import HitSchema, input, output
+    from neml2.types import Scalar
+
+
+    @register_neml2_object("ExtScaleScalar")
+    class ExtScaleScalar(Model):
+        """out = 2 * in -- a trivial external Scalar model."""
+
+        hit = HitSchema(
+            input("from_var", Scalar, "Input scalar"),
+            output("to_var", Scalar, "Output scalar (= 2 * input)"),
+        )
+
+        def forward(  # type: ignore[override]
+            self,
+            from_var: Scalar,
+            v: ChainRuleDict | None = None,
+        ) -> Scalar | tuple[Scalar, ChainRuleDict]:
+            out = from_var * 2.0
+            if v is None:
+                return out
+            return out, self.apply_chain_rule(
+                v, "to_var", {"from_var": lambda V: V * 2.0}, output=out
+            )
+    '''
+)
+
+# A ComposedModel containing an ImplicitUpdate -> 3 segments (forward / implicit
+# / forward), the shape that engages the parallel worker pool. The first forward
+# leaf is the out-of-package ExtScaleScalar, so every worker must re-import the
+# --load module before it can re-derive its segment. Mirrors composed_param/model.i
+# with `scale` swapped for the custom type.
+_EXT_COMPOSED_INPUT = textwrap.dedent(
+    """
+    [Models]
+      [extscale]
+        type = ExtScaleScalar
+        from_var = 'f'
+        to_var = 'x_rate_ext'
+      []
+      [modrate]
+        type = ScalarLinearCombination
+        from = 'x_rate_ext'
+        to = 'x_rate'
+        weights = '1.3'
+      []
+      [intg]
+        type = ScalarBackwardEulerTimeIntegration
+        variable = 'x'
+        time = 't'
+      []
+      [impl_residual]
+        type = ComposedModel
+        models = 'modrate intg'
+      []
+      [out]
+        type = ScalarLinearCombination
+        from = 'x'
+        to = 'y'
+        weights = '2.0'
+      []
+    []
+
+    [EquationSystems]
+      [eq_sys]
+        type = NonlinearSystem
+        model = 'impl_residual'
+        unknowns = 'x'
+        residuals = 'x_residual'
+      []
+    []
+
+    [Solvers]
+      [newton]
+        type = Newton
+        abs_tol = 1e-12
+        rel_tol = 1e-10
+        max_its = 25
+        linear_solver = 'lu'
+      []
+      [lu]
+        type = DenseLU
+      []
+    []
+
+    [Models]
+      [return_map]
+        type = ImplicitUpdate
+        equation_system = 'eq_sys'
+        solver = 'newton'
+      []
+      [model]
+        type = ComposedModel
+        models = 'extscale return_map out'
+      []
+    []
+    """
+)
+
+
+def test_load_extension_parallel_compile(tmp_path):
+    """A --load user extension used by a multi-segment model must compile under
+    -j N. Spawn workers re-derive their segment in a fresh interpreter, so they
+    have to re-import the --load module -- otherwise the custom @register_neml2_object
+    type is unknown and the worker dies (the reported bug)."""
+    ext_py = tmp_path / "ext_scale.py"
+    ext_py.write_text(_EXT_MODEL_BODY)
+    model_i = tmp_path / "model.i"
+    model_i.write_text(_EXT_COMPOSED_INPUT)
+
+    # Regression guard, run FIRST (before --load registers the type in this
+    # process): without --load, the parent can't even resolve the custom type at
+    # planning time, so main() returns 1. This proves the fixture genuinely
+    # depends on the extension.
+    noload_out = tmp_path / "noload"
+    assert main([str(model_i), "--model", "model", "--output-dir", str(noload_out)]) == 1
+
+    # With --load and jobs>1: the parent plans successfully AND every worker
+    # re-imports the extension, so the full 3-segment compile succeeds.
+    out = tmp_path / "out"
+    rc = main(
+        [
+            str(model_i),
+            "--model",
+            "model",
+            "--output-dir",
+            str(out),
+            "--load",
+            str(ext_py),
+            "-j",
+            "2",
+        ]
+    )
+    assert rc == 0
+    assert (out / "model" / "metadata.json").exists()
+    assert (out / "model" / "cpu" / "float64").is_dir()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_aoti_export.py
+++ b/tests/unit/test_aoti_export.py
@@ -900,3 +900,80 @@ def test_export_with_nl_parameter_matches_eager(tmp_path):
     if isinstance(aoti_out, tuple):
         aoti_out = aoti_out[0]
     assert torch.allclose(_as_tensor(eager_out), _as_tensor(aoti_out), rtol=1e-10, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# metadata.json atomic write (_write_meta)
+# ---------------------------------------------------------------------------
+
+
+def test_write_meta_roundtrip_no_temp_left(tmp_path):
+    """Happy path: metadata.json holds the exact dict and no *.tmp file lingers."""
+    from neml2.cli.aoti_export import _write_meta
+
+    p = tmp_path / "metadata.json"
+    meta = {"schema_version": "9", "inputs": [{"name": "x"}], "nested": {"a": 1}}
+    _write_meta(p, meta)
+    assert json.loads(p.read_text()) == meta
+    # The temp file is renamed onto the target, never left behind.
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_write_meta_atomic_overwrite(tmp_path):
+    """A second write replaces the file wholesale (atomic overwrite)."""
+    from neml2.cli.aoti_export import _write_meta
+
+    p = tmp_path / "metadata.json"
+    _write_meta(p, {"v": 1})
+    _write_meta(p, {"v": 2})
+    assert json.loads(p.read_text()) == {"v": 2}
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_write_meta_cleans_temp_on_failure(tmp_path, monkeypatch):
+    """If the atomic replace fails, the exception propagates AND the temp file is
+    removed (no partial/stray metadata left in the artifact dir)."""
+    import os
+
+    from neml2.cli.aoti_export import _write_meta
+
+    def _boom(*_a, **_k):
+        raise OSError("simulated replace failure")
+
+    # _write_meta calls os.replace via the shared os module; patch it there.
+    monkeypatch.setattr(os, "replace", _boom)
+    p = tmp_path / "metadata.json"
+    with pytest.raises(OSError, match="simulated replace failure"):
+        _write_meta(p, {"v": 1})
+    # Target never appeared, and the temp was cleaned up on the failure path.
+    assert not p.exists()
+    assert list(tmp_path.glob("*")) == []
+
+
+# ---------------------------------------------------------------------------
+# spawn-worker extension re-import (_prepare_opts_in_worker)
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_opts_in_worker_imports_load(tmp_path):
+    """A spawn worker re-imports the ``--load`` extensions and strips ``load``
+    from the kwargs it forwards to ``_prepare_export``."""
+    from neml2.cli.aoti_export import _prepare_opts_in_worker
+
+    # An extension whose top-level code has an observable side effect on import.
+    sentinel = tmp_path / "loaded.flag"
+    ext = tmp_path / "ext_mod.py"
+    ext.write_text(f"from pathlib import Path\nPath({str(sentinel)!r}).write_text('loaded')\n")
+    opts = _prepare_opts_in_worker({"load": (str(ext),), "promoted": ["a"]})
+    assert sentinel.exists()  # the extension module was executed
+    assert opts == {"promoted": ["a"]}  # 'load' consumed, rest forwarded verbatim
+
+
+def test_prepare_opts_in_worker_no_load_is_identity_copy():
+    """With no ``load`` key the kwargs pass through unchanged, as a fresh copy."""
+    from neml2.cli.aoti_export import _prepare_opts_in_worker
+
+    src = {"promoted": ["a"], "renames": None, "derivatives": ()}
+    opts = _prepare_opts_in_worker(src)
+    assert opts == src
+    assert opts is not src  # a copy -- never mutate the caller's dict


### PR DESCRIPTION
Two pre-release fixes for the v3.0.7 patch.

## 1. `neml2-compile --load` fails under `-j N` (bug)

`--load` user extensions were imported only in the **parent** process (`main()` → `load_user_extensions`). The `-j N` path spawns `spawn` workers that re-derive each segment via `_prepare_export` → `load_input`, but those fresh interpreters never re-imported the `--load` modules — so custom `@register_neml2_object` types were unknown and the worker died.

**Fix (root cause):** thread `load` through the worker `export_opts` and re-import it in each worker before `_prepare_export` (new `_prepare_opts_in_worker` helper, shared by `_compile_segment_worker` and `_compile_grid_worker`). `load` is exposed on `export_model_for_aoti`, `export_model_multidevice`, and `compile_and_emit_stub`.

**Audit ("do other cliargs fail similarly?"):** No — `--load` was the only gap. `promoted`, `derivatives`, `renames`, `example_batch_shape`, `dynamic_batch`, `pre`, and `additional_args` were all already plumbed into `export_opts`.

**Test:** `tests/aoti/test_compile_cli.py::test_load_extension_parallel_compile` compiles a multi-segment model that uses an out-of-package leaf under `-j 2`, with a no-`--load` regression guard proving the fixture genuinely needs the extension.

## 2. Pin torch in CI (reproducibility)

Three spots installed a bare `torch` and drifted onto each new PyTorch release (this is why the release test gate had silently been running on torch 2.13):

- `[tool.cibuildwheel] before-build` — the **published wheels'** build-time torch
- `[tool.cibuildwheel] test-requires` — the release wheel test gate
- `python.yaml` `wheels` job — the wheel smoke test

All three now pin to `torch.version` (annotated so `dep_manager` keeps them synced). `compat.yaml` remains the one place torch is intentionally swept.

## torch 2.13 — investigated, deferred

An earlier revision of this PR added torch 2.13 support. It was **dropped** after CI showed the AOTI runtime is version-locked to the build torch: a wheel built against 2.12.1 cannot load `.pt2` packages generated by torch 2.13.0's Inductor (AOTI derivative-graph failures → segfault on both Linux and macOS), while building against 2.13.0 references a 2.13-only stable-ABI symbol (`torch_exception_get_what_without_backtrace`) that can't resolve on torch <2.13 (and forces `/std:c++20` on MSVC). Net: **one wheel can't support both torch 2.10–2.12 and 2.13**, so 2.13 is deferred to a dedicated future change (likely requiring a per-torch-minor wheel strategy). This PR leaves the supported range unchanged (torch 2.10.0–2.12.1).

Bumps neml2 `3.0.6` → `3.0.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
