### PR TITLE
AOTI: un-bake the linear solve into operator + solve graphs (schema v10)

### DIFF
--- a/doc/content/references/aoti_packages.md
+++ b/doc/content/references/aoti_packages.md
@@ -128,9 +128,13 @@ boundary into separate **segments**, each numbered `_seg{i}_`:
 | :------------------------------ | :------------------------------------------------------ |
 | `<name>_seg{i}.pt2`             | Forward-segment value graph.                            |
 | `<name>_seg{i}_jvp.pt2`         | Forward-segment per-pair Jacobian graph (only when `-d` requested a pair this segment contributes to). |
-| `<name>_seg{i}_rhs.pt2`         | Implicit-segment Newton residual `-r(u, g)`.            |
-| `<name>_seg{i}_step.pt2`        | Implicit-segment fused assemble + solve + update.       |
-| `<name>_seg{i}_ift.pt2`         | Implicit-function-theorem sensitivity `-A^{-1} B` (only when `-d` requested a pair routed through this segment). |
+| `<name>_seg{i}_residual.pt2`    | Implicit-segment Newton residual `-r(u, g)`.            |
+| `<name>_seg{i}_jacobian.pt2`    | Implicit-segment residual Jacobian operator `A = ∂r/∂u` (+ `b`); no baked solve. |
+| `<name>_seg{i}_solve.pt2`       | Implicit-segment linear solve `du = A^{-1} b` (the configured linear solver, un-baked from the operator). |
+| `<name>_seg{i}_jacobian_given.pt2` | IFT given-side operator `B = ∂r/∂g` (only when `-d` requested an input-derivative pair routed through this segment). |
+| `<name>_seg{i}_solve_ift.pt2`   | IFT solve `-A^{-1} B` disassembled to per-`(unknown, given)` blocks (paired with `_jacobian_given`). |
+| `<name>_seg{i}_dr_dparam.pt2`   | Parameter-derivative operators: dense `A` + `∂r/∂θ` (only when `-d` requested a promoted-parameter pair). |
+| `<name>_seg{i}_solve_param.pt2` | Parameter-sensitivity solve `-A^{-1} ∂r/∂θ` per `(unknown, param)` block. |
 | `<name>_seg{i}_predictor.pt2`   | Newton initial guess (only if the source had one).      |
 
 The `_seg0_` infix is dropped in the single-segment shortcut, so
@@ -168,8 +172,10 @@ folder path. It records, at a high level:
   (`atol`, `rtol`, `miters`) and line-search settings (`ls_type`,
   `ls_max_iters`, `ls_cutback`, `ls_c`). The C++ runtime reads this
   directly from the metadata; it can be overridden at runtime via
-  `set_solver_config`. Only the linear solver is baked into the compiled
-  `_step.pt2` / `_ift.pt2` graphs and cannot be changed without recompiling.
+  `set_solver_config`. The linear solve is un-baked from the residual Jacobian
+  operator: the choice of linear solver lives in the `_solve.pt2` / `_solve_ift.pt2`
+  / `_solve_param.pt2` graphs (recompile to change it), while the C++ runtime
+  drives the operator → solve chain generically.
 - **Boundary aliases** (optional `boundary_aliases`) — shallow renames
   applied at the interface only. Present only when the artifact was
   compiled with `--rename-input` / `--rename-output` / `--rename-parameter`;
@@ -187,7 +193,7 @@ refuses any non-matching version with a clear "regenerate via
 `neml2-compile`" message; the only remediation is a re-compile.
 
 <!-- dependencies: aoti.schema_version -->
-The current schema version is `9`.
+The current schema version is `10`.
 
 ### Segment kinds
 
@@ -198,21 +204,24 @@ Two segment kinds appear inside `segments`:
   requested a derivative pair this segment contributes to (a block that
   does not depend on the dynamic batch is emitted unbatched). Call shape
   is `(*user_inputs, *promoted_params) -> outputs`.
-- **Implicit** segments always lower `_rhs.pt2` (Newton residual) and
-  `_step.pt2` (fused assemble + LU solve + update + post-update
-  residual), plus an optional `_predictor.pt2` graph when the source had
-  a `Predictor`. They additionally lower `_ift.pt2` (`-A^{-1} B`
-  implicit-function-theorem sensitivity at the converged state) **only
-  when `-d` requested a pair whose derivative path runs through this
-  segment**. The Newton loop body is one loader call per iteration plus a
-  convergence sync; the IFT graph, when present, is consumed by
-  `jacobian()` and `jvp()`.
+- **Implicit** segments always lower `_residual.pt2` (Newton residual),
+  `_jacobian.pt2` (the residual Jacobian operator `A = ∂r/∂u` + `b`), and
+  `_solve.pt2` (the linear solve `du = A^{-1} b`), plus an optional
+  `_predictor.pt2` graph when the source had a `Predictor`. The linear solve
+  is **un-baked** from the operator: the C++ runtime chains `_jacobian → _solve`
+  per Newton iteration, so the same operator can feed an iterative solver.
+  They additionally lower `_jacobian_given.pt2` (`B = ∂r/∂g`) + `_solve_ift.pt2`
+  (`-A^{-1} B` implicit-function-theorem sensitivity at the converged state,
+  reusing `_jacobian`'s `A`) **only when `-d` requested an input-derivative pair
+  routed through this segment**, and `_dr_dparam.pt2` + `_solve_param.pt2` for a
+  promoted-parameter derivative. The Newton loop body is two loader calls
+  (jacobian → solve) per iteration plus a convergence sync; the IFT / param
+  graphs, when present, are consumed by `jacobian()` / `jvp()` / `param_jacobian()`.
 
   The Newton solve's convergence tolerances, iteration cap, and line-search
   settings are recorded in `metadata.json` under `solver_config` and read
   directly by the C++ runtime (see [What's in the metadata JSON](#whats-in-the-metadata-json)
-  above). Only the linear solver is baked — it lives inside the compiled
-  `_step.pt2` / `_ift.pt2` graphs.
+  above). The linear-solver choice is baked into the `_solve*.pt2` graphs.
 
 Each segment declares its inputs / outputs / promoted-parameter inputs
 in the same per-variable structure as the top-level layout.

--- a/neml2/cli/aoti_export.py
+++ b/neml2/cli/aoti_export.py
@@ -36,8 +36,10 @@ Unified on-disk schema: every export emits
 * **Forward** (root is a non-Implicit model, no ``ImplicitUpdate`` children):
   one segment, ``"kind": "forward"`` → one ``.pt2``.
 * **Implicit** (root is an ``ImplicitUpdate``): one segment,
-  ``"kind": "implicit"`` → two ``.pt2``\\ s (``_rhs`` + ``_step``) plus
-  optional ``_predictor.pt2``.
+  ``"kind": "implicit"`` → three ``.pt2``\\ s (``_residual`` + ``_jacobian`` +
+  ``_solve`` -- the operator + un-baked linear solve) plus optional
+  ``_jacobian_given`` + ``_solve_ift`` (input derivatives), ``_dr_dparam`` +
+  ``_solve_param`` (parameter derivatives), and ``_predictor.pt2``.
 * **Composed** (root is a ``ComposedModel`` whose dependency graph contains an
   ``ImplicitUpdate`` child): partitioned at each ``ImplicitUpdate`` boundary
   into a sequence of segments (alternating forward / implicit / forward / …),
@@ -85,7 +87,7 @@ if TYPE_CHECKING:
 #: ``scripts/dep_manager.py`` (which keeps this literal, the C++ loader, and the
 #: docs in sync).
 # dependencies: aoti.schema_version
-AOTI_META_SCHEMA_VERSION = 9
+AOTI_META_SCHEMA_VERSION = 10
 
 
 def _var_size(type_cls) -> int:
@@ -2019,12 +2021,18 @@ def _compile_implicit_segment(
     selected_param_pairs: set[tuple[str, str]] | None = None,
     progress_cb: Callable[[str], None] | None = None,
 ) -> dict:
-    """Compile an ImplicitUpdate to ``<pkg_basename>_rhs.pt2`` + ``_step.pt2``
-    (+ ``_ift.pt2`` when *emit_ift*) (+ ``_pift.pt2`` when *selected_param_pairs*)
-    (+ optional ``_predictor.pt2``), returning the metadata dict (without the
-    outer ``"type"`` key — caller adds it).
+    """Compile an ImplicitUpdate to ``<pkg_basename>_residual.pt2`` +
+    ``_jacobian.pt2`` + ``_solve.pt2`` (+ ``_jacobian_given.pt2`` + ``_solve_ift.pt2``
+    when *emit_ift*) (+ ``_dr_dparam.pt2`` + ``_solve_param.pt2`` when
+    *selected_param_pairs*) (+ optional ``_predictor.pt2``), returning the metadata
+    dict (without the outer ``"type"`` key — caller adds it).
 
-    *selected_ift_pairs* restricts the IFT graph to the requested
+    The linear solve is un-baked (schema v10): ``jacobian`` emits the residual
+    Jacobian operator ``A = ∂r/∂u`` (+ ``b``) and ``solve`` applies the configured
+    linear solver ``du = A^{-1} b``. The C++ runtime chains ``jacobian -> solve``
+    for the Newton step, so the operator can also feed an iterative solver.
+
+    *selected_ift_pairs* restricts the input-derivative pairs to the requested
     ``(unknown, given)`` pairs (``None`` = all). A requested pair whose unknown
     or given is **sub-batched** (per-grain, e.g. crystal plasticity) is rejected
     here with a clear compile-time error: the per-pair IFT consumer only supports
@@ -2032,29 +2040,41 @@ def _compile_implicit_segment(
     derivative of a crystal-plasticity model compiles, while a per-grain pair
     fails fast at ``neml2-compile`` rather than at runtime.
 
-    ``rhs`` + ``step`` drive the forward Newton solve and are always compiled.
-    ``ift`` is the user-facing input-derivative graph (the implicit-function-
-    theorem sensitivity ``du/dg``); it is compiled only when *emit_ift* is True
-    (some ``-d`` pair targets a structural input). ``pift`` is the parameter
-    sensitivity graph (:class:`~neml2.es.implicit.ParamIFT`, ``du/dθ``); it is
-    compiled only when *selected_param_pairs* is non-empty (some ``-d`` pair
-    targets a promoted parameter inside the residual). When a graph is not
-    compiled its package key is omitted and the runtime leaves that loader null.
+    ``residual`` + ``jacobian`` + ``solve`` drive the forward Newton solve and are
+    always compiled. ``jacobian_given`` (``B = ∂r/∂g``) + ``solve_ift`` are the
+    user-facing input-derivative graphs (the implicit-function-theorem sensitivity
+    ``du/dg = -A^{-1} B``, reusing ``jacobian``'s ``A``); compiled only when
+    *emit_ift* is True (some ``-d`` pair targets a structural input). ``dr_dparam``
+    (dense ``A`` + ``∂r/∂θ``) + ``solve_param`` are the parameter-sensitivity
+    graphs (``du/dθ = -A^{-1} ∂r/∂θ``); compiled only when *selected_param_pairs*
+    is non-empty (some ``-d`` pair targets a promoted parameter inside the
+    residual). When a graph is not compiled its package key is omitted and the
+    runtime leaves that loader null.
 
-    Per-variable I/O at the AOTI graph boundary (v5+): each unknown,
-    given, and residual is its own positional tensor in the segment
-    signature. Preserved-label per-group sub_batch storage stays
-    heterogeneous-ndim end-to-end; no cross-group cat or fold-to-flat
-    inside the graph (except IFT's once-per-solve flat ``du/dg`` slab).
+    Per-variable I/O at the AOTI graph boundary (v5+): each unknown, given, and
+    residual is its own positional tensor in the operator-graph signatures.
+    Preserved-label per-group sub_batch storage stays heterogeneous-ndim
+    end-to-end; the solve graphs reconstruct the typed operands from the raw
+    per-block tensors.
 
     Promoted parameters living inside the implicit residual are threaded as a
-    positional tail through every graph. ``rhs`` / ``step`` / ``ift``
-    take the stored SCALAR (constant across the solve / input-Jacobian); the C++
-    runtime passes ``_gather_params(seg.param_inputs)`` for them. ``pift`` takes
-    the parameter PER-BATCH (the reverse pass must be per batch element); the C++
-    runtime broadcasts the stored scalar to the runtime batch before calling it.
+    positional tail through the operator graphs. ``residual`` / ``jacobian`` /
+    ``jacobian_given`` take the stored SCALAR (constant across the solve /
+    input-Jacobian); the C++ runtime passes ``_gather_params(seg.param_inputs)``
+    for them. ``dr_dparam`` takes the parameter PER-BATCH (the reverse pass must be
+    per batch element); the C++ runtime broadcasts the stored scalar to the runtime
+    batch before calling it.
     """
-    from ..es import IFT, RHS, AssembledVector, NewtonStep, ParamIFT
+    from ..es import (
+        RHS,
+        AssembledVector,
+        DrDParam,
+        Jacobian,
+        JacobianGiven,
+        LinearSolve,
+        LinearSolveIFT,
+        LinearSolveParam,
+    )
     from ..models.common import ComposedModel
     from ..models.export import compile_model
 
@@ -2077,11 +2097,20 @@ def _compile_implicit_segment(
     emit_pift = bool(selected_param_pairs)
 
     rhs = RHS(system, param_names=param_tail).to(device)
-    step = NewtonStep(system, solver.linear_solver, param_names=param_tail).to(device)
-    ift = IFT(
+    jacobian = Jacobian(system, param_names=param_tail).to(device)
+    linear_solve = LinearSolve(system, solver.linear_solver, param_names=param_tail).to(device)
+    # IFT (input-derivative) operators + solve: `jacobian` supplies A = ∂r/∂u;
+    # `jacobian_given` supplies B = ∂r/∂g; `solve_ift` applies A^{-1}B and emits
+    # per-(unknown, given) blocks. ParamIFT: `dr_dparam` emits the dense A + ∂r/∂θ
+    # (strict + reverse-AD); `solve_param` does the dense sensitivity solve.
+    jacobian_given = JacobianGiven(system, param_names=param_tail).to(device)
+    solve_ift = LinearSolveIFT(
         system, solver.linear_solver, selected_pairs=selected_ift_pairs, param_names=param_tail
     ).to(device)
-    pift = ParamIFT(
+    dr_dparam = DrDParam(
+        system, solver.linear_solver, param_tail, selected_pairs=selected_param_pairs
+    ).to(device)
+    solve_param = LinearSolveParam(
         system, solver.linear_solver, param_tail, selected_pairs=selected_param_pairs
     ).to(device)
 
@@ -2091,7 +2120,7 @@ def _compile_implicit_segment(
     # supported; fail fast here with a clear message instead of at runtime. A
     # global-output / global-input pair of the same model compiles fine.
     if emit_ift:
-        for u, g in ift.emitted_pairs():
+        for u, g in solve_ift.emitted_pairs():
             u_sub = tuple(system.ulayout.sub_batch_shape(u))
             g_sub = tuple(system.glayout.sub_batch_shape(g))
             if u_sub or g_sub:
@@ -2137,7 +2166,7 @@ def _compile_implicit_segment(
 
     u_group_examples = _per_group_examples(system.ulayout, _example_for_unknown)
     g_group_examples = _per_group_examples(system.glayout, _example_for_given)
-    # Promoted-parameter tail. rhs/step/ift take the stored SCALAR (natural
+    # Promoted-parameter tail. The operator graphs take the stored SCALAR (natural
     # shape -- typically ()); ParamIFT takes the parameter PER-BATCH
     # ((*dyn, *param_base)) so its reverse pass is per batch element (the same
     # scalar-vs-per-batch split the forward value vs param-Jacobian graphs use).
@@ -2156,14 +2185,17 @@ def _compile_implicit_segment(
     example_inputs = base_examples + tuple(scalar_param_examples)
     pift_example_inputs = base_examples + tuple(per_batch_param_examples)
 
-    rhs_name = f"{pkg_basename}_rhs.pt2"
-    step_name = f"{pkg_basename}_step.pt2"
-    ift_name = f"{pkg_basename}_ift.pt2"
-    pift_name = f"{pkg_basename}_pift.pt2"
+    residual_name = f"{pkg_basename}_residual.pt2"
+    jacobian_name = f"{pkg_basename}_jacobian.pt2"
+    solve_name = f"{pkg_basename}_solve.pt2"
+    jacobian_given_name = f"{pkg_basename}_jacobian_given.pt2"
+    solve_ift_name = f"{pkg_basename}_solve_ift.pt2"
+    dr_dparam_name = f"{pkg_basename}_dr_dparam.pt2"
+    solve_param_name = f"{pkg_basename}_solve_param.pt2"
 
     dynamic_dim = 0 if dynamic_batch else None
     # A request_AD leaf inside the residual makes the residual Jacobian (``A=∂r/∂u``
-    # in ``step``, ``∂r/∂g`` in ``ift``) carry an embedded reverse-mode
+    # in ``jacobian``, ``∂r/∂g`` in ``jacobian_given``) carry an embedded reverse-mode
     # ``torch.autograd.grad``, which lowers only under ``trace_autograd_ops`` +
     # ``strict``. The equation-system assembly that both graphs use was made
     # strict-export-friendly (no in-``forward`` generators -- the static layout math
@@ -2171,10 +2203,23 @@ def _compile_implicit_segment(
     # the residual VALUE (no autograd), always plain compile.
     uses_ad = _model_uses_request_ad(system.model)
     _compile_jac = _compile_param_derivative_graph if uses_ad else compile_model
-    compile_model(rhs, example_inputs, output_dir / rhs_name, dynamic_batch_dim=dynamic_dim)
-    _report(progress_cb, rhs_name)
-    _compile_jac(step, example_inputs, output_dir / step_name, dynamic_batch_dim=dynamic_dim)
-    _report(progress_cb, step_name)
+    compile_model(rhs, example_inputs, output_dir / residual_name, dynamic_batch_dim=dynamic_dim)
+    _report(progress_cb, residual_name)
+    _compile_jac(
+        jacobian, example_inputs, output_dir / jacobian_name, dynamic_batch_dim=dynamic_dim
+    )
+    _report(progress_cb, jacobian_name)
+    # The solve graph consumes the Jacobian's raw outputs ``(*A_blocks, *b)`` and
+    # returns ``du``. Trace it on an eager Jacobian evaluation of the same example
+    # inputs so the solve's input shapes match the jacobian graph's outputs
+    # exactly. Pure linear algebra (no embedded autograd), so plain ``compile_model``
+    # even for a request_AD residual (only the ``jacobian`` assembly carries AD).
+    with torch.no_grad():
+        solve_example_inputs = tuple(t.detach().contiguous() for t in jacobian(*example_inputs))
+    compile_model(
+        linear_solve, solve_example_inputs, output_dir / solve_name, dynamic_batch_dim=dynamic_dim
+    )
+    _report(progress_cb, solve_name)
     # Per-(unknown, given) pair metadata for the IFT graph. The IFT emits one
     # block per variable pair (via AssembledMatrix.disassemble), in
     # ift.emitted_pairs() order, so the C++ runtime composes them against
@@ -2195,10 +2240,32 @@ def _compile_implicit_segment(
                 "in_sub_batch_shape": [],
                 "batch_independent": False,
             }
-            for (u, g) in ift.emitted_pairs()
+            for (u, g) in solve_ift.emitted_pairs()
         ]
-        _compile_jac(ift, example_inputs, output_dir / ift_name, dynamic_batch_dim=dynamic_dim)
-        _report(progress_cb, ift_name)
+        # `jacobian_given` (B = ∂r/∂g) is a chain-rule operator (strict-if-AD, like
+        # `jacobian`). `solve_ift` reconstructs A (from `jacobian`) + B and applies
+        # A^{-1}B -- pure linear algebra (plain compile). Trace `solve_ift` on eager
+        # A blocks (jacobian output minus the trailing b groups) + B blocks.
+        _compile_jac(
+            jacobian_given,
+            example_inputs,
+            output_dir / jacobian_given_name,
+            dynamic_batch_dim=dynamic_dim,
+        )
+        _report(progress_cb, jacobian_given_name)
+        n_a = system.blayout.ngroup * system.ulayout.ngroup
+        with torch.no_grad():
+            a_blocks_example = solve_example_inputs[:n_a]
+            b_blocks_example = tuple(
+                t.detach().contiguous() for t in jacobian_given(*example_inputs)
+            )
+        compile_model(
+            solve_ift,
+            a_blocks_example + b_blocks_example,
+            output_dir / solve_ift_name,
+            dynamic_batch_dim=dynamic_dim,
+        )
+        _report(progress_cb, solve_ift_name)
 
     # Per-(unknown, param) parameter-Jacobian graph (ParamIFT). Emits one dense
     # ``du/dθ`` block per requested ``(unknown, param)`` pair, in
@@ -2216,12 +2283,30 @@ def _compile_implicit_segment(
                 "out_base_shape": [int(s) for s in system.ulayout.specs[u].BASE_SHAPE],
                 "param_base_shape": [int(s) for s in promoted_snapshots[p].shape],
             }
-            for (u, p) in pift.emitted_param_pairs()
+            for (u, p) in solve_param.emitted_param_pairs()
         ]
+        # `dr_dparam` emits the dense A + ∂r/∂θ via reverse-mode AD (strict +
+        # trace_autograd_ops). `solve_param` does the dense sensitivity solve on
+        # those two operators -- plain compile. Trace it on an eager `dr_dparam`
+        # evaluation so the solve's input shapes match.
         _compile_param_derivative_graph(
-            pift, pift_example_inputs, output_dir / pift_name, dynamic_batch_dim=dynamic_dim
+            dr_dparam,
+            pift_example_inputs,
+            output_dir / dr_dparam_name,
+            dynamic_batch_dim=dynamic_dim,
         )
-        _report(progress_cb, pift_name)
+        _report(progress_cb, dr_dparam_name)
+        # DrDParam forms A / ∂r/∂θ via reverse-mode autograd.grad internally, so it
+        # must run with grad ENABLED (not under torch.no_grad) to build the graph;
+        # its outputs are already detached, so nothing leaks into solve_param's trace.
+        param_op_example = tuple(t.detach().contiguous() for t in dr_dparam(*pift_example_inputs))
+        compile_model(
+            solve_param,
+            param_op_example,
+            output_dir / solve_param_name,
+            dynamic_batch_dim=dynamic_dim,
+        )
+        _report(progress_cb, solve_param_name)
 
     # Per-variable infos retained at the segment level as the source of
     # truth for the C++ runtime's per-variable state map (predictor
@@ -2268,11 +2353,13 @@ def _compile_implicit_segment(
     # NB: solver convergence / line-search configuration (atol / rtol / miters /
     # linesearch) is NOT baked per-segment. It rides in the shared metadata.json
     # (written by _build_meta) and is applied by the C++ runtime at load time.
-    # Only the linear solver is baked -- it lives inside the compiled step/ift
-    # graphs above.
+    # The residual Jacobian is emitted as an OPERATOR (`_jacobian`); the linear
+    # solve is a separate `_solve` graph (which bakes the configured linear
+    # solver). The C++ runtime chains `_jacobian -> _solve` for the Newton step.
     seg: dict = {
-        "rhs_package": rhs_name,
-        "step_package": step_name,
+        "residual_package": residual_name,
+        "jacobian_package": jacobian_name,
+        "solve_package": solve_name,
         "unknowns": unknown_infos,
         "givens": given_infos,
         "residuals": residual_infos,
@@ -2295,13 +2382,18 @@ def _compile_implicit_segment(
         "incremental_variables": list(inner.incremental_variables),
     }
     if emit_ift:
-        seg["ift_package"] = ift_name
-        # Per-(unknown, given) pair metadata for the IFT loader's output tuple,
-        # in the same order the IFT graph emits blocks. Consumed via the
-        # per-pair Jacobian composition (same path as a forward segment).
+        # IFT operators (B = ∂r/∂g) + solve; A is reused from the forward
+        # `jacobian` graph. The C++ runtime chains jacobian + jacobian_given ->
+        # solve_ift -> per-pair blocks.
+        seg["jacobian_given_package"] = jacobian_given_name
+        seg["solve_ift_package"] = solve_ift_name
+        # Per-(unknown, given) pair metadata for the solve_ift loader's output
+        # tuple, in emission order. Consumed via the per-pair Jacobian
+        # composition (same path as a forward segment).
         seg["jacobian_pairs"] = ift_jacobian_pairs
     if emit_pift:
-        seg["param_ift_package"] = pift_name
+        seg["dr_dparam_package"] = dr_dparam_name
+        seg["solve_param_package"] = solve_param_name
         # Per-(unknown, param) pair metadata for the ParamIFT loader's output
         # tuple, in pift.emitted_param_pairs() order (unknowns outer, params
         # inner). Consumed by the C++ implicit parameter-Jacobian path.
@@ -2734,11 +2826,13 @@ def _predict_implicit_artifacts(
 ) -> list[str]:
     """Ordered ``.pt2`` names an implicit segment emits -- mirrors, in emission
     order, the ``compile_model`` calls in :func:`_compile_implicit_segment`."""
-    arts = [f"{basename}_rhs.pt2", f"{basename}_step.pt2"]
+    arts = [f"{basename}_residual.pt2", f"{basename}_jacobian.pt2", f"{basename}_solve.pt2"]
     if emit_ift:
-        arts.append(f"{basename}_ift.pt2")
+        arts.append(f"{basename}_jacobian_given.pt2")
+        arts.append(f"{basename}_solve_ift.pt2")
     if emit_pift:
-        arts.append(f"{basename}_pift.pt2")
+        arts.append(f"{basename}_dr_dparam.pt2")
+        arts.append(f"{basename}_solve_param.pt2")
     if has_predictor:
         arts.append(f"{basename}_predictor.pt2")
     return arts

--- a/neml2/csrc/aoti/Model.cpp
+++ b/neml2/csrc/aoti/Model.cpp
@@ -167,7 +167,7 @@ Model::Impl::Impl(const std::filesystem::path & artifact_root,
   // a cryptic missing-field error deep in the parser. The canonical value lives
   // in scripts/dependencies.yaml; this literal is kept in sync by dep_manager.py.
   // dependencies: aoti.schema_version
-  static constexpr int kSupportedSchemaVersion = 9;
+  static constexpr int kSupportedSchemaVersion = 10;
   const auto schema_version = meta.value("schema_version", 0);
   _assert(schema_version == kSupportedSchemaVersion,
           "aoti::Model: metadata schema_version=",
@@ -547,12 +547,21 @@ Model::Impl::Impl(const std::filesystem::path & artifact_root,
     {
       seg.kind = SegmentKind::Implicit;
       seg.max_substepping_level = seg_meta.value("max_substepping_level", 0);
-      seg.rhs_loader = make_loader(cache_dir / seg_meta["rhs_package"].get<std::string>(), dev_idx);
-      seg.step_loader =
-          make_loader(cache_dir / seg_meta["step_package"].get<std::string>(), dev_idx);
-      if (seg_meta.contains("ift_package"))
-        seg.ift_loader =
-            make_loader(cache_dir / seg_meta["ift_package"].get<std::string>(), dev_idx);
+      // Operator + solve graphs (schema v10): the Jacobian is emitted as an
+      // operator and the linear solve is a separate graph the C++ driver chains.
+      seg.residual_loader =
+          make_loader(cache_dir / seg_meta["residual_package"].get<std::string>(), dev_idx);
+      seg.jacobian_loader =
+          make_loader(cache_dir / seg_meta["jacobian_package"].get<std::string>(), dev_idx);
+      seg.solve_loader =
+          make_loader(cache_dir / seg_meta["solve_package"].get<std::string>(), dev_idx);
+      if (seg_meta.contains("solve_ift_package"))
+      {
+        seg.jacobian_given_loader =
+            make_loader(cache_dir / seg_meta["jacobian_given_package"].get<std::string>(), dev_idx);
+        seg.solve_ift_loader =
+            make_loader(cache_dir / seg_meta["solve_ift_package"].get<std::string>(), dev_idx);
+      }
 
       for (const auto & v : seg_meta["unknowns"])
         seg.unknowns.push_back(parse_var_info(v));
@@ -609,10 +618,12 @@ Model::Impl::Impl(const std::filesystem::path & artifact_root,
       // derivative targeting a promoted parameter inside the residual was
       // requested. Emits one dense du/dθ block per (unknown, param) pair in
       // param_jacobian_pairs order (unknowns outer, params inner).
-      if (seg_meta.contains("param_ift_package"))
+      if (seg_meta.contains("solve_param_package"))
       {
-        seg.param_ift_loader =
-            make_loader(cache_dir / seg_meta["param_ift_package"].get<std::string>(), dev_idx);
+        seg.dr_dparam_loader =
+            make_loader(cache_dir / seg_meta["dr_dparam_package"].get<std::string>(), dev_idx);
+        seg.solve_param_loader =
+            make_loader(cache_dir / seg_meta["solve_param_package"].get<std::string>(), dev_idx);
         for (const auto & p : seg_meta["param_jacobian_pairs"])
         {
           Segment::ParamPairInfo pi;

--- a/neml2/csrc/aoti/_aoti.cpp
+++ b/neml2/csrc/aoti/_aoti.cpp
@@ -296,7 +296,7 @@ Empty when the model was compiled with no ``--parameter`` flags.
           "read from metadata.json at load time).");
 
   // Eager-path entry point: the same C++ Newton solver the AOTI runtime uses,
-  // driven over Python-supplied residual/step callables (RHS / NewtonStep).
+  // driven over Python-supplied residual/step callables (RHS / (Jacobian -> LinearSolve)).
   // This is what unifies the eager solve with the compiled one -- a single
   // iteration-control implementation.
   m.def(
@@ -349,7 +349,7 @@ Run the shared C++ Newton solver over an eager (Python-delegating) system.
 
 ``residual_fn(list[Tensor]) -> list[Tensor]`` and ``step_fn(list[Tensor]) ->
 (list[Tensor], list[Tensor])`` supply the per-group residual and Newton step
-(they bind the givens + linear solver, e.g. ``RHS`` / ``NewtonStep``).
+(they bind the givens + linear solver, e.g. ``RHS`` + ``Jacobian`` -> ``LinearSolve``).
 ``unknown_layout`` / ``residual_layout`` are ``(structure, sub_batch_shape)``
 per group. Returns ``(u_solved, converged, iterations)``.
 )");

--- a/neml2/csrc/aoti/internal.h
+++ b/neml2/csrc/aoti/internal.h
@@ -188,17 +188,31 @@ struct Model::Impl
     std::vector<std::string> fwd_inputs;
     std::vector<std::string> fwd_outputs;
 
-    // Implicit-segment-only.
-    std::unique_ptr<torch::inductor::AOTIModelPackageLoader> rhs_loader;
-    std::unique_ptr<torch::inductor::AOTIModelPackageLoader> step_loader;
-    std::unique_ptr<torch::inductor::AOTIModelPackageLoader> ift_loader;
-    /// Implicit-segment parameter sensitivity graph: du/dθ for a
-    /// promoted parameter inside the residual. Takes the converged per-group
-    /// unknowns + givens + the promoted parameters PER-BATCH (the runtime
-    /// broadcasts the stored scalar to the batch before the call), returns one
-    /// dense du/dθ block per (unknown, param) pair in `param_jacobian_pairs`
-    /// order. Null unless an implicit parameter derivative was compiled.
-    std::unique_ptr<torch::inductor::AOTIModelPackageLoader> param_ift_loader;
+    // Implicit-segment-only. The residual Jacobian is emitted as an OPERATOR
+    // (`jacobian_loader`: (*u,*g,*p) -> (*A_blocks, *b_groups)); the linear solve
+    // is a separate graph (`solve_loader`: (*A_blocks, *b_groups) -> (*du_groups))
+    // that bakes the configured linear solver. `AOTINonlinearSystem::step()`
+    // chains jacobian -> solve. `residual_loader` is the cheap residual eval for
+    // line-search trials.
+    std::unique_ptr<torch::inductor::AOTIModelPackageLoader> residual_loader;
+    std::unique_ptr<torch::inductor::AOTIModelPackageLoader> jacobian_loader;
+    std::unique_ptr<torch::inductor::AOTIModelPackageLoader> solve_loader;
+    /// IFT (input-derivative) operator + solve graphs. `jacobian_given_loader`
+    /// emits B = ∂r/∂g; A = ∂r/∂u is reused from `jacobian_loader`. `solve_ift_loader`
+    /// takes `(*A_blocks, *B_blocks)` and emits one `-du/dg` block per (unknown,
+    /// given) pair in `jacobian_pairs` order. Both null unless an input derivative
+    /// was compiled.
+    std::unique_ptr<torch::inductor::AOTIModelPackageLoader> jacobian_given_loader;
+    std::unique_ptr<torch::inductor::AOTIModelPackageLoader> solve_ift_loader;
+    /// Implicit-segment parameter sensitivity graphs: du/dθ for a promoted
+    /// parameter inside the residual. `dr_dparam_loader` emits the dense A = ∂r/∂u
+    /// and ∂r/∂θ (reverse-mode AD; parameters enter PER-BATCH -- the runtime
+    /// broadcasts the stored scalar to the batch before the call); `solve_param_loader`
+    /// takes `(A_dense, dr_dparam)` and emits one dense du/dθ block per (unknown,
+    /// param) pair in `param_jacobian_pairs` order. Both null unless an implicit
+    /// parameter derivative was compiled.
+    std::unique_ptr<torch::inductor::AOTIModelPackageLoader> dr_dparam_loader;
+    std::unique_ptr<torch::inductor::AOTIModelPackageLoader> solve_param_loader;
     std::unique_ptr<torch::inductor::AOTIModelPackageLoader> predictor_loader;
 
     /// Per-variable metadata. The natural ``(*B, *sub_batch, *base)``
@@ -297,7 +311,7 @@ struct Model::Impl
     std::vector<std::string> predictor_outputs;
     /// Promoted parameters the predictor graph consumes. Separate
     /// from `param_inputs` because the predictor is a distinct nn.Module: the
-    /// rhs/step/ift graphs take the residual's promoted tail, but the predictor
+    /// the operator graphs take the residual's promoted tail, but the predictor
     /// is compiled without it, so it currently receives no promoted params
     /// (empty). Kept as its own field so threading promoted params into a
     /// predictor later does not perturb the residual tail.
@@ -409,7 +423,7 @@ struct Model::Impl
   /// solved-unknown sensitivity -- so one IFT call yields
   /// `J_k = A_k·J_{k-1} + B_k·frac_k·J_endpoint`. On return `state` holds the
   /// final unknowns and `dstate[unknown]` the total `du_M/d(master inputs)`.
-  /// Requires `seg.ift_loader`. Only called when `seg.max_substepping_level > 0`.
+  /// Requires `seg.solve_ift_loader`. Only called when `seg.max_substepping_level > 0`.
   void _run_implicit_segment_substepped_jacobian(const Segment & seg,
                                                  std::map<std::string, at::Tensor> & state,
                                                  std::map<std::string, at::Tensor> & dstate) const;
@@ -584,8 +598,8 @@ struct Model::Impl
   /// contribution (`jvp_loader` per-pair blocks composed against `dpstate[in]`
   /// via `_run_forward_segment_jacobian`) plus its DIRECT contribution
   /// (`param_jacobian_loader` blocks injected at the parameter's column band);
-  /// each implicit segment adds its indirect (`ift_loader` via
-  /// `_run_implicit_segment_jacobian`) plus its direct (`param_ift_loader`
+  /// each implicit segment adds its indirect (the IFT operator+solve graphs via
+  /// `_run_implicit_segment_jacobian`) plus its direct (`solve_param_loader`
   /// blocks). Returns the master outputs + the per-variable `dpstate` map; the
   /// caller slices each requested `(out, param)` block.
   std::pair<std::map<std::string, at::Tensor>, std::map<std::string, at::Tensor>>
@@ -601,7 +615,7 @@ struct Model::Impl
                                  std::map<std::string, at::Tensor> & dpstate) const;
 
   /// Add an implicit segment's DIRECT parameter sensitivity into `dpstate`: run
-  /// the segment's `param_ift_loader` on the converged per-group unknowns +
+  /// the segment's dr_dparam + solve_param graphs on the converged per-group unknowns +
   /// givens + promoted params (broadcast per-batch) and accumulate each
   /// `du/d(param)` block at the parameter's column band of `dpstate[unknown]`.
   void _add_implicit_param_direct(const Segment & seg,

--- a/neml2/csrc/aoti/jacobian.cpp
+++ b/neml2/csrc/aoti/jacobian.cpp
@@ -242,7 +242,8 @@ Model::Impl::_implicit_param_pair_blocks(const std::map<std::string, at::Tensor>
 
   // One dense du/dθ block per (unknown, param) pair, in param_jacobian_pairs
   // order (unknowns outer, params inner).
-  const auto blocks = seg.param_ift_loader->run(pift_in);
+  const auto op_out = seg.dr_dparam_loader->run(pift_in);  // (A_dense, Bp)
+  const auto blocks = seg.solve_param_loader->run(op_out); // per-(unknown, param) blocks
   const std::size_t n_pairs = seg.param_jacobian_pairs.size();
   _assert(blocks.size() == n_pairs,
           "aoti::Model::param_jacobian: ParamIFT loader returned ",
@@ -339,7 +340,8 @@ Model::Impl::_add_implicit_param_direct(const Segment & seg,
                                  common_dyn,
                                  static_cast<int64_t>(_param_base_shapes.at(pname).size())));
 
-  const auto blocks = seg.param_ift_loader->run(pift_in);
+  const auto op_out = seg.dr_dparam_loader->run(pift_in);  // (A_dense, Bp)
+  const auto blocks = seg.solve_param_loader->run(op_out); // per-(unknown, param) blocks
   _assert(blocks.size() == seg.param_jacobian_pairs.size(),
           "aoti::Model::param_jacobian: ParamIFT loader returned ",
           blocks.size(),
@@ -428,7 +430,7 @@ Model::Impl::_param_jacobian_dstate(const std::map<std::string, at::Tensor> & in
       std::vector<at::Tensor> u_solved_groups;
       std::vector<at::Tensor> g_groups;
       _run_implicit_segment(seg, state, u_solved_groups, g_groups);
-      if (seg.ift_loader)
+      if (seg.solve_ift_loader)
         _run_implicit_segment_jacobian(seg, u_solved_groups, g_groups, dpstate); // indirect
       else
         for (const auto & u : seg.unknowns)
@@ -438,7 +440,7 @@ Model::Impl::_param_jacobian_dstate(const std::map<std::string, at::Tensor> & in
           shp.push_back(P);
           dpstate[u.name] = at::zeros(shp, ref.options());
         }
-      if (seg.param_ift_loader)
+      if (seg.solve_param_loader)
         _add_implicit_param_direct(seg, u_solved_groups, g_groups, common_dyn, dpstate); // direct
     }
   }
@@ -643,20 +645,33 @@ Model::Impl::_run_implicit_segment_jacobian(const Segment & seg,
                                             const std::vector<at::Tensor> & g_groups,
                                             std::map<std::string, at::Tensor> & dstate) const
 {
-  // IFT loader signature: (*u_groups, *g_groups, [params...]) -> *blocks, one
-  // per (unknown, given) pair in seg.jacobian_pairs order (the disassemble of
-  // -du/dg). Compose each block against dstate[given] into dstate[unknown] --
-  // the same per-pair Jacobian path a forward segment uses.
-  std::vector<at::Tensor> ift_in;
-  ift_in.reserve(u_solved_groups.size() + g_groups.size() + seg.param_inputs.size());
+  // Operator + solve chain (schema v10): the IFT solve is un-baked. Run the
+  // `jacobian` operator (A = ∂r/∂u + b) and the `jacobian_given` operator
+  // (B = ∂r/∂g) at the converged point, then feed A blocks (the leading
+  // n_residual*n_unknown outputs of `jacobian`, dropping the trailing b groups)
+  // + B blocks to `solve_ift`, which emits one -du/dg block per (unknown, given)
+  // pair in seg.jacobian_pairs order (the disassemble of -du/dg). Compose each
+  // block against dstate[given] into dstate[unknown] -- the same per-pair
+  // Jacobian path a forward segment uses.
+  std::vector<at::Tensor> op_in;
+  op_in.reserve(u_solved_groups.size() + g_groups.size() + seg.param_inputs.size());
   for (const auto & t : u_solved_groups)
-    ift_in.push_back(t.contiguous());
+    op_in.push_back(t.contiguous());
   for (const auto & t : g_groups)
-    ift_in.push_back(t.contiguous());
+    op_in.push_back(t.contiguous());
   for (auto & p : _gather_params(seg.param_inputs))
-    ift_in.push_back(std::move(p));
+    op_in.push_back(std::move(p));
 
-  const auto blocks = seg.ift_loader->run(ift_in);
+  const auto jac_out = seg.jacobian_loader->run(op_in);         // n_r*n_u A blocks + n_r b
+  const auto given_out = seg.jacobian_given_loader->run(op_in); // n_r*n_g B blocks
+  const std::size_t n_a = seg.residual_groups.size() * seg.unknown_groups.size();
+  std::vector<at::Tensor> solve_in;
+  solve_in.reserve(n_a + given_out.size());
+  solve_in.insert(
+      solve_in.end(), jac_out.begin(), jac_out.begin() + static_cast<std::ptrdiff_t>(n_a));
+  solve_in.insert(solve_in.end(), given_out.begin(), given_out.end());
+
+  const auto blocks = seg.solve_ift_loader->run(solve_in);
   const std::size_t n_pairs = seg.jacobian_pairs.size();
   _assert(blocks.size() == n_pairs,
           "aoti::Model: IFT loader returned ",

--- a/neml2/csrc/aoti/nonlinear_system_aoti.cpp
+++ b/neml2/csrc/aoti/nonlinear_system_aoti.cpp
@@ -35,14 +35,16 @@ namespace neml2::aoti
 // Out-of-line dtor anchors the NonlinearSystem vtable in this TU.
 NonlinearSystem::~NonlinearSystem() = default;
 
-AOTINonlinearSystem::AOTINonlinearSystem(torch::inductor::AOTIModelPackageLoader & rhs_loader,
-                                         torch::inductor::AOTIModelPackageLoader & step_loader,
+AOTINonlinearSystem::AOTINonlinearSystem(torch::inductor::AOTIModelPackageLoader & residual_loader,
+                                         torch::inductor::AOTIModelPackageLoader & jacobian_loader,
+                                         torch::inductor::AOTIModelPackageLoader & solve_loader,
                                          std::vector<GroupLayout> unknown_layout,
                                          std::vector<GroupLayout> residual_layout,
                                          std::vector<at::Tensor> g_groups,
                                          std::vector<at::Tensor> params)
-  : _rhs_loader(rhs_loader),
-    _step_loader(step_loader),
+  : _residual_loader(residual_loader),
+    _jacobian_loader(jacobian_loader),
+    _solve_loader(solve_loader),
     _unknown_layout(std::move(unknown_layout)),
     _residual_layout(std::move(residual_layout)),
     _g(std::move(g_groups)),
@@ -67,24 +69,38 @@ AOTINonlinearSystem::build_inputs(const std::vector<at::Tensor> & u) const
 std::vector<at::Tensor>
 AOTINonlinearSystem::residual(const std::vector<at::Tensor> & u) const
 {
-  return _rhs_loader.run(build_inputs(u));
+  return _residual_loader.run(build_inputs(u));
 }
 
 std::pair<std::vector<at::Tensor>, std::vector<at::Tensor>>
 AOTINonlinearSystem::step(const std::vector<at::Tensor> & u) const
 {
-  // step graph returns (*du_groups, *b_curr_groups) of length n_u + n_r.
-  const auto step_outs = _step_loader.run(build_inputs(u));
+  // Chain the operator + solve graphs (no solver algebra here):
+  //   jacobian: (*u, *g, *p) -> (*A_blocks, *b_groups)  [n_r*n_u A blocks + n_r b]
+  //   solve:    (*A_blocks, *b_groups) -> (*du_groups)   [n_u du]
+  // The Jacobian's outputs feed the solve verbatim; the trailing b_groups are
+  // returned for the line search (mirrors the old fused `step` graph's du+b).
   const std::size_t n_u = _unknown_layout.size();
   const std::size_t n_r = _residual_layout.size();
-  _assert(step_outs.size() == n_u + n_r,
-          "AOTINonlinearSystem::step: step loader returned ",
-          step_outs.size(),
-          " tensors, expected n_unknown_groups + n_residual_groups (",
-          n_u + n_r,
+
+  const auto jac_outs = _jacobian_loader.run(build_inputs(u));
+  _assert(jac_outs.size() == n_r * n_u + n_r,
+          "AOTINonlinearSystem::step: jacobian loader returned ",
+          jac_outs.size(),
+          " tensors, expected n_residual*n_unknown + n_residual groups (",
+          n_r * n_u + n_r,
           ")");
-  std::vector<at::Tensor> du(step_outs.begin(), step_outs.begin() + n_u);
-  std::vector<at::Tensor> b(step_outs.begin() + n_u, step_outs.end());
+
+  auto du = _solve_loader.run(jac_outs);
+  _assert(du.size() == n_u,
+          "AOTINonlinearSystem::step: solve loader returned ",
+          du.size(),
+          " tensors, expected one per unknown group (",
+          n_u,
+          ")");
+
+  // b_groups are the last n_r outputs of the jacobian graph.
+  std::vector<at::Tensor> b(jac_outs.end() - static_cast<std::ptrdiff_t>(n_r), jac_outs.end());
   return {std::move(du), std::move(b)};
 }
 } // namespace neml2::aoti

--- a/neml2/csrc/aoti/nonlinear_system_aoti.h
+++ b/neml2/csrc/aoti/nonlinear_system_aoti.h
@@ -24,11 +24,13 @@
 
 #pragma once
 
-// Internal header -- NOT shipped. The AOTI-backed `NonlinearSystem`: residual /
-// step come from a compiled implicit segment's `.pt2` loaders. Deliberately
-// decoupled from the private `Model::Impl`/`Segment` -- the owning Impl member
-// builds the layouts and hands over the two loaders, so this class depends only
-// on the loader type and `NonlinearSystem`. Givens and the promoted-parameter
+// Internal header -- NOT shipped. The AOTI-backed `NonlinearSystem`. `residual`
+// runs the compiled `residual` graph; `step` chains the compiled `jacobian`
+// operator graph (`(*u,*g,*p) -> (*A_blocks, *b)`) into the compiled `solve`
+// graph (`(*A_blocks, *b) -> (*du)`) -- the linear solve is a separate graph, so
+// this class is a generic driver with no solver algebra. Deliberately decoupled
+// from the private `Model::Impl`/`Segment` -- the owning Impl member builds the
+// layouts and hands over the three loaders. Givens and the promoted-parameter
 // tail are bound once at construction (constant across the solve); only the
 // unknowns vary per iteration.
 
@@ -49,11 +51,12 @@ namespace neml2::aoti
 class AOTINonlinearSystem : public NonlinearSystem
 {
 public:
-  /// ``rhs_loader``/``step_loader`` must outlive this system (owned by the
-  /// segment). ``g_groups`` are the per-group given tensors; ``params`` is the
-  /// promoted-parameter tail in graph-call order.
-  AOTINonlinearSystem(torch::inductor::AOTIModelPackageLoader & rhs_loader,
-                      torch::inductor::AOTIModelPackageLoader & step_loader,
+  /// ``residual_loader``/``jacobian_loader``/``solve_loader`` must outlive this
+  /// system (owned by the segment). ``g_groups`` are the per-group given tensors;
+  /// ``params`` is the promoted-parameter tail in graph-call order.
+  AOTINonlinearSystem(torch::inductor::AOTIModelPackageLoader & residual_loader,
+                      torch::inductor::AOTIModelPackageLoader & jacobian_loader,
+                      torch::inductor::AOTIModelPackageLoader & solve_loader,
                       std::vector<GroupLayout> unknown_layout,
                       std::vector<GroupLayout> residual_layout,
                       std::vector<at::Tensor> g_groups,
@@ -69,8 +72,9 @@ private:
   /// Loader-call input list: ``(*u_groups, *g_groups, *params)``.
   std::vector<at::Tensor> build_inputs(const std::vector<at::Tensor> & u) const;
 
-  torch::inductor::AOTIModelPackageLoader & _rhs_loader;
-  torch::inductor::AOTIModelPackageLoader & _step_loader;
+  torch::inductor::AOTIModelPackageLoader & _residual_loader;
+  torch::inductor::AOTIModelPackageLoader & _jacobian_loader;
+  torch::inductor::AOTIModelPackageLoader & _solve_loader;
   std::vector<GroupLayout> _unknown_layout;
   std::vector<GroupLayout> _residual_layout;
   std::vector<at::Tensor> _g;

--- a/neml2/csrc/aoti/nonlinear_system_eager.cpp
+++ b/neml2/csrc/aoti/nonlinear_system_eager.cpp
@@ -37,7 +37,7 @@ namespace py = pybind11;
 namespace
 {
 // NonlinearSystem backed by two Python callables. The givens + linear solver
-// are already bound inside the callables (RHS / NewtonStep), so this only ever
+// are already bound inside the callables (RHS / (Jacobian -> LinearSolve)), so this only ever
 // forwards the unknowns. The GIL is held by the caller for the whole solve, so
 // the Python calls happen inline with no extra acquire/release.
 class EagerNonlinearSystem : public NonlinearSystem

--- a/neml2/csrc/aoti/nonlinear_system_eager.h
+++ b/neml2/csrc/aoti/nonlinear_system_eager.h
@@ -26,7 +26,7 @@
 
 // Lives in the pybind module (NOT the free-standing aoti library): bridges the
 // shared C++ Newton solver to the eager Python path. `EagerNonlinearSystem`
-// delegates residual/step to Python callables (typically RHS / NewtonStep from
+// delegates residual/step to Python callables (typically RHS / (Jacobian -> LinearSolve) from
 // neml2.es.implicit), so the eager and AOTI paths run the *same* C++ iteration.
 
 #include <cstddef>
@@ -46,8 +46,8 @@ namespace neml2::aoti
 ///
 /// ``residual_fn(list[Tensor] u) -> list[Tensor] b`` and
 /// ``step_fn(list[Tensor] u) -> (list[Tensor] du, list[Tensor] b)`` are Python
-/// callables that already bind the givens + linear solver (e.g. RHS /
-/// NewtonStep). ``unknown_layout`` / ``residual_layout`` are ``(structure,
+/// callables that already bind the givens + linear solver (e.g. RHS +
+/// Jacobian->LinearSolve). ``unknown_layout`` / ``residual_layout`` are ``(structure,
 /// sub_batch_shape)`` per group. Returns ``(u_solved, converged, iterations,
 /// log)`` where ``log`` is the per-iteration convergence history (empty unless
 /// ``cfg.collect_log`` is set). Must be called with the GIL held (it invokes

--- a/neml2/csrc/aoti/ops.cpp
+++ b/neml2/csrc/aoti/ops.cpp
@@ -244,7 +244,7 @@ Model::Impl::_jacobian_dstate(const std::map<std::string, at::Tensor> & inputs) 
         }
       }
     }
-    else if (seg.max_substepping_level > 0 && seg.ift_loader)
+    else if (seg.max_substepping_level > 0 && seg.solve_ift_loader)
     {
       // Substepped solve + chained consistent-tangent accumulation in one
       // bisection recursion (state + dstate advanced together). Masked when the
@@ -262,7 +262,7 @@ Model::Impl::_jacobian_dstate(const std::map<std::string, at::Tensor> & inputs) 
         _run_implicit_segment_substepped(seg, state, u_solved_groups, g_groups);
       else
         _run_implicit_segment(seg, state, u_solved_groups, g_groups);
-      if (seg.ift_loader)
+      if (seg.solve_ift_loader)
         _run_implicit_segment_jacobian(seg, u_solved_groups, g_groups, dstate);
       else
         // Off-path implicit segment: forward solve already advanced `state`;
@@ -346,7 +346,7 @@ Model::Impl::param_jacobian(const std::map<std::string, at::Tensor> & inputs,
       static_cast<bool>(_segments.front().param_jacobian_loader))
     return _forward_param_pair_blocks(inputs);
   if (_segments.size() == 1 && _segments.front().kind == SegmentKind::Implicit &&
-      static_cast<bool>(_segments.front().param_ift_loader))
+      static_cast<bool>(_segments.front().solve_param_loader))
     return _implicit_param_pair_blocks(inputs);
 
   // Multi-segment (composed) artifacts: compose the parameter sensitivity across

--- a/neml2/csrc/aoti/solve.cpp
+++ b/neml2/csrc/aoti/solve.cpp
@@ -279,8 +279,9 @@ Model::Impl::_run_implicit_segment(const Segment & seg,
       out.push_back(GroupLayout{g.structure, g.sub_batch_shape});
     return out;
   };
-  AOTINonlinearSystem sys(*seg.rhs_loader,
-                          *seg.step_loader,
+  AOTINonlinearSystem sys(*seg.residual_loader,
+                          *seg.jacobian_loader,
+                          *seg.solve_loader,
                           to_layouts(seg.unknown_groups),
                           to_layouts(seg.residual_groups),
                           g_groups,
@@ -376,8 +377,9 @@ Model::Impl::_run_implicit_segment_masked(const Segment & seg,
       out.push_back(GroupLayout{g.structure, g.sub_batch_shape});
     return out;
   };
-  AOTINonlinearSystem sys(*seg.rhs_loader,
-                          *seg.step_loader,
+  AOTINonlinearSystem sys(*seg.residual_loader,
+                          *seg.jacobian_loader,
+                          *seg.solve_loader,
                           to_layouts(seg.unknown_groups),
                           to_layouts(seg.residual_groups),
                           g_groups,

--- a/neml2/es/__init__.py
+++ b/neml2/es/__init__.py
@@ -35,14 +35,23 @@ Layered:
   boundary surface).
 - :mod:`.system` -- :class:`LinearSystem`, :class:`NonlinearSystem`,
   :class:`ModelNonlinearSystem`.
-- :mod:`.implicit` -- AOTI export wrappers (:class:`RHS`,
-  :class:`NewtonStep`, :class:`IFT`, :class:`ParamIFT`) for the
-  implicit-segment Newton path.
+- :mod:`.implicit` -- AOTI export wrappers for the implicit-segment Newton
+  path: operator graphs (:class:`RHS`, :class:`Jacobian`, :class:`JacobianGiven`,
+  :class:`DrDParam`) + solve graphs (:class:`LinearSolve`, :class:`LinearSolveIFT`,
+  :class:`LinearSolveParam`); the linear solve is un-baked from the operators.
 """
 
 from .assembled import AssembledMatrix, AssembledVector, norm, norm_sq
 from .axis_layout import AxisLayout
-from .implicit import IFT, RHS, NewtonStep, ParamIFT
+from .implicit import (
+    RHS,
+    DrDParam,
+    Jacobian,
+    JacobianGiven,
+    LinearSolve,
+    LinearSolveIFT,
+    LinearSolveParam,
+)
 from .sparse import SparseMatrix, SparseVector
 from .system import LinearSystem, ModelNonlinearSystem, NonlinearSystem
 
@@ -56,9 +65,12 @@ __all__ = [
     "NonlinearSystem",
     "ModelNonlinearSystem",
     "RHS",
-    "NewtonStep",
-    "IFT",
-    "ParamIFT",
+    "Jacobian",
+    "LinearSolve",
+    "JacobianGiven",
+    "LinearSolveIFT",
+    "DrDParam",
+    "LinearSolveParam",
     "norm",
     "norm_sq",
 ]

--- a/neml2/es/assembled.py
+++ b/neml2/es/assembled.py
@@ -246,6 +246,48 @@ def wrap_group_raw(
     return Tensor(raw, batch_ndim=raw.ndim - 1, sub_batch_ndim=0)
 
 
+def group_block_sub_batch_ndim(
+    row_layout: AxisLayout,
+    row_gi: int,
+    col_layout: AxisLayout,
+    col_gi: int,
+) -> int:
+    """The ``sub_batch_ndim`` of the assembled ``(row_gi, col_gi)`` block.
+
+    Single source of truth mirroring the storage convention in
+    :func:`_build_group_block` / :func:`_zero_block` /
+    :func:`_convert_tangent_to_paired_block`: a DENSE side folds its sub_batch
+    into base (0 intmd axes); a BLOCK side keeps its sub_batch as intmd axes; a
+    BLOCK+BLOCK pair with identical per-site shape is stored on the compact
+    paired diagonal (a single per-site axis, not the full grid).
+
+    Used to reconstruct a typed :class:`AssembledMatrix` from raw per-block
+    tensors at the solver graph boundary (:class:`~neml2.es.implicit.LinearSolve`):
+    only the (structural) ``sub_batch_ndim`` is needed there -- ``batch_ndim``
+    follows from the runtime tensor's ndim.
+    """
+    rs = row_layout.structure[row_gi]
+    cs = col_layout.structure[col_gi]
+    r_sub = tuple(int(s) for s in row_layout.group_sub_batch_shape(row_gi))
+    c_sub = tuple(int(s) for s in col_layout.group_sub_batch_shape(col_gi))
+    if rs == "block" and cs == "block" and r_sub == c_sub and len(r_sub) > 0:
+        return len(r_sub)  # paired diagonal (compact)
+    r_intmd = len(r_sub) if rs == "block" else 0
+    c_intmd = len(c_sub) if cs == "block" else 0
+    return r_intmd + c_intmd
+
+
+def wrap_block_raw(raw: torch.Tensor, sub_batch_ndim: int) -> Tensor:
+    """Wrap a raw assembled-matrix block into a typed dynamic-base :class:`Tensor`.
+
+    Inverse of the per-block ``.data`` extraction at the solver graph boundary: a
+    block is ``(*dyn, *sub, row_storage, col_storage)`` (``base_ndim=2``), so
+    ``batch_ndim = raw.ndim - sub_batch_ndim - 2``. ``sub_batch_ndim`` comes from
+    :func:`group_block_sub_batch_ndim`.
+    """
+    return Tensor(raw, batch_ndim=raw.ndim - sub_batch_ndim - 2, sub_batch_ndim=sub_batch_ndim)
+
+
 # ---------------------------------------------------------------------------
 # AssembledMatrix
 # ---------------------------------------------------------------------------
@@ -1083,5 +1125,7 @@ __all__ = [
     "norm",
     "norm_sq",
     "wrap_group_raw",
+    "wrap_block_raw",
+    "group_block_sub_batch_ndim",
     "_build_block_matrix",
 ]

--- a/neml2/es/implicit.py
+++ b/neml2/es/implicit.py
@@ -24,33 +24,40 @@
 
 """AOTI export wrappers for the implicit-segment Newton path.
 
-Four ``nn.Module`` graphs, one per piece of the Newton orchestration:
+The linear solve is **un-baked** from the operators (schema v10): each graph
+either ASSEMBLES an operator or SOLVES; the C++ runtime chains operator -> solve.
+This lets the same residual Jacobian feed a direct solve today or a matrix-free
+iterative solver later, and keeps a single solver implementation (the Python
+``[Solvers]`` classes, run live for eager and compiled for AOTI).
 
-- :class:`RHS`        -- ``(*u_groups, *g_groups, *params) -> (*b_groups)``
-                         (residual eval, cheap; called every line-search
-                         trial).
-- :class:`NewtonStep` -- ``(*u_groups, *g_groups, *params) ->
-                         (*du_groups, *b_groups)`` (Newton step direction +
-                         residual at the current iterate).
-- :class:`IFT`        -- ``(*u_groups, *g_groups, *params) -> *blocks``
-                         (implicit function theorem Jacobian
-                         ``du/dg = -A^{-1} B`` at the converged state, emitted
-                         as one block per ``(unknown, given)`` pair via
-                         ``AssembledMatrix.disassemble``; the C++ runtime
-                         composes each block against ``dg_dmaster`` with the
-                         same per-pair path a forward segment uses).
-- :class:`ParamIFT`   -- ``(*u_groups, *g_groups, *params) -> *blocks``
-                         (parameter sensitivity ``du/dθ = -A^{-1} ∂r/∂θ`` at
-                         the converged state, one block per ``(unknown,
-                         param)`` pair). ``A = ∂r/∂u`` is assembled
-                         analytically through the chain rule exactly as in
-                         :class:`IFT`; ``∂r/∂θ`` comes from reverse-mode
-                         ``torch.autograd.grad`` over the residual w.r.t. the
-                         promoted parameter (the only AD that lowers through
-                         AOTInductor). The parameter enters this graph as a
-                         PER-BATCH input so the reverse pass is per batch
-                         element; the C++ runtime broadcasts the stored scalar
-                         parameter to the batch before the call.
+Operator graphs (assemble; no solve):
+
+- :class:`RHS`          -- ``(*u,*g,*params) -> (*b_groups)`` (residual eval,
+                           cheap; every line-search trial).
+- :class:`Jacobian`     -- ``(*u,*g,*params) -> (*A_blocks, *b_groups)``
+                           (``A = ∂r/∂u`` row-major (residual × unknown) grid +
+                           ``b = -r``; the Newton-step operator).
+- :class:`JacobianGiven`-- ``(*u,*g,*params) -> (*B_blocks)`` (``B = ∂r/∂g``;
+                           the IFT's given-side operator, paired with
+                           ``Jacobian``'s ``A``).
+- :class:`DrDParam`     -- ``(*u,*g,*params_per_batch) -> (A_dense, ∂r/∂θ)``
+                           (dense operators for the parameter sensitivity, via
+                           reverse-mode ``torch.autograd.grad`` -- the only AD
+                           that lowers through AOTInductor; strict + per-batch
+                           parameter, the runtime broadcasts the stored scalar).
+
+Solve graphs (consume operators; no assembly):
+
+- :class:`LinearSolve`     -- ``(*A_blocks, *b_groups) -> (*du_groups)`` (Newton
+                              step ``du = A^{-1} b`` via the configured solver).
+- :class:`LinearSolveIFT`  -- ``(*A_blocks, *B_blocks) -> *blocks`` (IFT
+                              ``du/dg = -A^{-1} B``, one block per ``(unknown,
+                              given)`` pair via ``AssembledMatrix.disassemble``;
+                              the C++ runtime composes each against ``dg_dmaster``
+                              with the same per-pair path a forward segment uses).
+- :class:`LinearSolveParam`-- ``(A_dense, ∂r/∂θ) -> *blocks`` (parameter
+                              sensitivity ``du/dθ = -A^{-1} ∂r/∂θ``, one dense
+                              block per ``(unknown, param)`` pair).
 
 The promoted-parameter tail (``*params``) is empty in the common case (no
 ``--parameter`` targeting an attribute inside the implicit region); when
@@ -58,20 +65,20 @@ present it lists, in graph-call order, the promoted parameters that live
 inside the implicit segment's residual model. After
 :func:`~neml2.cli.aoti_export._promote_parameters` these appear in
 ``system.model.input_spec`` but are neither unknowns nor givens, so the
-wrappers inject them into the per-variable state from the trailing forward
-args. ``RHS`` / ``NewtonStep`` / ``IFT`` take them as the stored scalar
-(constant across the solve and the input-Jacobian); ``ParamIFT`` takes them
-per-batch.
+operator wrappers inject them into the per-variable state from the trailing
+forward args. The operator graphs take them as the stored scalar (constant
+across the solve and the input-Jacobian); ``DrDParam`` takes them per-batch.
 
-The first three segments take and return per-group raw tensors at the natural
-``AssembledVector`` / ``AssembledMatrix`` group shape -- BLOCK groups
-preserve their ``sub_batch_shape`` axes, DENSE groups have sub_batch
-folded into the last base axis. The C++ runtime maintains per-variable
-``dstate`` for downstream forward composition; the per-variable ↔
-per-group conversion happens twice per solve (once at solve start to
-pack ``u_groups`` / ``g_groups``, once at solve end to unpack converged
-``u_groups`` back to ``dstate``). The Newton inner loop is fully
-per-group.
+The operator graphs take/return per-group raw tensors at the natural
+``AssembledVector`` / ``AssembledMatrix`` group shape -- BLOCK groups preserve
+their ``sub_batch_shape`` axes, DENSE groups have sub_batch folded into the last
+base axis. The solve graphs reconstruct the typed operands from those raw blocks
+(:func:`~neml2.es.assembled.group_block_sub_batch_ndim` /
+:func:`~neml2.es.assembled.wrap_block_raw`). The C++ runtime maintains
+per-variable ``dstate`` for downstream forward composition; the per-variable ↔
+per-group conversion happens twice per solve (once at solve start to pack
+``u_groups`` / ``g_groups``, once at solve end to unpack converged
+``u_groups`` back to ``dstate``). The Newton inner loop is fully per-group.
 """
 
 from __future__ import annotations
@@ -85,7 +92,14 @@ from neml2.models.chain_rule import ChainRuleDict
 from neml2.types import TensorWrapper
 
 from ._helpers import _flatten_base, build_identity_seed
-from .assembled import AssembledMatrix, AssembledVector, _build_block_matrix, wrap_group_raw
+from .assembled import (
+    AssembledMatrix,
+    AssembledVector,
+    _build_block_matrix,
+    group_block_sub_batch_ndim,
+    wrap_block_raw,
+    wrap_group_raw,
+)
 from .axis_layout import AxisLayout
 from .system import ModelNonlinearSystem
 
@@ -104,9 +118,9 @@ def enumerate_group_var_names(layout: AxisLayout) -> tuple[tuple[str, ...], ...]
 class _SystemModule(nn.Module):
     """Tensor-only export surface for a frozen :class:`ModelNonlinearSystem`.
 
-    Segment subclasses (:class:`RHS`, :class:`NewtonStep`, :class:`IFT`,
-    :class:`ParamIFT`) take per-group raw tensors at the graph signature --
-    ``forward(*u_groups, *g_groups, *params)`` where the leading
+    The operator subclasses (:class:`RHS`, :class:`Jacobian`,
+    :class:`JacobianGiven`, :class:`DrDParam`) take per-group raw tensors at the
+    graph signature -- ``forward(*u_groups, *g_groups, *params)`` where the leading
     ``len(unknown_groups)`` positional args are the unknown groups (in
     ``ulayout.groups`` order), the next ``len(given_groups)`` are the given
     groups (in ``glayout.groups`` order), and the trailing ``len(param_names)``
@@ -164,7 +178,7 @@ class _SystemModule(nn.Module):
         reshapes as standard torch ops, compiled in by Inductor. Promoted
         parameters are injected verbatim (wrapped to their typed class);
         wrapping preserves any autograd graph on the incoming tensor so the
-        :class:`ParamIFT` reverse pass can differentiate through them.
+        :class:`DrDParam` reverse pass can differentiate through them.
         """
         n_u = len(self.unknown_groups)
         n_g = len(self.given_groups)
@@ -281,6 +295,20 @@ def _vector_to_per_group_raws(vec: AssembledVector) -> tuple[torch.Tensor, ...]:
     return tuple(t.data for t in vec.tensors)  # data-ok AOTI
 
 
+def _matrix_to_per_block_raws(mat: AssembledMatrix) -> tuple[torch.Tensor, ...]:
+    """Row-major per-``(row_group, col_group)`` raw blocks of an AssembledMatrix.
+
+    The legitimate framework-imposed ``.data`` exception at the AOTI
+    segment-output boundary (CLAUDE.md rule 2), mirroring
+    :func:`_vector_to_per_group_raws` for the matrix operator.
+    """
+    return tuple(
+        mat.tensors[i][j].data  # data-ok AOTI
+        for i in range(mat.row_layout.ngroup)
+        for j in range(mat.col_layout.ngroup)
+    )
+
+
 class RHS(_SystemModule):
     """Exportable residual graph.
 
@@ -299,17 +327,40 @@ class RHS(_SystemModule):
         return _vector_to_per_group_raws(b)
 
 
-class NewtonStep(_SystemModule):
-    """Exportable Newton step-direction graph.
+class Jacobian(_SystemModule):
+    """Exportable residual-Jacobian operator graph.
 
-    Contract: ``(*u_groups, *g_groups, *params) -> (*du_groups, *b_groups)``
-    where ``du_groups`` are the per-unknown-group step directions (in
-    ``ulayout.groups`` order) and ``b_groups`` are the per-residual-group
-    ``b = -r(u)`` at the current iterate (in ``blayout.groups`` order).
-    The C++ runtime applies ``u_groups[i] = u_groups[i] + alpha *
-    du_groups[i]`` per-group for line-search trials via cheap
-    :class:`RHS` evaluations. The promoted-parameter tail is empty in the
-    common case (scalar, constant across the solve).
+    Contract: ``(*u_groups, *g_groups, *params) -> (*A_blocks, *b_groups)`` where
+    ``A_blocks`` is the row-major ``(residual_group × unknown_group)`` grid of
+    ``A = ∂r/∂u`` and ``b_groups`` is ``b = -r`` at the current iterate. The
+    linear solve is NOT baked here -- it lives in the separate :class:`LinearSolve`
+    graph, so the same operator can feed a direct solve today or a matrix-free
+    iterative solver later. The C++ runtime chains ``Jacobian -> LinearSolve`` for
+    the Newton step (``step``) and reuses the ``b_groups`` tail for the
+    line-search residual. The promoted-parameter tail is empty in the common case.
+    """
+
+    def forward(self, *args: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        state = self._state_from_per_group_args(args)
+        output_state, v_out = self._call_model_from_state(state, self.unknown_names)
+        A = self._assembled_matrix(self.ulayout, v_out, output_state)
+        b = self._assembled_b(output_state)
+        return (*_matrix_to_per_block_raws(A), *_vector_to_per_group_raws(b))
+
+
+class LinearSolve(_SystemModule):
+    """Exportable linear-solve graph: ``(*A_blocks, *b_groups) -> (*du_groups)``.
+
+    Reconstructs the typed ``AssembledMatrix`` ``A`` (row_layout = residuals,
+    col_layout = unknowns) and ``AssembledVector`` ``b`` from the raw per-group
+    blocks emitted by :class:`Jacobian`, then applies the configured Python linear
+    solver (``DenseLU`` / ``SchurComplement``). Un-baked from :class:`Jacobian` so
+    the solver is a separate, swappable stage and the same operator can feed an
+    iterative solver. Per-block ``sub_batch_ndim`` is a structural constant of the
+    layouts (:func:`~neml2.es.assembled.group_block_sub_batch_ndim`); ``batch_ndim``
+    follows from the runtime tensor ndim, so this graph is batch-size agnostic.
+    The promoted-parameter tail carries no state here (the solve is pure linear
+    algebra over the assembled operators) but is accepted for a uniform signature.
     """
 
     def __init__(
@@ -320,36 +371,70 @@ class NewtonStep(_SystemModule):
     ) -> None:
         super().__init__(system, param_names)
         self._linear_solver = linear_solver
+        self._n_r = len(self.residual_groups)
+        self._n_u = len(self.unknown_groups)
+        # Structural sub_batch_ndim per (residual_group, unknown_group) A block --
+        # the reconstruction key at the raw solver boundary.
+        self._block_sub_ndims: list[list[int]] = [
+            [group_block_sub_batch_ndim(self.blayout, i, self.ulayout, j) for j in range(self._n_u)]
+            for i in range(self._n_r)
+        ]
+
+    def forward(self, *args: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        n_a = self._n_r * self._n_u
+        a_raws = args[:n_a]
+        b_raws = args[n_a : n_a + self._n_r]
+        a_blocks = [
+            [
+                wrap_block_raw(a_raws[i * self._n_u + j], self._block_sub_ndims[i][j])
+                for j in range(self._n_u)
+            ]
+            for i in range(self._n_r)
+        ]
+        A = AssembledMatrix(self.blayout, self.ulayout, a_blocks)
+        b_tensors = [
+            wrap_group_raw(raw, gnames, structure, self.blayout)
+            for raw, gnames, structure in zip(
+                b_raws, self.residual_groups, self.blayout.structure, strict=True
+            )
+        ]
+        b = AssembledVector(self.blayout, b_tensors)
+        du = self._linear_solver.solve(A, b)
+        return _vector_to_per_group_raws(du)
+
+
+class JacobianGiven(_SystemModule):
+    """Exportable ``∂r/∂g`` operator graph -- the IFT's given-side Jacobian.
+
+    Contract: ``(*u_groups, *g_groups, *params) -> (*B_blocks)`` where ``B_blocks``
+    is the row-major ``(residual_group × given_group)`` grid of ``B = ∂r/∂g`` at
+    the converged state. The un-baked given-side companion of :class:`Jacobian`
+    (which supplies ``A = ∂r/∂u``): the C++ runtime runs ``Jacobian`` (for ``A``)
+    + ``JacobianGiven`` (for ``B``) at the converged point and feeds both to
+    :class:`LinearSolveIFT` for the implicit-function-theorem solve
+    ``du/dg = -A^{-1} B``. Seeds the givens only. The promoted-parameter tail is
+    the stored scalar (constant across the input Jacobian).
+    """
 
     def forward(self, *args: torch.Tensor) -> tuple[torch.Tensor, ...]:
         state = self._state_from_per_group_args(args)
-        output_state, v_out = self._call_model_from_state(state, self.unknown_names)
-        A = self._assembled_matrix(self.ulayout, v_out, output_state)
-        b = self._assembled_b(output_state)
-        du = self._linear_solver.solve(A, b)
-        return (*_vector_to_per_group_raws(du), *_vector_to_per_group_raws(b))
+        output_state, v_out = self._call_model_from_state(state, self.given_names)
+        B = self._assembled_matrix(self.glayout, v_out, output_state)
+        return _matrix_to_per_block_raws(B)
 
 
-class IFT(_SystemModule):
-    """Exportable IFT Jacobian $du/dg = -A^{-1} B$ for a converged
-    :class:`ImplicitUpdate`.
+class LinearSolveIFT(_SystemModule):
+    """Exportable IFT solve: ``(*A_blocks, *B_blocks) -> *du_dg_pair_blocks``.
 
-    Contract: ``(*u_groups, *g_groups, *params) -> *blocks`` where each block
-    is one per-variable-pair ``(unknown, given)`` entry of ``-du_dg``, emitted
-    in ``unknown_names`` (outer) × ``given_names`` (inner) order -- matching
-    the ``jacobian_pairs`` metadata in
-    :func:`~neml2.cli.aoti_export._compile_implicit_segment`.
-
-    The equation system assembles the dense ``A`` / ``B`` (via the model's
-    per-variable chain rule), applies the IFT solve, then ``disassemble()``\\ s
-    the resulting :class:`~neml2.es.assembled.AssembledMatrix` into
-    per-(unknown, given) blocks. Each block keeps its natural per-structure
-    shape (``"dense"`` -> ``(*B, u_storage, g_storage)``; a BLOCK side stays
-    block-diagonal-compact, no N² fold). The C++ runtime then composes these
-    blocks against ``dg_dmaster`` exactly like a forward segment's per-pair
-    Jacobian blocks -- one uniform per-pair path for forward and implicit.
-    The promoted-parameter tail (scalar) lets ``A``/``B`` see the same
-    parameter value the solve used; empty in the common case.
+    Reconstructs the typed ``A = ∂r/∂u`` (blayout × ulayout, from :class:`Jacobian`)
+    and ``B = ∂r/∂g`` (blayout × glayout, from :class:`JacobianGiven`) from the raw
+    per-group blocks, applies the configured linear solver (``du/dg = -A^{-1} B``,
+    matrix RHS), then disassembles into per-``(unknown, given)`` blocks in
+    :meth:`emitted_pairs` order -- matching the ``jacobian_pairs`` metadata. Shares
+    the same solver as the forward Newton step (un-baked from the operators). The
+    emitted pairs are plain-batch (guarded at compile time), but ``A`` itself may
+    carry BLOCK unknown groups; per-block ``sub_batch_ndim`` follows the layout
+    convention (:func:`~neml2.es.assembled.group_block_sub_batch_ndim`).
     """
 
     def __init__(
@@ -361,9 +446,19 @@ class IFT(_SystemModule):
     ) -> None:
         super().__init__(system, param_names)
         self._linear_solver = linear_solver
-        # Local (unknown, given) pairs to emit; ``None`` = all. Emitted in
-        # unknown x given order to match the metadata.
+        # Local (unknown, given) pairs to emit; ``None`` = all.
         self._selected_pairs = selected_pairs
+        self._n_r = len(self.residual_groups)
+        self._n_u = len(self.unknown_groups)
+        self._n_g = len(self.given_groups)
+        self._a_sub: list[list[int]] = [
+            [group_block_sub_batch_ndim(self.blayout, i, self.ulayout, j) for j in range(self._n_u)]
+            for i in range(self._n_r)
+        ]
+        self._b_sub: list[list[int]] = [
+            [group_block_sub_batch_ndim(self.blayout, i, self.glayout, j) for j in range(self._n_g)]
+            for i in range(self._n_r)
+        ]
 
     def emitted_pairs(self) -> list[tuple[str, str]]:
         """The (unknown, given) pairs this graph emits, in emission order."""
@@ -375,22 +470,43 @@ class IFT(_SystemModule):
         ]
 
     def forward(self, *args: torch.Tensor) -> tuple[torch.Tensor, ...]:
-        state = self._state_from_per_group_args(args)
-        seed_names = (*self.unknown_names, *self.given_names)
-        output_state, v_out = self._call_model_from_state(state, seed_names)
-        A = self._assembled_matrix(self.ulayout, v_out, output_state)
-        B = self._assembled_matrix(self.glayout, v_out, output_state)
+        n_a = self._n_r * self._n_u
+        n_b = self._n_r * self._n_g
+        a_raws = args[:n_a]
+        b_raws = args[n_a : n_a + n_b]
+        A = AssembledMatrix(
+            self.blayout,
+            self.ulayout,
+            [
+                [
+                    wrap_block_raw(a_raws[i * self._n_u + j], self._a_sub[i][j])
+                    for j in range(self._n_u)
+                ]
+                for i in range(self._n_r)
+            ],
+        )
+        B = AssembledMatrix(
+            self.blayout,
+            self.glayout,
+            [
+                [
+                    wrap_block_raw(b_raws[i * self._n_g + j], self._b_sub[i][j])
+                    for j in range(self._n_g)
+                ]
+                for i in range(self._n_r)
+            ],
+        )
         du_dg = self._linear_solver.solve(A, B)
         cells = (-du_dg).disassemble().cells
-        # Emit per-(unknown, given) raw blocks in the canonical order. The
-        # ``.data`` reads are the legitimate AOTI segment-output boundary.
+        # Emit per-(unknown, given) raw blocks in the canonical order. The ``.data``
+        # reads are the legitimate AOTI segment-output boundary.
         return tuple(
             cells[u][g].data  # data-ok AOTI
             for (u, g) in self.emitted_pairs()
         )
 
 
-class ParamIFT(_SystemModule):
+class _ParamIFTBase(_SystemModule):
     r"""Exportable parameter sensitivity $du/d\theta = -A^{-1}\,\partial r/\partial\theta$
     for a converged :class:`ImplicitUpdate`.
 
@@ -515,6 +631,22 @@ class ParamIFT(_SystemModule):
     # never sees these source lines even though the AOTI implicit parameter-
     # derivative tests exercise it end-to-end (compile + run + FD check). Hence the
     # coverage exclusion on the def below.
+
+
+class DrDParam(_ParamIFTBase):
+    """Exportable operator graph for the implicit parameter sensitivity.
+
+    Contract: ``(*u_groups, *g_groups, *params_per_batch) -> (A_dense, Bp)`` where
+    ``A = ∂r/∂u`` is the dense ``(*batch, R, U)`` residual Jacobian and ``Bp =
+    ∂r/∂θ`` the dense ``(*batch, R, P)`` parameter Jacobian, both formed by
+    reverse-mode ``torch.autograd.grad`` over the flat residual (the only AD that
+    lowers through AOTInductor -- so this graph, like the old ``ParamIFT``, is
+    compiled strict + ``trace_autograd_ops``). The solve is un-baked into
+    :class:`LinearSolveParam`. Plain-batch only (the implicit-promotion guard
+    rejects sub-batched unknowns / givens / params, so ``R == U`` and the system
+    is a single dense block).
+    """
+
     def forward(self, *args: torch.Tensor) -> tuple[torch.Tensor, ...]:  # pragma: no cover
         n_u = len(self.unknown_groups)
         n_g = len(self.given_groups)
@@ -605,12 +737,26 @@ class ParamIFT(_SystemModule):
 
         A = torch.stack(a_rows, dim=-2)  # (*batch, R, U), R == U
         Bp = torch.stack(bp_rows, dim=-2)  # (*batch, R, P)
+        # Emit the dense operators; the solve lives in LinearSolveParam. Detach:
+        # AOTAutograd drops requires_grad on graph outputs.
+        return A.detach(), Bp.detach()
 
+
+class LinearSolveParam(_ParamIFTBase):
+    """Exportable parameter-sensitivity solve: ``(A_dense, Bp) -> *du_dparam_blocks``.
+
+    Solves ``A du/dθ = -∂r/∂θ`` with a dense ``torch.linalg.solve`` (exact for the
+    plain-batch square system :class:`DrDParam` emits) and slices per-``(unknown,
+    param)`` block in :meth:`emitted_param_pairs` order -- matching the
+    ``param_jacobian_pairs`` metadata. Un-baked from :class:`DrDParam`; pure
+    linear algebra (plain compile).
+    """
+
+    def forward(self, A: torch.Tensor, Bp: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        batch = tuple(A.shape[:-2])
         # du/dθ = -A^{-1} ∂r/∂θ via a full dense solve (exact for plain batch).
         du_dtheta = -torch.linalg.solve(A, Bp)  # (*batch, U, P)
 
-        # Slice per-(unknown, param) block (*batch, *u_base, *param_base). Detach:
-        # AOTAutograd drops requires_grad on graph outputs.
         u_off = {name: off for name, _b, _st, off in self._u_flat}
         u_base = {name: base for name, base, _st, _off in self._u_flat}
         u_storage = {name: st for name, _b, st, _off in self._u_flat}
@@ -627,8 +773,17 @@ class ParamIFT(_SystemModule):
         blocks: list[torch.Tensor] = []
         for u, p in self.emitted_param_pairs():
             sub = du_dtheta.narrow(-2, u_off[u], u_storage[u]).narrow(-1, p_off[p], p_storage[p])
-            blocks.append(sub.reshape(*batch, *u_base[u], *p_base[p]).detach())
+            blocks.append(sub.reshape(*batch, *u_base[u], *p_base[p]))
         return tuple(blocks)
 
 
-__all__ = ["RHS", "NewtonStep", "IFT", "ParamIFT", "enumerate_group_var_names"]
+__all__ = [
+    "RHS",
+    "Jacobian",
+    "LinearSolve",
+    "JacobianGiven",
+    "LinearSolveIFT",
+    "DrDParam",
+    "LinearSolveParam",
+    "enumerate_group_var_names",
+]

--- a/neml2/solvers/newton.py
+++ b/neml2/solvers/newton.py
@@ -137,9 +137,10 @@ class Newton:
 
         The iteration control (convergence test, line search) lives in C++ and
         is shared with the AOTI runtime; this wrapper supplies the residual /
-        Newton-step callbacks (the ``RHS`` / ``NewtonStep`` export modules, run
-        eagerly) plus the per-group layouts, then commits the converged iterate
-        back into the system.
+        Newton-step callbacks (the ``RHS`` residual + the ``Jacobian`` operator
+        chained into ``LinearSolve``, the same modules the AOTI runtime compiles,
+        run eagerly here) plus the per-group layouts, then commits the converged
+        iterate back into the system.
         """
         # Local imports: the compiled extension + the residual/step export
         # modules, kept off the package import path so a partial build can still
@@ -147,17 +148,22 @@ class Newton:
         from neml2.aoti._aoti import newton_solve_eager  # noqa: PLC0415
         from neml2.es.implicit import (  # noqa: PLC0415
             RHS,
-            NewtonStep,
+            Jacobian,
+            LinearSolve,
             _vector_to_per_group_raws,
         )
 
-        # The eager path runs the *same* residual/step modules the AOTI runtime
-        # compiles (RHS / NewtonStep), so the two cannot diverge -- only the
-        # iteration control differs (here C++, there C++ too). The givens are
-        # bound once; the C++ loop drives the unknowns.
+        # The eager path runs the *same* operator + solve modules the AOTI runtime
+        # compiles (RHS / Jacobian / LinearSolve), so the two cannot diverge --
+        # only the iteration control differs (here C++, there C++ too). The linear
+        # solve is un-baked from the Jacobian operator: ``Jacobian`` assembles
+        # ``(A_blocks, b)``; ``LinearSolve`` reconstructs the typed operators and
+        # applies the configured Python solver. The givens are bound once; the C++
+        # loop drives the unknowns.
         rhs = RHS(system)
-        step = NewtonStep(system, self.linear_solver)
-        n_u = system.ulayout.ngroup
+        jacobian = Jacobian(system)
+        linear_solve = LinearSolve(system, self.linear_solver)
+        n_a = system.blayout.ngroup * system.ulayout.ngroup  # A blocks (residual × unknown)
 
         # The Newton iterates are a fixed-point solve: gradients flow through
         # the converged state via the IFT (see ImplicitUpdate), never through
@@ -172,8 +178,14 @@ class Newton:
             def step_fn(
                 u_raws: list[torch.Tensor],
             ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
-                out = step(*u_raws, *g_raws)
-                return list(out[:n_u]), list(out[n_u:])
+                # Chain the operator + solve graphs: Jacobian -> (A_blocks, b),
+                # LinearSolve(A_blocks, b) -> du. The b groups (the last
+                # blayout.ngroup outputs of Jacobian) are reused for the
+                # line-search residual, matching the compiled C++ step() path.
+                jac_out = jacobian(*u_raws, *g_raws)
+                du = linear_solve(*jac_out)
+                b = jac_out[n_a:]
+                return list(du), list(b)
 
             u_star, converged, iterations, log = newton_solve_eager(
                 residual_fn=residual_fn,

--- a/scripts/dependencies.yaml
+++ b/scripts/dependencies.yaml
@@ -108,7 +108,7 @@ neml2:
 # ``doc/content/tutorials/models/compiled_models/`` are regenerated at
 # tutorial-rebuild time and so are not tracked here.
 aoti:
-  schema_version: "9"
+  schema_version: "10"
   files:
     - neml2/cli/aoti_export.py
     - neml2/csrc/aoti/Model.cpp

--- a/tests/aoti/test_request_ad_aoti.py
+++ b/tests/aoti/test_request_ad_aoti.py
@@ -141,9 +141,10 @@ def test_request_ad_in_implicit_residual_matches_eager(tmp_path: Path):
 
     out_dir = tmp_path / "implicit_request_ad"
     meta = export_model_for_aoti(_IMPLICIT_I, "model", out_dir, derivatives=(":",))
-    # The implicit segment carries an IFT graph with the residual's du/dg pairs.
-    seg = next(s for s in meta["segments"] if s.get("rhs_package"))
-    assert "ift_package" in seg
+    # The implicit segment carries the IFT operator + solve graphs with the
+    # residual's du/dg pairs.
+    seg = next(s for s in meta["segments"] if s.get("jacobian_package"))
+    assert "solve_ift_package" in seg
     # d(equivalent_plastic_strain)/d(temperature) flows through the request_AD
     # surrogate inside the residual.
     pairs = {(p["out_var"], p["in_var"]) for p in seg["jacobian_pairs"]}

--- a/tests/unit/test_aoti_export.py
+++ b/tests/unit/test_aoti_export.py
@@ -178,17 +178,21 @@ def test_predict_forward_artifacts_emit_order():
 
 def test_predict_implicit_artifacts_emit_order():
     """The implicit predictor mirrors the compile_model calls in
-    _compile_implicit_segment: rhs, step, then optional ift/pift/predictor."""
+    _compile_implicit_segment: residual, jacobian, solve, then optional
+    ift/pift/predictor."""
     from neml2.cli.aoti_export import _predict_implicit_artifacts
 
     assert _predict_implicit_artifacts(
         "m", emit_ift=False, emit_pift=False, has_predictor=False
-    ) == ["m_rhs.pt2", "m_step.pt2"]
+    ) == ["m_residual.pt2", "m_jacobian.pt2", "m_solve.pt2"]
     assert _predict_implicit_artifacts("m", emit_ift=True, emit_pift=True, has_predictor=True) == [
-        "m_rhs.pt2",
-        "m_step.pt2",
-        "m_ift.pt2",
-        "m_pift.pt2",
+        "m_residual.pt2",
+        "m_jacobian.pt2",
+        "m_solve.pt2",
+        "m_jacobian_given.pt2",
+        "m_solve_ift.pt2",
+        "m_dr_dparam.pt2",
+        "m_solve_param.pt2",
         "m_predictor.pt2",
     ]
 
@@ -217,9 +221,11 @@ def test_plan_export_artifacts_single_implicit():
     plan = plan_export_artifacts(_J2_NATIVE_I, "return_map", derivatives=[":"])
     assert [s.kind for s in plan.segments] == ["implicit"]
     assert plan.artifacts == [
-        "return_map_rhs.pt2",
-        "return_map_step.pt2",
-        "return_map_ift.pt2",
+        "return_map_residual.pt2",
+        "return_map_jacobian.pt2",
+        "return_map_solve.pt2",
+        "return_map_jacobian_given.pt2",
+        "return_map_solve_ift.pt2",
         "return_map_predictor.pt2",
         "metadata.json",
     ]
@@ -235,9 +241,11 @@ def test_plan_export_artifacts_composed_multi_segment():
     assert plan.artifacts == [
         "model_seg0.pt2",
         "model_seg0_jvp.pt2",
-        "model_seg1_rhs.pt2",
-        "model_seg1_step.pt2",
-        "model_seg1_ift.pt2",
+        "model_seg1_residual.pt2",
+        "model_seg1_jacobian.pt2",
+        "model_seg1_solve.pt2",
+        "model_seg1_jacobian_given.pt2",
+        "model_seg1_solve_ift.pt2",
         "model_seg2.pt2",
         "model_seg2_jvp.pt2",
         "metadata.json",
@@ -538,16 +546,20 @@ def test_export_implicit_model_produces_artifacts(implicit_export):
 
     # Phase-7 unified schema: a single ImplicitUpdate is a one-segment
     # composition with kind=implicit. Artifact filenames keep their original
-    # rhs/step/predictor suffixes (no `_seg0_` prefix for single-segment).
+    # residual/jacobian/solve/predictor suffixes (no `_seg0_` prefix for
+    # single-segment).
     assert meta["type"] == "composed"
     assert len(meta["segments"]) == 1
     assert meta["segments"][0]["kind"] == "implicit"
-    # Schema v10: binaries under <device>/<dtype>/, shared metadata.json at root.
-    assert (leaf / "return_map_rhs.pt2").exists()
-    assert (leaf / "return_map_step.pt2").exists()
-    assert (leaf / "return_map_ift.pt2").exists()
+    # Schema v10: operator + solve graphs, binaries under <device>/<dtype>/,
+    # shared metadata.json at root.
+    assert (leaf / "return_map_residual.pt2").exists()
+    assert (leaf / "return_map_jacobian.pt2").exists()
+    assert (leaf / "return_map_solve.pt2").exists()
+    assert (leaf / "return_map_jacobian_given.pt2").exists()
+    assert (leaf / "return_map_solve_ift.pt2").exists()
     assert (out_dir / "metadata.json").exists()
-    assert meta["segments"][0]["ift_package"] == "return_map_ift.pt2"
+    assert meta["segments"][0]["solve_ift_package"] == "return_map_solve_ift.pt2"
     # An implicit model records the runtime solver config in the shared meta so
     # the Python-free C++ runtime is configured straight from the artifact.
     assert "solver_config" in meta
@@ -575,7 +587,12 @@ def test_export_implicit_ift_satisfies_IFT_identity(implicit_export):
     f = load_input(_J2_NATIVE_I)
     return_map = f.get_model("return_map")
     _, out_dir, leaf = implicit_export
-    ift_pkg = load_package(leaf / "return_map_ift.pt2")
+    # Schema v10: the IFT is un-baked into operator + solve graphs. Chain
+    # `jacobian` (A = ∂r/∂u + b) + `jacobian_given` (B = ∂r/∂g) -> `solve_ift`
+    # (A^{-1}B -> per-pair -du/dg blocks), exactly as the C++ runtime does.
+    jacobian_pkg = load_package(leaf / "return_map_jacobian.pt2")
+    jacobian_given_pkg = load_package(leaf / "return_map_jacobian_given.pt2")
+    solve_ift_pkg = load_package(leaf / "return_map_solve_ift.pt2")
 
     system: ModelNonlinearSystem = return_map.system  # type: ignore[attr-defined]
 
@@ -630,10 +647,18 @@ def test_export_implicit_ift_satisfies_IFT_identity(implicit_export):
     A = A_assembled.tensors[0][0].data
     B = B_assembled.tensors[0][0].data
 
-    # The IFT graph now emits one block per (unknown, given) pair (the
+    # The solve_ift graph emits one block per (unknown, given) pair (the
     # disassemble of -du/dg), in unknown x given order. Reassemble them into the
     # full -du/dg matrix and check the IFT identity A J + B = 0.
-    blocks = ift_pkg(u, g)
+    jac_out = jacobian_pkg(u, g)
+    if not isinstance(jac_out, tuple):
+        jac_out = (jac_out,)
+    n_a = system.blayout.ngroup * system.ulayout.ngroup
+    a_blocks = jac_out[:n_a]  # drop the trailing b groups
+    b_blocks = jacobian_given_pkg(u, g)
+    if not isinstance(b_blocks, tuple):
+        b_blocks = (b_blocks,)
+    blocks = solve_ift_pkg(*a_blocks, *b_blocks)
     if not isinstance(blocks, tuple):
         blocks = (blocks,)
     u_off = {
@@ -703,7 +728,7 @@ def test_export_implicit_rhs_output_matches_eager(implicit_export):
 
     _, out_dir, leaf = implicit_export
 
-    rhs_pkg = load_package(leaf / "return_map_rhs.pt2")
+    rhs_pkg = load_package(leaf / "return_map_residual.pt2")
 
     system: ModelNonlinearSystem = return_map.system  # type: ignore[attr-defined]
 

--- a/tests/unit/test_compile_interactive.py
+++ b/tests/unit/test_compile_interactive.py
@@ -274,7 +274,7 @@ def test_plan_summary_composed_multi_segment():
     ]
     # Every predicted artifact plus the meta + stub is enumerated, stub last.
     assert summary.files[-1] == "model_aoti.i"
-    assert "model_seg1_ift.pt2" in summary.files
+    assert "model_seg1_solve_ift.pt2" in summary.files
 
 
 def test_validate_ok_for_real_file():


### PR DESCRIPTION
## Summary

The implicit-segment AOTI graphs previously **baked the linear solve** (`du = A⁻¹b`) into the compiled `.pt2` (the fused `_step` graph). That blocks swapping in an iterative/Krylov linear solver, since the solve is frozen inside the graph. This PR **decouples it**: the residual Jacobian is emitted as an *operator*, and every linear solve moves into a *separate* graph. The C++ runtime becomes a generic driver that chains `operator → solve`. **No baked solve remains on the AOTI path.**

This is the prerequisite for the follow-up iterative/matrix-free linear-solver work — with `_jacobian` (assemble `A`) and `_solve` (`du = A⁻¹b`) as separate graphs, an iterative solver becomes a new solver-kind that swaps only the `_solve` stage for a matvec loop.

## What changed (schema v9 → v10)

Per implicit segment, the fused graphs split into operator + solve pairs:

| Before (v9) | After (v10) |
| --- | --- |
| `_rhs` + `_step` (fused assemble + solve) | `_residual` + `_jacobian` (`A = ∂r/∂u`, `+b`) + `_solve` (`du = A⁻¹b`) |
| `_ift` | `_jacobian_given` (`B = ∂r/∂g`) + `_solve_ift` (`du/dg = −A⁻¹B`) |
| `_pift` | `_dr_dparam` (dense `A` + `∂r/∂θ`) + `_solve_param` (`du/dθ`) |

## Design — uniform Python authoring + generic C++ driver

Solver bodies are the existing Python `[Solvers]` classes (`DenseLU` / `SchurComplement`): run **live** for the eager routes and **compiled** to `_solve*` graphs for AOTI — a single solver implementation, so parity holds by construction. The C++ `AOTINonlinearSystem::step()` is now `solve_loader.run(jacobian_loader.run(inputs))` with **no solver algebra** in C++; the choice of linear solver is baked into the `_solve*` graphs (recompile to change it).

Key changes:
- **`es/implicit.py`** — new operator graphs (`Jacobian`, `JacobianGiven`, `DrDParam`) and solve graphs (`LinearSolve`, `LinearSolveIFT`, `LinearSolveParam`); retire `NewtonStep` / `IFT` / `ParamIFT`.
- **`es/assembled.py`** — `group_block_sub_batch_ndim` + `wrap_block_raw`: single source of truth for reconstructing typed operators from raw per-block tensors (handles the compact paired-diagonal BLOCK+BLOCK storage where `sub_batch_ndim` isn't derivable as row+col count).
- **`solvers/newton.py`** — eager step composes `Jacobian → LinearSolve` live.
- **`cli/aoti_export.py`** — emit the operator+solve graph set; new metadata package keys; `schema_version` 9 → 10 (via `dep_manager`).
- **`csrc/aoti`** — rename/rework segment loaders; `step()` chains `jacobian → solve`; `jacobian.cpp` chains the IFT / ParamIFT operator → solve graphs.

## Testing

Validated across all six evaluation routes:
- AOTI end-to-end suite (99), regression incl. `taylor` BLOCK-Schur (57), verification, models, unit (955 combined), C++ ctests (14/14).
- Re-verified on this rebased base: `tests/unit/test_aoti_export.py` (24 passed) — metadata / artifact-name contract.

## Note on base

This branch is based on `main`. It was developed on top of #425; the two are independent (config/CLI vs. graph split). Intent is to merge #425 first, then rebase this cleanly — the diff here is the decoupling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
