### PR TITLE
Make derived_output names user-overridable by default + surface them in neml2-syntax

### DIFF
--- a/neml2/cli/syntax.py
+++ b/neml2/cli/syntax.py
@@ -155,6 +155,29 @@ def _field_to_json(field: HitField) -> dict[str, Any]:
     }
 
 
+def _derived_output_to_json(field: HitField, knob: str) -> dict[str, Any]:
+    """Serialize a ``derived_output``'s implicit rename knob as an OUTPUT option.
+
+    A derived output declares no HIT option of its own, but its default name
+    (``knob`` = referenced option + suffix) doubles as an optional rename knob
+    (see :func:`neml2.schema._read_derived_var_name`), so it belongs in the
+    catalog. ``required=False`` and ``value=knob`` convey "optional; defaults to
+    this name". Derived fields carry no docstring, so synthesize one.
+    """
+    doc = field.doc or (
+        f"Optional name for the derived output (defaults to '{knob}', i.e. the "
+        f"'{field.name}' variable name with the '{field.suffix}' suffix)."
+    )
+    return {
+        "name": knob,
+        "doc": _ascii_doc(doc, f"{knob} option doc"),
+        "ftype": "OUTPUT",
+        "required": False,
+        "type": _type_name(field.value_type),
+        "value": knob,
+    }
+
+
 def record_to_json(record: SyntaxRecord, *, include_options: bool = True) -> dict[str, Any]:
     j: dict[str, Any] = {
         "type": record.type_name,
@@ -164,14 +187,20 @@ def record_to_json(record: SyntaxRecord, *, include_options: bool = True) -> dic
         "class_name": record.class_name,
     }
     if include_options and record.hit is not None:
-        # ``derived_*`` fields reference another option to derive a variable
-        # name; they aren't user-facing HIT options of their own and would
-        # confuse the syntax catalog by duplicating the base option's entry.
-        j["options"] = [
-            _field_to_json(field)
-            for field in record.hit.fields
-            if field.kind not in {"derived_input", "derived_output"}
-        ]
+        # ``derived_input`` fields reference another option to derive a
+        # variable name; they aren't user-facing HIT options of their own and
+        # would confuse the catalog by duplicating the base option's entry. A
+        # ``derived_output``, however, exposes an implicit rename knob (its
+        # default name) — surface that so the renamable output is discoverable.
+        options: list[dict[str, Any]] = []
+        for field in record.hit.fields:
+            if field.kind in {"derived_input", "derived_output"}:
+                knob = field.implicit_override_name
+                if knob is not None:
+                    options.append(_derived_output_to_json(field, knob))
+                continue
+            options.append(_field_to_json(field))
+        j["options"] = options
     return j
 
 

--- a/neml2/schema.py
+++ b/neml2/schema.py
@@ -111,6 +111,22 @@ class HitField:
     def is_output(self) -> bool:
         return self.kind in {"output", "var_output"}
 
+    @property
+    def implicit_override_name(self) -> str | None:
+        """HIT option that renames this field's derived variable, or ``None``.
+
+        A ``derived_output``'s default name — the referenced option name plus
+        ``suffix`` (e.g. ``back_stress`` + ``_rate`` = ``back_stress_rate``) —
+        doubles as an optional rename knob (see :func:`_read_derived_var_name`);
+        this returns that knob's name. Only ``derived_output`` fields with a
+        ``suffix`` expose one — ``derived_input`` does not. Single source of
+        truth for the resolver, the unknown-field validator, and the syntax
+        catalog.
+        """
+        if self.kind == "derived_output" and self.suffix:
+            return f"{self.name}{self.suffix}"
+        return None
+
 
 class HitSchema:
     """Ordered declaration of a native object's HIT surface."""
@@ -222,8 +238,9 @@ class HitSchema:
                 # Purely virtual — a derived field introduces no HIT option of
                 # its own, except that a derived_output's default name doubles
                 # as an implicit rename knob (see _read_derived_var_name).
-                if field.kind == "derived_output" and field.suffix:
-                    allowed.add(f"{field.name}{field.suffix}")
+                knob = field.implicit_override_name
+                if knob is not None:
+                    allowed.add(knob)
                 continue
             allowed.add(field.name)
             if field.override:
@@ -660,8 +677,9 @@ def _read_derived_var_name(
         override_val = node.param_optional_str(field.override, "")
         if override_val:
             return override_val
-    if field.kind == "derived_output" and field.suffix:
-        auto_val = node.param_optional_str(f"{field.name}{field.suffix}", "")
+    knob = field.implicit_override_name
+    if knob is not None:
+        auto_val = node.param_optional_str(knob, "")
         if auto_val:
             return auto_val
     base = name_values.get(field.name)

--- a/neml2/schema.py
+++ b/neml2/schema.py
@@ -212,12 +212,19 @@ class HitSchema:
         schema-driven kwargs pass to dispatch the registered class.
         Override option names (an :func:`option`'s ``override=`` target) are
         also allowed; they substitute for the primary option's value when
-        non-empty.
+        non-empty. A :func:`derived_output`'s default name (referenced name +
+        suffix) is likewise allowed: it doubles as an implicit rename knob (see
+        :func:`_read_derived_var_name`).
         """
         allowed: set[str] = {"type"}
         for field in self.fields:
             if field.kind in {"derived_input", "derived_output"}:
-                continue  # purely virtual; doesn't introduce a HIT field
+                # Purely virtual — a derived field introduces no HIT option of
+                # its own, except that a derived_output's default name doubles
+                # as an implicit rename knob (see _read_derived_var_name).
+                if field.kind == "derived_output" and field.suffix:
+                    allowed.add(f"{field.name}{field.suffix}")
+                continue
             allowed.add(field.name)
             if field.override:
                 allowed.add(field.override)
@@ -348,6 +355,15 @@ def derived_output(
     See :func:`derived_input`. The canonical use is
     ``derived_output("variable", T, suffix="_residual")`` for an implicit
     residual output named after the base ``variable`` option/input.
+
+    Unlike :func:`derived_input`, a derived output is renamable by default: its
+    *default* name — the referenced field name plus ``suffix`` (e.g.
+    ``back_stress`` + ``_rate`` = ``back_stress_rate``) — doubles as a HIT
+    rename knob, so ``back_stress_rate = 'X_rate'`` renames the output the same
+    way ``stress = 'my_stress'`` renames a regular :func:`output`. The knob name
+    is the *static* default (it does not shift when the referenced base is
+    renamed); the value assigned to it is the new output name, and it takes
+    precedence over the ``base + suffix`` cascade.
     """
     return HitField(
         "derived_output",
@@ -626,15 +642,28 @@ def _read_derived_var_name(
 ) -> str | None:
     """Resolve a ``derived_input`` / ``derived_output`` field's variable name.
 
-    ``override`` (if set): check HIT for the named option; when non-empty,
-    that value short-circuits the derivation and is returned as-is. Else the
-    base value comes from ``name_values[field.name]`` (the already-resolved
-    value of the referenced input/output/option) and ``suffix`` is appended.
+    Resolution precedence:
+
+    1. Explicit ``override`` (if set): check HIT for that named option; when
+       non-empty, it short-circuits the derivation and is returned as-is.
+    2. Implicit override (``derived_output`` only): the field's *default*
+       derived name — the referenced option name plus ``suffix`` (e.g.
+       ``back_stress`` + ``_rate`` = ``back_stress_rate``) — doubles as a HIT
+       rename knob. When the user sets that option non-empty, it wins, exactly
+       as setting a regular :func:`output`'s option renames it. This makes
+       every derived output renamable with no per-model opt-in.
+    3. Otherwise the base value comes from ``name_values[field.name]`` (the
+       already-resolved value of the referenced input/output/option) and
+       ``suffix`` is appended.
     """
     if field.override is not None:
         override_val = node.param_optional_str(field.override, "")
         if override_val:
             return override_val
+    if field.kind == "derived_output" and field.suffix:
+        auto_val = node.param_optional_str(f"{field.name}{field.suffix}", "")
+        if auto_val:
+            return auto_val
     base = name_values.get(field.name)
     if field.suffix and base is not None:
         return f"{base}{field.suffix}"

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -459,3 +459,92 @@ def test_normalize_load_target():
     # A concrete cuda index is preserved (pins a dispatcher Model to that GPU);
     # the ``torch.`` prefix on a dtype's ``str()`` is stripped.
     assert _normalize_load_target(torch.device("cuda", 1), torch.float32) == ("cuda:1", "float32")
+
+
+# ---------------------------------------------------------------------------
+# derived_output names are user-overridable by default: the default derived
+# name (referenced option + suffix, e.g. back_stress + _rate = back_stress_rate)
+# doubles as a HIT rename knob, with no per-model opt-in. See
+# neml2.schema._read_derived_var_name / HitSchema.reject_unknown_fields.
+# ---------------------------------------------------------------------------
+
+
+def _build_model(hit_text: str, name: str = "m"):
+    import nmhit
+
+    root = nmhit.parse_text(hit_text)
+    return _NativeInputFile(root, Path("synthetic.i")).get_model(name)
+
+
+def test_derived_output_name_override_at_construction():
+    """Setting the derived output's default name (``back_stress_rate``) renames
+    FredrickArmstrong's rate output. The computed value is unchanged; only the
+    name (output_spec key + the leaf's chain-rule output attr) moves."""
+    from neml2.types import SR2, Scalar
+
+    def build(extra: str):
+        return _build_model(
+            "[Models]\n  [m]\n    type = FredrickArmstrongPlasticHardening\n"
+            f"    C = 1000\n    g = 10\n{extra}  []\n[]\n"
+        )
+
+    default = build("")
+    renamed = build("    back_stress_rate = 'X_rate'\n")
+
+    assert "back_stress_rate" in default.output_spec
+    assert "X_rate" in renamed.output_spec
+    assert "back_stress_rate" not in renamed.output_spec
+    assert renamed._X_rate == "X_rate"
+    # An output rename leaves the inputs untouched.
+    assert set(renamed.input_spec) == set(default.input_spec)
+
+    gen = torch.Generator().manual_seed(7)
+    fr = Scalar(torch.rand((), generator=gen, dtype=torch.float64))
+    nm = SR2(torch.rand(6, generator=gen, dtype=torch.float64))
+    x = SR2(torch.rand(6, generator=gen, dtype=torch.float64))
+    assert torch.allclose(renamed(fr, nm, x).data, default(fr, nm, x).data, rtol=1e-12, atol=1e-12)
+
+
+def test_derived_output_override_independent_of_base_rename():
+    """The knob name is the static schema default (``back_stress_rate``) even
+    when the base input is renamed, and the explicit knob wins over the
+    ``base + suffix`` cascade (which would otherwise yield ``X_rate``)."""
+    m = _build_model(
+        "[Models]\n  [m]\n    type = FredrickArmstrongPlasticHardening\n"
+        "    C = 1000\n    g = 10\n"
+        "    back_stress = 'X'\n"
+        "    back_stress_rate = 'X_dot'\n  []\n[]\n"
+    )
+    assert "X" in m.input_spec
+    assert "back_stress" not in m.input_spec
+    assert "X_dot" in m.output_spec
+    assert "X_rate" not in m.output_spec
+    assert m._X_rate == "X_dot"
+
+
+def test_derived_output_residual_name_override():
+    """The ``_residual`` derived outputs on the implicit time integrators are
+    covered by the same framework knob (``variable_residual``) with zero
+    per-model changes."""
+    m = _build_model(
+        "[Models]\n  [m]\n    type = SR2BackwardEulerTimeIntegration\n"
+        "    variable = 'foo'\n"
+        "    variable_residual = 'my_resid'\n  []\n[]\n"
+    )
+    assert "my_resid" in m.output_spec
+    assert "foo_residual" not in m.output_spec
+    assert m._residual == "my_resid"
+
+
+def test_derived_output_knob_accepted_but_typo_rejected():
+    """The implicit rename knob is a recognized option, but a typo of it is
+    still a hard unknown-option error -- typos must not silently pass."""
+    _build_model(  # exact knob: no raise
+        "[Models]\n  [m]\n    type = FredrickArmstrongPlasticHardening\n"
+        "    C = 1000\n    g = 10\n    back_stress_rate = 'X_rate'\n  []\n[]\n"
+    )
+    with pytest.raises(ValueError, match=r"unknown option"):
+        _build_model(
+            "[Models]\n  [m]\n    type = FredrickArmstrongPlasticHardening\n"
+            "    C = 1000\n    g = 10\n    back_stress_rat = 'X_rate'\n  []\n[]\n"
+        )

--- a/tests/unit/test_syntax_cli.py
+++ b/tests/unit/test_syntax_cli.py
@@ -98,6 +98,36 @@ def test_schema_backed_solver_emits_option_metadata():
     }
 
 
+def test_derived_output_rename_knob_is_catalogued():
+    """A ``derived_output``'s default name doubles as a rename knob (see
+    ``schema._read_derived_var_name``); it must be discoverable as an OUTPUT
+    option even though the field declares no explicit HIT option."""
+    record = _record_map()["FredrickArmstrongPlasticHardening"]
+    opts = {opt["name"]: opt for opt in _syntax_cli.record_to_json(record)["options"]}
+
+    assert "back_stress_rate" in opts
+    knob = opts["back_stress_rate"]
+    assert knob["ftype"] == "OUTPUT"
+    assert knob["required"] is False
+    assert knob["type"] == "SR2"
+    assert knob["doc"]  # synthesized, non-empty
+    # The real inputs remain; the derived knob is additive.
+    assert {"flow_rate", "flow_direction", "back_stress"} <= set(opts)
+
+
+def test_derived_input_names_stay_hidden_but_residual_is_catalogued():
+    """``derived_input`` names (previous-step ``~1``, rate) stay hidden, but a
+    residual ``derived_output`` surfaces as a rename knob on the same model."""
+    record = _record_map()["SR2BackwardEulerTimeIntegration"]
+    names = {opt["name"] for opt in _syntax_cli.record_to_json(record)["options"]}
+
+    assert "variable_residual" in names  # derived_output knob, surfaced
+    assert "variable~1" not in names  # derived_input, hidden
+    assert "variable_rate" not in names  # derived_input, hidden
+    # The explicit user-facing options remain.
+    assert {"variable", "time", "rate"} <= names
+
+
 def test_collect_records_rejects_type_without_section(monkeypatch: pytest.MonkeyPatch):
     """A registered class missing ``SECTION`` is a programming bug — the
     catalog would silently drop the type otherwise. Fake a stale registry entry


### PR DESCRIPTION
## Summary

Every `derived_output` (e.g. `FredrickArmstrongPlasticHardening`'s `back_stress_rate`, all `*_rate` hardening/viscoelastic producers, the `_residual` outputs on the implicit time integrators) previously had a name the user could **not** rename independently of the referenced base option. `BackwardEulerTimeIntegration` solved the analogous problem for its rate *input* with an opt-in `override="rate"` + a hand-declared `option(...)`.

Rather than bolt that opt-in onto each model, this makes overriding a **default framework capability**: a `derived_output`'s default name — the referenced option name plus its suffix (e.g. `back_stress` + `_rate` = `back_stress_rate`) — doubles as a HIT rename knob, exactly as a regular `output()`'s option name renames it:

```
[Models]
  [m]
    type = FredrickArmstrongPlasticHardening
    C = 1000
    g = 10
    back_stress_rate = 'X_rate'   # renames the derived output, no per-model opt-in
  []
[]
```

**No per-model edits** — all `derived_output` sites gain the capability at once (single- and multi-output models alike). Scope is `derived_output` only; `derived_input` is unchanged, and `BackwardEuler`'s explicit `override="rate"` keeps top precedence.

## Changes

**1. Schema-level override (commit 1)**
- `_read_derived_var_name`: resolve an implicit auto-named override option (derived_output only). Precedence: explicit `override=` > implicit auto-name > `base + suffix` cascade.
- `reject_unknown_fields`: whitelist the implicit knob so it's accepted; typos remain hard errors.

**2. Catalog discoverability (commit 2)**
- Add `HitField.implicit_override_name` — the single source of truth for the knob name, shared by the resolver, the validator, and the catalog (the first two refactored onto it).
- `cli/syntax.record_to_json`: emit a synthetic OUTPUT option per derived_output knob (optional, typed, with a synthesized doc) so the renamable output is discoverable via `neml2-syntax` and the generated docs. `derived_input` names stay hidden.

Catalog result:
```
FredrickArmstrongPlasticHardening
  OUTPUT  back_stress_rate  req=False  type=SR2
          doc: Optional name for the derived output (defaults to 'back_stress_rate',
               i.e. the 'back_stress' variable name with the '_rate' suffix).
```

## Testing

- 4 new tests in `tests/unit/test_factory.py` (rate-output rename, independence-from-base-rename + precedence, residual rename via framework, typo still rejected). Negative control confirms the new behavior fails against the pre-change schema.
- 2 new tests in `tests/unit/test_syntax_cli.py` (derived_output knob catalogued as OUTPUT; derived_input stays hidden while residual is surfaced).
- Full `tests/unit/` (720) + pyzag (23) pass; `ruff`, `ruff format`, `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)