### PR TITLE
Capture solve-failure context on ConvergenceError (opt-in)

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -114,7 +114,16 @@ jobs:
         # torch lifts that cap; neml2 builds via scikit-build-core (not
         # setuptools' FileList) and ships nothing from a setuptools sdist, so
         # there is no exploit path. Remove once torch permits setuptools >= 83.
-        run: pip-audit --vulnerability-service osv --strict --ignore-vuln PYSEC-2026-3447
+        #
+        # PYSEC-2025-194 (CVE-2025-3000): a local memory-corruption in
+        # ``torch.jit.script`` (fixed in torch 2.13.0). neml2 never calls
+        # ``torch.jit.script`` -- it lowers via ``torch.export`` / AOTInductor,
+        # and its only ``torch.jit`` use is ``torch.jit.load`` of its own
+        # regression golds (a different, trusted-input path) -- so there is no
+        # exploit path. The 2.13.0 fix is unreachable while torch is pinned at
+        # 2.12.1 for the AOTI runtime ABI lock. Remove once neml2 moves to
+        # torch >= 2.13.0.
+        run: pip-audit --vulnerability-service osv --strict --ignore-vuln PYSEC-2026-3447 --ignore-vuln PYSEC-2025-194
 
   coverage:
     # Python branch + line coverage. Runs the fast lane only -- the

--- a/neml2/csrc/aoti/Exception.cpp
+++ b/neml2/csrc/aoti/Exception.cpp
@@ -100,6 +100,15 @@ FatalError::recoverable() const noexcept
   return false;
 }
 
+ConvergenceError::ConvergenceError(const std::string & what_arg,
+                                   at::Tensor converged_mask,
+                                   std::map<std::string, at::Tensor> unknowns)
+  : Exception(what_arg),
+    _converged_mask(std::move(converged_mask)),
+    _unknowns(std::move(unknowns))
+{
+}
+
 bool
 ConvergenceError::recoverable() const noexcept
 {

--- a/neml2/csrc/aoti/Exception.h
+++ b/neml2/csrc/aoti/Exception.h
@@ -96,7 +96,7 @@ public:
   /// stuck at, keyed by unknown-variable name. This context is populated only on
   /// the opt-in capture path (the `NEML2_CAPTURE_SOLVE_FAILURE` env var); the
   /// message-only constructor above leaves both empty. The pybind layer surfaces
-  /// them to Python as the `converged_mask` / `unknown` attributes so an offline
+  /// them to Python as the `converged_mask` / `unknowns` attributes so an offline
   /// replay can read the stuck state with near-zero boilerplate.
   ConvergenceError(const std::string & what_arg,
                    at::Tensor converged_mask,

--- a/neml2/csrc/aoti/Exception.h
+++ b/neml2/csrc/aoti/Exception.h
@@ -46,8 +46,12 @@
 // working; only code that wants the recoverable/fatal split needs the new types.
 
 #include <exception>
+#include <map>
 #include <stdexcept>
+#include <string>
 #include <vector>
+
+#include <ATen/core/Tensor.h>
 
 #include "neml2/csrc/aoti/aoti_export.h"
 
@@ -85,7 +89,32 @@ class AOTI_EXPORT ConvergenceError : public Exception
 {
 public:
   using Exception::Exception;
+
+  /// Enriched constructor that additionally carries a *failure context* for
+  /// offline debugging: a per-dynamic-batch-element convergence mask (`true`
+  /// where the element converged) and the best-effort iterate the solve got
+  /// stuck at, keyed by unknown-variable name. This context is populated only on
+  /// the opt-in capture path (the `NEML2_CAPTURE_SOLVE_FAILURE` env var); the
+  /// message-only constructor above leaves both empty. The pybind layer surfaces
+  /// them to Python as the `converged_mask` / `unknown` attributes so an offline
+  /// replay can read the stuck state with near-zero boilerplate.
+  ConvergenceError(const std::string & what_arg,
+                   at::Tensor converged_mask,
+                   std::map<std::string, at::Tensor> unknowns);
+
   bool recoverable() const noexcept override;
+
+  /// Per-dynamic-batch-element convergence mask captured at failure (an undefined
+  /// tensor when capture was disabled). `true` where the element converged.
+  const at::Tensor & converged_mask() const noexcept { return _converged_mask; }
+
+  /// Best-effort iterate at failure, keyed by unknown-variable name (empty when
+  /// capture was disabled).
+  const std::map<std::string, at::Tensor> & unknowns() const noexcept { return _unknowns; }
+
+private:
+  at::Tensor _converged_mask;
+  std::map<std::string, at::Tensor> _unknowns;
 };
 
 /// Several concurrent dispatches failed at once (the asynchronous

--- a/neml2/csrc/aoti/_aoti.cpp
+++ b/neml2/csrc/aoti/_aoti.cpp
@@ -80,7 +80,7 @@ PYBIND11_MODULE(_aoti, m)
   // captures under NEML2_CAPTURE_SOLVE_FAILURE (see aoti/solve.cpp) as Python
   // attributes on the raised exception:
   //   .converged_mask -- per-dynamic-batch-element bool tensor (True = converged)
-  //   .unknown        -- dict {unknown-variable name -> best-effort iterate}
+  //   .unknowns       -- dict {unknown-variable name -> best-effort iterate}
   // so an offline replay can read the stuck state with near-zero boilerplate.
   // When capture was disabled both are absent (mask undefined, unknowns empty),
   // and this behaves exactly like the default typed translator.
@@ -103,10 +103,10 @@ PYBIND11_MODULE(_aoti, m)
             inst.attr("converged_mask") = e.converged_mask();
           if (!e.unknowns().empty())
           {
-            py::dict unknown;
+            py::dict unknowns;
             for (const auto & [name, tensor] : e.unknowns())
-              unknown[py::str(name)] = tensor;
-            inst.attr("unknown") = unknown;
+              unknowns[py::str(name)] = tensor;
+            inst.attr("unknowns") = unknowns;
           }
           PyErr_SetObject(convergence_error_type.ptr(), inst.ptr());
         }

--- a/neml2/csrc/aoti/_aoti.cpp
+++ b/neml2/csrc/aoti/_aoti.cpp
@@ -69,11 +69,20 @@ PYBIND11_MODULE(_aoti, m)
   // recoverable neml2::aoti::ConvergenceError after the C++ -> Python -> C++
   // round trip; see neml2/csrc/eager/Model.cpp) can match it precisely. Without
   // this, pybind's default translator collapses every neml2::aoti::Exception
-  // (a std::runtime_error) to a bare RuntimeError, losing recoverable(). Static
-  // so the translator below can reference it without a capture.
-  static const py::exception<neml2::aoti::ConvergenceError> convergence_error_type =
+  // (a std::runtime_error) to a bare RuntimeError, losing recoverable().
+  //
+  // Stored in a static, NON-OWNING handle (``.release()`` leaks the type-object
+  // reference) so the translator below can reference it without a capture. A
+  // ``static py::exception``/``py::object`` would instead dec_ref the type at
+  // interpreter teardown -- after the GIL is gone -- aborting with
+  // "dec_ref() PyGILState_Check() failure" (surfaced by the embedded-interpreter
+  // test_eager under the coverage build). The registered exception type lives for
+  // the interpreter's lifetime regardless, so leaking its ref is the standard,
+  // safe fix.
+  static const py::handle convergence_error_type =
       py::register_exception<neml2::aoti::ConvergenceError>(
-          m, "ConvergenceError", PyExc_RuntimeError);
+          m, "ConvergenceError", PyExc_RuntimeError)
+          .release();
 
   // A second translator, registered after the line above so pybind tries it
   // first, additionally surfaces the optional *failure context* a failed solve
@@ -94,9 +103,9 @@ PYBIND11_MODULE(_aoti, m)
         }
         catch (const neml2::aoti::ConvergenceError & e)
         {
-          // `convergence_error_type` is a py::exception whose operator() *sets*
-          // the Python error (returns void); to construct an instance we call the
-          // underlying type object directly.
+          // Construct an instance by calling the type object directly (so we can
+          // set attributes on it before raising); `convergence_error_type` is a
+          // borrowed handle to that registered type.
           py::object exc_type = py::reinterpret_borrow<py::object>(convergence_error_type.ptr());
           py::object inst = exc_type(e.what());
           if (e.converged_mask().defined())

--- a/neml2/csrc/aoti/_aoti.cpp
+++ b/neml2/csrc/aoti/_aoti.cpp
@@ -69,8 +69,48 @@ PYBIND11_MODULE(_aoti, m)
   // recoverable neml2::aoti::ConvergenceError after the C++ -> Python -> C++
   // round trip; see neml2/csrc/eager/Model.cpp) can match it precisely. Without
   // this, pybind's default translator collapses every neml2::aoti::Exception
-  // (a std::runtime_error) to a bare RuntimeError, losing recoverable().
-  py::register_exception<neml2::aoti::ConvergenceError>(m, "ConvergenceError", PyExc_RuntimeError);
+  // (a std::runtime_error) to a bare RuntimeError, losing recoverable(). Static
+  // so the translator below can reference it without a capture.
+  static const py::exception<neml2::aoti::ConvergenceError> convergence_error_type =
+      py::register_exception<neml2::aoti::ConvergenceError>(
+          m, "ConvergenceError", PyExc_RuntimeError);
+
+  // A second translator, registered after the line above so pybind tries it
+  // first, additionally surfaces the optional *failure context* a failed solve
+  // captures under NEML2_CAPTURE_SOLVE_FAILURE (see aoti/solve.cpp) as Python
+  // attributes on the raised exception:
+  //   .converged_mask -- per-dynamic-batch-element bool tensor (True = converged)
+  //   .unknown        -- dict {unknown-variable name -> best-effort iterate}
+  // so an offline replay can read the stuck state with near-zero boilerplate.
+  // When capture was disabled both are absent (mask undefined, unknowns empty),
+  // and this behaves exactly like the default typed translator.
+  py::register_exception_translator(
+      [](std::exception_ptr p)
+      {
+        try
+        {
+          if (p)
+            std::rethrow_exception(p);
+        }
+        catch (const neml2::aoti::ConvergenceError & e)
+        {
+          // `convergence_error_type` is a py::exception whose operator() *sets*
+          // the Python error (returns void); to construct an instance we call the
+          // underlying type object directly.
+          py::object exc_type = py::reinterpret_borrow<py::object>(convergence_error_type.ptr());
+          py::object inst = exc_type(e.what());
+          if (e.converged_mask().defined())
+            inst.attr("converged_mask") = e.converged_mask();
+          if (!e.unknowns().empty())
+          {
+            py::dict unknown;
+            for (const auto & [name, tensor] : e.unknowns())
+              unknown[py::str(name)] = tensor;
+            inst.attr("unknown") = unknown;
+          }
+          PyErr_SetObject(convergence_error_type.ptr(), inst.ptr());
+        }
+      });
 
   py::class_<Model>(m, "Model", R"(
 Thin C++ runtime for an AOTI-exported NEML2 model.
@@ -361,6 +401,61 @@ Run the shared C++ Newton solver over an eager (Python-delegating) system.
 (they bind the givens + linear solver, e.g. ``RHS`` + ``Jacobian`` -> ``LinearSolve``).
 ``unknown_layout`` / ``residual_layout`` are ``(structure, sub_batch_shape)``
 per group. Returns ``(u_solved, converged, iterations)``.
+)");
+
+  // Masking variant of newton_solve_eager: drives Newton::solve_masked (no throw)
+  // and returns the best-effort iterate + per-element convergence mask. Used to
+  // capture a failed batch's non-converged state for offline debugging.
+  m.def(
+      "newton_solve_eager_masked",
+      [](py::object residual_fn,
+         py::object step_fn,
+         std::vector<std::pair<std::string, std::vector<int64_t>>> unknown_layout,
+         std::vector<std::pair<std::string, std::vector<int64_t>>> residual_layout,
+         std::vector<at::Tensor> u0,
+         double atol,
+         double rtol,
+         std::size_t miters,
+         const std::string & ls_type,
+         std::size_t ls_max_iters,
+         double ls_cutback,
+         double ls_c,
+         double substep_del_tol)
+      {
+        neml2::aoti::SolverConfig cfg;
+        cfg.atol = atol;
+        cfg.rtol = rtol;
+        cfg.miters = miters;
+        cfg.ls_type = ls_type;
+        cfg.ls_max_iters = ls_max_iters;
+        cfg.ls_cutback = ls_cutback;
+        cfg.ls_c = ls_c;
+        cfg.substep_del_tol = substep_del_tol;
+        return neml2::aoti::run_eager_newton_masked(cfg,
+                                                    std::move(residual_fn),
+                                                    std::move(step_fn),
+                                                    std::move(unknown_layout),
+                                                    std::move(residual_layout),
+                                                    std::move(u0));
+      },
+      py::arg("residual_fn"),
+      py::arg("step_fn"),
+      py::arg("unknown_layout"),
+      py::arg("residual_layout"),
+      py::arg("u0"),
+      py::arg("atol"),
+      py::arg("rtol"),
+      py::arg("miters"),
+      py::arg("ls_type"),
+      py::arg("ls_max_iters"),
+      py::arg("ls_cutback"),
+      py::arg("ls_c"),
+      py::arg("substep_del_tol") = 1.0e-6,
+      R"(
+Masking variant of newton_solve_eager: runs Newton::solve_masked (which never
+throws) over an eager system. Returns ``(u_best, converged_mask, iterations)``:
+the best-effort iterate, a per-dynamic-batch-element boolean convergence mask
+(``true`` where converged), and the iteration count.
 )");
 
   // Eager iterative path: the SAME C++ Newton loop, but each Newton step's linear

--- a/neml2/csrc/aoti/internal.h
+++ b/neml2/csrc/aoti/internal.h
@@ -57,6 +57,16 @@ class AOTIModelPackageLoader;
 
 namespace neml2::aoti
 {
+/// Whether to capture a *failure context* (per-element convergence mask +
+/// best-effort iterate) onto the recoverable ``ConvergenceError`` a failed
+/// implicit solve throws, for offline debugging. Opt-in via the
+/// ``NEML2_CAPTURE_SOLVE_FAILURE`` env var (truthy/falsy; see the definition in
+/// solve.cpp) because the capture holds the extra masked state. Read live on
+/// each failure (not cached) so it can be toggled at runtime and mirrors the
+/// Python path's ``os.environ`` lookup. Shared by the single-solve (solve.cpp)
+/// and substepping (substep.cpp) failure paths.
+bool capture_solve_failure_enabled();
+
 // The abstract residual/step provider the shared Newton loop drives; concrete
 // backends (AOTINonlinearSystem / KrylovAOTINonlinearSystem) are built by
 // `_make_implicit_system`. Defined in nonlinear_system.h.
@@ -430,62 +440,35 @@ struct Model::Impl
   std::unique_ptr<NonlinearSystem>
   _make_implicit_system(const Segment & seg, const std::vector<at::Tensor> & g_groups) const;
 
-  /// Adaptive substepping driver: wraps `_run_implicit_segment` in a
-  /// recursive bisection over the increment. Snapshots the segment's endpoint
-  /// givens, then solves the increment in one shot; on a recoverable
-  /// ConvergenceError it halves the span -- interpolating each paired force,
-  /// scaling each listed increment, and chaining each old-state to the previous
-  /// sub-step's solved unknown, per the given's `role` -- recursing up to
-  /// `seg.max_substepping_level` levels before re-raising. On return `state`
-  /// holds the final converged unknowns and the out-params hold the LAST
-  /// sub-step's per-group solved unknowns + givens (the point the IFT path,
-  /// when substepping the Jacobian, evaluates at). Only called when
-  /// `seg.max_substepping_level > 0`.
-  void _run_implicit_segment_substepped(const Segment & seg,
-                                        std::map<std::string, at::Tensor> & state,
-                                        std::vector<at::Tensor> & u_solved_groups,
-                                        std::vector<at::Tensor> & g_groups) const;
-
   /// Masked single implicit solve: like `_run_implicit_segment` but drives
   /// `Newton::solve_masked` and returns the per-element convergence mask (bool,
   /// dynamic-batch shape) WITHOUT throwing. Converged rows' solved unknowns are
   /// written to `state`; the mask tells the substep driver which rows to freeze
-  /// vs bisect. `_masking_ok` gates whether masking applies (1-D dynamic batch).
+  /// vs bisect.
   at::Tensor _run_implicit_segment_masked(const Segment & seg,
                                           std::map<std::string, at::Tensor> & state) const;
 
-  /// Per-element (masked) substepping: solve only the still-unconverged subset of
-  /// the dynamic batch at each sub-step, freezing converged rows at their
-  /// coarsest converging solution and bisecting only the failing subset. The
-  /// value + Jacobian variants mirror `_run_implicit_segment_substepped[_jacobian]`
-  /// but scatter converged rows into full-batch accumulators. Require a 1-D
-  /// dynamic batch (see `_masking_ok`); `ops.cpp` falls back to the whole-batch
-  /// driver otherwise. Only called when `seg.max_substepping_level > 0`.
+  /// Adaptive per-element (masked) substepping -- the ONLY substepping path.
+  /// Solve only the still-unconverged subset of the dynamic batch at each
+  /// sub-step, freeze converged rows at their coarsest converging solution, and
+  /// bisect only the failing subset (so a few hard elements do not drag the whole
+  /// batch through the deep sub-steps), recursing up to `seg.max_substepping_level`
+  /// levels before raising a recoverable `ConvergenceError`. Masking indexes dim
+  /// 0, so a non-1-D dynamic batch (multi-axis, or unbatched) is flattened to a
+  /// single leading axis internally and the solved unknowns reshaped back on
+  /// return -- the compiled solve accepts any dynamic-batch rank, so this is a
+  /// pure reshape. When `capture_solve_failure_enabled()`, a raised error carries
+  /// the level-0 (single-shot) convergence mask + best-effort iterate as its
+  /// failure context. On return `state` (value) / `state` + `dstate` (jacobian)
+  /// hold the final unknowns / total `du_M/d(master inputs)`. Only called when
+  /// `seg.max_substepping_level > 0`; the jacobian variant requires the IFT
+  /// operator (`seg.jacobian_given_loader`).
   void _run_implicit_segment_substepped_masked(const Segment & seg,
                                                std::map<std::string, at::Tensor> & state) const;
   void _run_implicit_segment_substepped_masked_jacobian(
       const Segment & seg,
       std::map<std::string, at::Tensor> & state,
       std::map<std::string, at::Tensor> & dstate) const;
-
-  /// True iff masking applies to `state` for this segment: the dynamic batch is
-  /// a single axis (dim 0), so per-row `index_select`/`index_copy` cleanly
-  /// selects elements. Multi-axis dynamic batches fall back to whole-batch.
-  bool _masking_ok(const Segment & seg, const std::map<std::string, at::Tensor> & state) const;
-
-  /// Substepping analogue of `_run_implicit_segment_jacobian`: solves the
-  /// increment by the same bisection AND accumulates the chained consistent
-  /// tangent into `dstate`. At each successfully-solved leaf sub-span it runs
-  /// the value solve then the IFT composition, having first written the span's
-  /// givens into `dstate` per their role -- interpolated force sensitivities,
-  /// scaled increments, and each old-state seeded with the previous span's
-  /// solved-unknown sensitivity -- so one IFT call yields
-  /// `J_k = A_k·J_{k-1} + B_k·frac_k·J_endpoint`. On return `state` holds the
-  /// final unknowns and `dstate[unknown]` the total `du_M/d(master inputs)`.
-  /// Requires `seg.solve_ift_loader`. Only called when `seg.max_substepping_level > 0`.
-  void _run_implicit_segment_substepped_jacobian(const Segment & seg,
-                                                 std::map<std::string, at::Tensor> & state,
-                                                 std::map<std::string, at::Tensor> & dstate) const;
 
   /// Write the substep sub-span [a, b] transform of a name->tensor map into
   /// `dst`, reading the endpoint snapshot `orig` and the chained old-state

--- a/neml2/csrc/aoti/nonlinear_system_eager.cpp
+++ b/neml2/csrc/aoti/nonlinear_system_eager.cpp
@@ -159,6 +159,22 @@ run_eager_newton(const SolverConfig & cfg,
   return {std::move(result.u), result.converged, result.iterations, std::move(result.log)};
 }
 
+std::tuple<std::vector<at::Tensor>, at::Tensor, std::size_t>
+run_eager_newton_masked(const SolverConfig & cfg,
+                        py::object residual_fn,
+                        py::object step_fn,
+                        std::vector<std::pair<std::string, std::vector<int64_t>>> unknown_layout,
+                        std::vector<std::pair<std::string, std::vector<int64_t>>> residual_layout,
+                        std::vector<at::Tensor> u0)
+{
+  EagerNonlinearSystem sys(std::move(residual_fn),
+                           std::move(step_fn),
+                           to_layouts(unknown_layout),
+                           to_layouts(residual_layout));
+  NewtonResult result = Newton(cfg).solve_masked(sys, u0);
+  return {std::move(result.u), std::move(result.converged_mask), result.iterations};
+}
+
 std::tuple<std::vector<at::Tensor>, bool, std::size_t, std::vector<std::string>>
 run_eager_krylov(const SolverConfig & newton_cfg,
                  const KrylovConfig & krylov_cfg,

--- a/neml2/csrc/aoti/nonlinear_system_eager.h
+++ b/neml2/csrc/aoti/nonlinear_system_eager.h
@@ -61,6 +61,20 @@ run_eager_newton(const SolverConfig & cfg,
                  std::vector<std::pair<std::string, std::vector<int64_t>>> residual_layout,
                  std::vector<at::Tensor> u0);
 
+/// Masking variant of run_eager_newton: drives ``Newton::solve_masked`` (which
+/// never throws) and returns ``(u_best, converged_mask, iterations)`` -- the
+/// best-effort iterate, the per-dynamic-batch-element convergence mask (``true``
+/// where the element converged), and the iteration count. Used to capture a
+/// failed batch's non-converged state and which elements diverged, for offline
+/// debugging (see ``NEML2_DUMP_SOLVE_FAILURE``). Must be called with the GIL held.
+std::tuple<std::vector<at::Tensor>, at::Tensor, std::size_t>
+run_eager_newton_masked(const SolverConfig & cfg,
+                        pybind11::object residual_fn,
+                        pybind11::object step_fn,
+                        std::vector<std::pair<std::string, std::vector<int64_t>>> unknown_layout,
+                        std::vector<std::pair<std::string, std::vector<int64_t>>> residual_layout,
+                        std::vector<at::Tensor> u0);
+
 /// Drive the shared C++ Newton solver over an eager system whose inner linear
 /// solve is a matrix-free Krylov iteration (krylov.h) rather than a direct solve.
 ///

--- a/neml2/csrc/aoti/nonlinear_system_eager.h
+++ b/neml2/csrc/aoti/nonlinear_system_eager.h
@@ -66,7 +66,7 @@ run_eager_newton(const SolverConfig & cfg,
 /// best-effort iterate, the per-dynamic-batch-element convergence mask (``true``
 /// where the element converged), and the iteration count. Used to capture a
 /// failed batch's non-converged state and which elements diverged, for offline
-/// debugging (see ``NEML2_DUMP_SOLVE_FAILURE``). Must be called with the GIL held.
+/// debugging (see ``NEML2_CAPTURE_SOLVE_FAILURE``). Must be called with the GIL held.
 std::tuple<std::vector<at::Tensor>, at::Tensor, std::size_t>
 run_eager_newton_masked(const SolverConfig & cfg,
                         pybind11::object residual_fn,

--- a/neml2/csrc/aoti/ops.cpp
+++ b/neml2/csrc/aoti/ops.cpp
@@ -174,12 +174,10 @@ Model::Impl::forward(const std::map<std::string, at::Tensor> & inputs,
       std::vector<at::Tensor> u_solved_groups;
       std::vector<at::Tensor> g_groups;
       if (seg.max_substepping_level > 0)
-      {
-        if (_masking_ok(seg, state))
-          _run_implicit_segment_substepped_masked(seg, state);
-        else
-          _run_implicit_segment_substepped(seg, state, u_solved_groups, g_groups);
-      }
+        // Adaptive substepping: per-element masking over the dynamic batch
+        // (flattened to a single axis for any rank) -- freeze converged rows and
+        // bisect only the still-failing subset.
+        _run_implicit_segment_substepped_masked(seg, state);
       else
         _run_implicit_segment(seg, state, u_solved_groups, g_groups);
     }
@@ -247,21 +245,21 @@ Model::Impl::_jacobian_dstate(const std::map<std::string, at::Tensor> & inputs) 
     else if (seg.max_substepping_level > 0 && seg.jacobian_given_loader)
     {
       // Substepped solve + chained consistent-tangent accumulation in one
-      // bisection recursion (state + dstate advanced together). Masked when the
-      // dynamic batch is 1-D so only the still-unconverged rows are re-solved.
-      // Gated on the IFT OPERATOR (jacobian_given), present for both a direct and
-      // an iterative input-sensitivity solver.
-      if (_masking_ok(seg, state))
-        _run_implicit_segment_substepped_masked_jacobian(seg, state, dstate);
-      else
-        _run_implicit_segment_substepped_jacobian(seg, state, dstate);
+      // bisection recursion (state + dstate advanced together): per-element
+      // masking over the dynamic batch (flattened to a single axis for any rank)
+      // so only the still-unconverged rows are re-solved. Gated on the IFT
+      // OPERATOR (jacobian_given), present for both a direct and an iterative
+      // input-sensitivity solver.
+      _run_implicit_segment_substepped_masked_jacobian(seg, state, dstate);
     }
     else
     {
       std::vector<at::Tensor> u_solved_groups;
       std::vector<at::Tensor> g_groups;
       if (seg.max_substepping_level > 0)
-        _run_implicit_segment_substepped(seg, state, u_solved_groups, g_groups);
+        // Off-path implicit segment (no IFT operator requested): advance `state`
+        // via masked substepping; its unknowns' dstate is zero-filled below.
+        _run_implicit_segment_substepped_masked(seg, state);
       else
         _run_implicit_segment(seg, state, u_solved_groups, g_groups);
       if (seg.jacobian_given_loader)

--- a/neml2/csrc/aoti/solve.cpp
+++ b/neml2/csrc/aoti/solve.cpp
@@ -35,6 +35,8 @@
 #include "neml2/csrc/aoti/nonlinear_system_aoti.h"
 #include "neml2/csrc/aoti/nonlinear_system_krylov_aoti.h"
 
+#include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <memory>
 #include <string>
@@ -43,23 +45,22 @@
 
 namespace neml2::aoti
 {
-namespace
-{
-/// Whether to capture a *failure context* (per-element convergence mask +
-/// best-effort iterate) onto the recoverable ``ConvergenceError`` a failed
-/// implicit solve throws, for offline debugging. Opt-in via the
-/// ``NEML2_CAPTURE_SOLVE_FAILURE`` env var (any non-empty value other than
-/// ``"0"``) because the capture costs an extra masked re-solve. Read live on
-/// each failure (not cached) so it can be toggled at runtime and mirrors the
-/// Python path's ``os.environ`` lookup; a solve failure is the rare recoverable
-/// path (it triggers an outer cutback anyway), so the getenv is free.
 bool
 capture_solve_failure_enabled()
 {
   const char * v = std::getenv("NEML2_CAPTURE_SOLVE_FAILURE");
-  return v != nullptr && v[0] != '\0' && std::string(v) != "0";
+  if (v == nullptr)
+    return false;
+  // Truthy/falsy parse (case-insensitive, trimmed), mirroring the Python path's
+  // ``_env_flag`` in ImplicitUpdate.py so both routes toggle identically:
+  // unset / "" / "0" / "false" / "no" / "off" are OFF, everything else is ON.
+  std::string s(v);
+  const auto not_space = [](unsigned char c) { return std::isspace(c) == 0; };
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
+  s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
+  std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+  return !(s.empty() || s == "0" || s == "false" || s == "no" || s == "off");
 }
-} // namespace
 
 void
 Model::Impl::_run_forward_segment(const Segment & seg,

--- a/neml2/csrc/aoti/solve.cpp
+++ b/neml2/csrc/aoti/solve.cpp
@@ -29,17 +29,38 @@
 // per-group state and wires an AOTINonlinearSystem (compiled loaders) into the
 // shared `Newton` solver.
 
+#include "neml2/csrc/aoti/Exception.h"
 #include "neml2/csrc/aoti/internal.h"
 #include "neml2/csrc/aoti/newton.h"
 #include "neml2/csrc/aoti/nonlinear_system_aoti.h"
 #include "neml2/csrc/aoti/nonlinear_system_krylov_aoti.h"
 
+#include <cstdlib>
 #include <memory>
+#include <string>
 
 #include <torch/csrc/inductor/aoti_package/model_package_loader.h>
 
 namespace neml2::aoti
 {
+namespace
+{
+/// Whether to capture a *failure context* (per-element convergence mask +
+/// best-effort iterate) onto the recoverable ``ConvergenceError`` a failed
+/// implicit solve throws, for offline debugging. Opt-in via the
+/// ``NEML2_CAPTURE_SOLVE_FAILURE`` env var (any non-empty value other than
+/// ``"0"``) because the capture costs an extra masked re-solve. Read live on
+/// each failure (not cached) so it can be toggled at runtime and mirrors the
+/// Python path's ``os.environ`` lookup; a solve failure is the rare recoverable
+/// path (it triggers an outer cutback anyway), so the getenv is free.
+bool
+capture_solve_failure_enabled()
+{
+  const char * v = std::getenv("NEML2_CAPTURE_SOLVE_FAILURE");
+  return v != nullptr && v[0] != '\0' && std::string(v) != "0";
+}
+} // namespace
+
 void
 Model::Impl::_run_forward_segment(const Segment & seg,
                                   std::map<std::string, at::Tensor> & state,
@@ -323,7 +344,26 @@ Model::Impl::_run_implicit_segment(const Segment & seg,
   // ConvergenceError out of solve(), so reaching `.u` means it converged -- the
   // recoverable error propagates up through Model::forward/jacobian to the
   // caller, who can cut the time step and retry.
-  u_solved_groups = Newton(_solver_config).solve(*sys, u0_groups).u;
+  try
+  {
+    u_solved_groups = Newton(_solver_config).solve(*sys, u0_groups).u;
+  }
+  catch (const ConvergenceError & e)
+  {
+    if (!capture_solve_failure_enabled())
+      throw;
+    // Opt-in failure capture: re-run the *same* solve in masking mode (no throw)
+    // to recover the per-element convergence mask + best-effort iterate, unpack
+    // that iterate to per-variable state, and re-throw the recoverable error
+    // enriched with the context. Only the (debug) capture path pays the extra
+    // masked solve; the normal failure path re-throws untouched above.
+    const auto res = Newton(_solver_config).solve_masked(*sys, u0_groups);
+    _unpack_groups(res.u, seg.unknown_groups, state);
+    std::map<std::string, at::Tensor> stuck;
+    for (const auto & v : seg.unknowns)
+      stuck[v.name] = state.at(v.name);
+    throw ConvergenceError(e.what(), res.converged_mask, std::move(stuck));
+  }
 
   // Unpack converged per-group unknowns back to per-variable state for
   // downstream forward segments / master outputs to read by name.

--- a/neml2/csrc/aoti/substep.cpp
+++ b/neml2/csrc/aoti/substep.cpp
@@ -92,151 +92,19 @@ Model::Impl::_apply_substep_span(const Segment & seg,
   }
 }
 
-void
-Model::Impl::_run_implicit_segment_substepped(const Segment & seg,
-                                              std::map<std::string, at::Tensor> & state,
-                                              std::vector<at::Tensor> & u_solved_groups,
-                                              std::vector<at::Tensor> & g_groups) const
-{
-  // Snapshot the endpoint value of every given before we start overwriting them.
-  std::map<std::string, at::Tensor> orig;
-  for (const auto & g : seg.givens)
-  {
-    auto it = state.find(g.name);
-    _assert(it != state.end(),
-            "aoti::Model substepping: implicit segment given '",
-            g.name,
-            "' is not in the state map.");
-    orig[g.name] = it->second;
-  }
-
-  std::function<void(double, double, const std::map<std::string, at::Tensor> &, int)> solve_span =
-      [&](double a, double b, const std::map<std::string, at::Tensor> & chained_old, int level)
-  {
-    _apply_substep_span(seg, orig, a, b, chained_old, state);
-    try
-    {
-      _run_implicit_segment(seg, state, u_solved_groups, g_groups);
-      return;
-    }
-    catch (const ConvergenceError &)
-    {
-      // Only a recoverable divergence / max-iters is retried by subdivision; a
-      // FatalError (shape/device/config) propagates immediately.
-      if (level >= seg.max_substepping_level)
-        throw;
-    }
-    const double mid = 0.5 * (a + b);
-    solve_span(a, mid, chained_old, level + 1);
-    // The first half's converged unknowns now sit in `state`; feed each as the
-    // second half's old-state (chain old-state given -> its base unknown).
-    std::map<std::string, at::Tensor> chained_next;
-    for (const auto & g : seg.givens)
-      if (g.role == "old_state")
-        chained_next[g.name] = state.at(g.pair);
-    solve_span(mid, b, chained_next, level + 1);
-  };
-
-  // Initial chained old-state = the increment's own ~1 values (the true history).
-  std::map<std::string, at::Tensor> chained0;
-  for (const auto & g : seg.givens)
-    if (g.role == "old_state")
-      chained0[g.name] = orig.at(g.name);
-
-  solve_span(0.0, 1.0, chained0, 0);
-}
-
-void
-Model::Impl::_run_implicit_segment_substepped_jacobian(
-    const Segment & seg,
-    std::map<std::string, at::Tensor> & state,
-    std::map<std::string, at::Tensor> & dstate) const
-{
-  // Snapshot endpoint VALUES (for the primal interpolation) and endpoint DSTATE
-  // (the givens' sensitivity to the master inputs, for the tangent interpolation)
-  // before either is overwritten per sub-span.
-  std::map<std::string, at::Tensor> orig_val;
-  std::map<std::string, at::Tensor> orig_dstate;
-  for (const auto & g : seg.givens)
-  {
-    auto vit = state.find(g.name);
-    _assert(vit != state.end(),
-            "aoti::Model substepping: implicit segment given '",
-            g.name,
-            "' is not in the state map.");
-    orig_val[g.name] = vit->second;
-    auto dit = dstate.find(g.name);
-    _assert(dit != dstate.end(),
-            "aoti::Model substepping: dstate missing given '",
-            g.name,
-            "' at Jacobian composition time.");
-    orig_dstate[g.name] = dit->second;
-  }
-
-  std::function<void(double,
-                     double,
-                     const std::map<std::string, at::Tensor> &,
-                     const std::map<std::string, at::Tensor> &,
-                     int)>
-      solve_span = [&](double a,
-                       double b,
-                       const std::map<std::string, at::Tensor> & chained_val,
-                       const std::map<std::string, at::Tensor> & chained_dstate,
-                       int level)
-  {
-    _apply_substep_span(seg, orig_val, a, b, chained_val, state);
-    _apply_substep_span(seg, orig_dstate, a, b, chained_dstate, dstate);
-    try
-    {
-      std::vector<at::Tensor> u_solved_groups;
-      std::vector<at::Tensor> g_groups;
-      _run_implicit_segment(seg, state, u_solved_groups, g_groups);
-      // Overwrites dstate[unknown] with Σ_g (-A⁻¹B)_{u,g} · dstate[g]. With
-      // dstate[old_state] carrying J_{k-1} and dstate[forces] the interpolated
-      // endpoint sensitivities, this is exactly A_k·J_{k-1} + B_k·frac_k·J_endpoint.
-      _run_implicit_segment_jacobian(seg, u_solved_groups, g_groups, dstate);
-      return;
-    }
-    catch (const ConvergenceError &)
-    {
-      if (level >= seg.max_substepping_level)
-        throw;
-    }
-    const double mid = 0.5 * (a + b);
-    solve_span(a, mid, chained_val, chained_dstate, level + 1);
-    // Chain BOTH the solved values and their sensitivities into the next half.
-    std::map<std::string, at::Tensor> chained_val_next;
-    std::map<std::string, at::Tensor> chained_dstate_next;
-    for (const auto & g : seg.givens)
-      if (g.role == "old_state")
-      {
-        chained_val_next[g.name] = state.at(g.pair);
-        chained_dstate_next[g.name] = dstate.at(g.pair);
-      }
-    solve_span(mid, b, chained_val_next, chained_dstate_next, level + 1);
-  };
-
-  std::map<std::string, at::Tensor> chained0_val;
-  std::map<std::string, at::Tensor> chained0_dstate;
-  for (const auto & g : seg.givens)
-    if (g.role == "old_state")
-    {
-      chained0_val[g.name] = orig_val.at(g.name);
-      chained0_dstate[g.name] = orig_dstate.at(g.name);
-    }
-
-  solve_span(0.0, 1.0, chained0_val, chained0_dstate, 0);
-}
-
 // ----------------------------------------------------------------------------
-// Per-element (masked) substepping
+// Per-element (masked) substepping -- the ONLY substepping path
 // ----------------------------------------------------------------------------
 // Solve only the still-unconverged subset of the dynamic batch at each sub-step,
 // freeze converged rows at their coarsest converging solution, and bisect only
 // the failing subset -- so a few hard elements no longer drag the whole batch
 // through the deep sub-steps. `a,b` stay scalar per span (uniform interval);
 // masking is purely *which rows are active*, so `_apply_substep_span` and the
-// coefficient math are reused unchanged. Requires a 1-D dynamic batch.
+// coefficient math are reused unchanged. Masking indexes dim 0, so the drivers
+// flatten the dynamic batch to a single leading axis (any rank -> 1-D; an
+// unbatched call -> a leading 1) before running and reshape the solved unknowns
+// back on return -- the compiled solve accepts any dynamic-batch rank, so this
+// is a pure reshape (see `flatten_dyn` / `unflatten_dyn`).
 
 namespace
 {
@@ -247,29 +115,63 @@ mask_to_idx(const at::Tensor & m)
   return at::nonzero(m).squeeze(-1);
 }
 
-} // namespace
-
-bool
-Model::Impl::_masking_ok(const Segment & seg, const std::map<std::string, at::Tensor> & state) const
+// Trailing (sub_batch + base) axis count of a segment given/unknown -- the axes
+// that sit behind the dynamic batch. Works for both `seg.givens` and
+// `seg.unknowns` (both carry `sub_batch_shape` + `base_shape`).
+template <typename VarT>
+int64_t
+var_trail(const VarT & v)
 {
-  if (seg.givens.empty())
-    return false;
-  auto it = state.find(seg.givens[0].name);
-  if (it == state.end())
-    return false;
-  const auto & g0 = it->second;
-  const auto & g0i = seg.givens[0];
-  const int64_t trail = static_cast<int64_t>(g0i.sub_batch_shape.size() + g0i.base_shape.size());
-  // Masking indexes dim 0; it is well-defined only when the dynamic batch is a
-  // single leading axis (the batch_chunk.h contract). Multi-axis dynamic batches
-  // fall back to the whole-batch driver.
-  return (g0.dim() - trail) == 1;
+  return static_cast<int64_t>(v.sub_batch_shape.size() + v.base_shape.size());
 }
+
+// Flatten the leading dynamic-batch axes of `t` (everything before its `trail`
+// trailing axes) into a single axis, so the masking driver's dim-0
+// index/scatter is well-defined for any dynamic-batch rank (0-D -> a leading 1).
+inline at::Tensor
+flatten_dyn(const at::Tensor & t, int64_t trail)
+{
+  std::vector<int64_t> shape;
+  shape.reserve(static_cast<std::size_t>(trail) + 1);
+  shape.push_back(-1);
+  for (int64_t d = t.dim() - trail; d < t.dim(); ++d)
+    shape.push_back(t.size(d));
+  return t.reshape(shape);
+}
+
+// Inverse of `flatten_dyn`: restore the dynamic batch `dyn` in front of the last
+// `trail` trailing axes of `t` (whose leading axis is the flattened batch).
+inline at::Tensor
+unflatten_dyn(const at::Tensor & t, const std::vector<int64_t> & dyn, int64_t trail)
+{
+  std::vector<int64_t> shape(dyn);
+  for (int64_t d = t.dim() - trail; d < t.dim(); ++d)
+    shape.push_back(t.size(d));
+  return t.reshape(shape);
+}
+
+} // namespace
 
 void
 Model::Impl::_run_implicit_segment_substepped_masked(
     const Segment & seg, std::map<std::string, at::Tensor> & state) const
 {
+  const bool capture = capture_solve_failure_enabled();
+
+  // Flatten the dynamic batch to a single leading axis (see the file-level note);
+  // restored / reshaped back on return. `dyn` is the original dynamic batch.
+  const int64_t g0_dyn_trail = var_trail(seg.givens[0]);
+  const auto & g0_orig = state.at(seg.givens[0].name);
+  const std::vector<int64_t> dyn(g0_orig.sizes().begin(), g0_orig.sizes().end() - g0_dyn_trail);
+  const bool reshape_needed = dyn.size() != 1;
+  std::map<std::string, at::Tensor> saved_givens;
+  if (reshape_needed)
+    for (const auto & g : seg.givens)
+    {
+      saved_givens[g.name] = state.at(g.name);
+      state[g.name] = flatten_dyn(saved_givens[g.name], var_trail(g));
+    }
+
   std::map<std::string, at::Tensor> orig;
   for (const auto & g : seg.givens)
     orig[g.name] = state.at(g.name);
@@ -301,6 +203,10 @@ Model::Impl::_run_implicit_segment_substepped_masked(
 
   const bool console_info = nlog::enabled(nlog::Channel::Substep, nlog::Level::Info);
   const bool console_debug = nlog::enabled(nlog::Channel::Substep, nlog::Level::Debug);
+  // Opt-in failure context (attached to the recoverable error if substepping
+  // ultimately fails): the level-0 single-shot mask + best-effort iterate.
+  at::Tensor cap_mask;
+  std::map<std::string, at::Tensor> cap_unknowns;
   int64_t n_solves = 0, max_depth = 0, n_substepped = 0;
   std::function<void(double, double, const at::Tensor &, int)> solve_to =
       [&](double a, double b, const at::Tensor & active, int level)
@@ -316,6 +222,15 @@ Model::Impl::_run_implicit_segment_substepped_masked(
     max_depth = std::max(max_depth, static_cast<int64_t>(level));
     if (level == 0)
       n_substepped = fail.numel(); // rows that failed the full step need substepping
+    if (capture && level == 0)
+    {
+      // Level 0 = the single-shot masked solve over the full increment (all rows
+      // active): its mask + best-effort iterate are the failure context, matching
+      // the non-substepped capture in solve.cpp.
+      cap_mask = mask;
+      for (const auto & u : seg.unknowns)
+        cap_unknowns[u.name] = span.at(u.name);
+    }
     // LCOV_EXCL_START -- diagnostic per-sub-span trace (verbosity-gated; see neml2.log)
     if (console_debug)
     {
@@ -345,13 +260,27 @@ Model::Impl::_run_implicit_segment_substepped_masked(
       // time-stepping consumer (e.g. MOOSE) cuts the outer step and retries -- so
       // it must throw the recoverable ConvergenceError, NOT `_assert` (which
       // throws the non-recoverable FatalError, defeating a `recoverable()` retry
-      // and making a maxed-out substep unrecoverable downstream). This mirrors the
-      // whole-batch drivers, which re-throw the caught ConvergenceError.
+      // and making a maxed-out substep unrecoverable downstream).
       if (level >= seg.max_substepping_level)
-        throw ConvergenceError("aoti::Model substepping: " + std::to_string(fail.numel()) +
-                               " element(s) failed to converge at max_substepping_level=" +
-                               std::to_string(seg.max_substepping_level) +
-                               ". Reduce the outer time step.");
+      {
+        const std::string msg = "aoti::Model substepping: " + std::to_string(fail.numel()) +
+                                " element(s) failed to converge at max_substepping_level=" +
+                                std::to_string(seg.max_substepping_level) +
+                                ". Reduce the outer time step.";
+        // Attach the level-0 (single-shot) failure context when capture is on,
+        // reshaped back to the original dynamic batch.
+        if (capture)
+        {
+          std::map<std::string, at::Tensor> stuck;
+          for (const auto & u : seg.unknowns)
+            stuck[u.name] = reshape_needed
+                                ? unflatten_dyn(cap_unknowns.at(u.name), dyn, var_trail(u))
+                                : cap_unknowns.at(u.name);
+          throw ConvergenceError(
+              msg, reshape_needed ? cap_mask.reshape(dyn) : cap_mask, std::move(stuck));
+        }
+        throw ConvergenceError(msg);
+      }
       auto fail_g = active.index_select(0, fail);
       const double mid = 0.5 * (a + b);
       solve_to(a, mid, fail_g, level + 1);
@@ -371,6 +300,16 @@ Model::Impl::_run_implicit_segment_substepped_masked(
   // LCOV_EXCL_STOP
   for (const auto & u : seg.unknowns)
     state[u.name] = result[u.name];
+
+  // Restore original-shape givens + reshape the solved unknowns back to the call
+  // batch (the driver ran on the flattened 1-D dynamic batch).
+  if (reshape_needed)
+  {
+    for (const auto & g : seg.givens)
+      state[g.name] = saved_givens[g.name];
+    for (const auto & u : seg.unknowns)
+      state[u.name] = unflatten_dyn(state.at(u.name), dyn, var_trail(u));
+  }
 }
 
 void
@@ -379,6 +318,26 @@ Model::Impl::_run_implicit_segment_substepped_masked_jacobian(
     std::map<std::string, at::Tensor> & state,
     std::map<std::string, at::Tensor> & dstate) const
 {
+  const bool capture = capture_solve_failure_enabled();
+
+  // Flatten the dynamic batch to a single leading axis (see the file-level note).
+  // A dstate block is (*dyn, folded, M) -- the pure dynamic batch (sub-batch
+  // stripped; see `_init_dstate`) plus exactly two trailing axes (folded storage,
+  // derivative width M) -- so its trail is 2, regardless of the primal given's.
+  const int64_t g0_dyn_trail = var_trail(seg.givens[0]);
+  const auto & g0_orig = state.at(seg.givens[0].name);
+  const std::vector<int64_t> dyn(g0_orig.sizes().begin(), g0_orig.sizes().end() - g0_dyn_trail);
+  const bool reshape_needed = dyn.size() != 1;
+  std::map<std::string, at::Tensor> saved_givens, saved_givens_d;
+  if (reshape_needed)
+    for (const auto & g : seg.givens)
+    {
+      saved_givens[g.name] = state.at(g.name);
+      saved_givens_d[g.name] = dstate.at(g.name);
+      state[g.name] = flatten_dyn(saved_givens[g.name], var_trail(g));
+      dstate[g.name] = flatten_dyn(saved_givens_d[g.name], /*trail=*/2);
+    }
+
   std::map<std::string, at::Tensor> orig, orig_d;
   for (const auto & g : seg.givens)
   {
@@ -422,6 +381,9 @@ Model::Impl::_run_implicit_segment_substepped_masked_jacobian(
 
   const bool console_info = nlog::enabled(nlog::Channel::Substep, nlog::Level::Info);
   const bool console_debug = nlog::enabled(nlog::Channel::Substep, nlog::Level::Debug);
+  // Opt-in failure context (level-0 single-shot mask + best-effort value iterate).
+  at::Tensor cap_mask;
+  std::map<std::string, at::Tensor> cap_unknowns;
   int64_t n_solves = 0, max_depth = 0, n_substepped = 0;
   std::function<void(double, double, const at::Tensor &, int)> solve_to =
       [&](double a, double b, const at::Tensor & active, int level)
@@ -440,6 +402,14 @@ Model::Impl::_run_implicit_segment_substepped_masked_jacobian(
     max_depth = std::max(max_depth, static_cast<int64_t>(level));
     if (level == 0)
       n_substepped = fail.numel();
+    if (capture && level == 0)
+    {
+      // Level 0 = the single-shot masked solve; its mask + best-effort value
+      // iterate are the failure context (same semantics as solve.cpp).
+      cap_mask = mask;
+      for (const auto & u : seg.unknowns)
+        cap_unknowns[u.name] = span.at(u.name);
+    }
     // LCOV_EXCL_START -- diagnostic per-sub-span trace (verbosity-gated; see neml2.log)
     if (console_debug)
     {
@@ -484,13 +454,27 @@ Model::Impl::_run_implicit_segment_substepped_masked_jacobian(
       // time-stepping consumer (e.g. MOOSE) cuts the outer step and retries -- so
       // it must throw the recoverable ConvergenceError, NOT `_assert` (which
       // throws the non-recoverable FatalError, defeating a `recoverable()` retry
-      // and making a maxed-out substep unrecoverable downstream). This mirrors the
-      // whole-batch drivers, which re-throw the caught ConvergenceError.
+      // and making a maxed-out substep unrecoverable downstream).
       if (level >= seg.max_substepping_level)
-        throw ConvergenceError("aoti::Model substepping: " + std::to_string(fail.numel()) +
-                               " element(s) failed to converge at max_substepping_level=" +
-                               std::to_string(seg.max_substepping_level) +
-                               ". Reduce the outer time step.");
+      {
+        const std::string msg = "aoti::Model substepping: " + std::to_string(fail.numel()) +
+                                " element(s) failed to converge at max_substepping_level=" +
+                                std::to_string(seg.max_substepping_level) +
+                                ". Reduce the outer time step.";
+        // Attach the level-0 (single-shot) failure context when capture is on,
+        // reshaped back to the original dynamic batch.
+        if (capture)
+        {
+          std::map<std::string, at::Tensor> stuck;
+          for (const auto & u : seg.unknowns)
+            stuck[u.name] = reshape_needed
+                                ? unflatten_dyn(cap_unknowns.at(u.name), dyn, var_trail(u))
+                                : cap_unknowns.at(u.name);
+          throw ConvergenceError(
+              msg, reshape_needed ? cap_mask.reshape(dyn) : cap_mask, std::move(stuck));
+        }
+        throw ConvergenceError(msg);
+      }
       auto fail_g = active.index_select(0, fail);
       const double mid = 0.5 * (a + b);
       solve_to(a, mid, fail_g, level + 1);
@@ -512,6 +496,22 @@ Model::Impl::_run_implicit_segment_substepped_masked_jacobian(
   {
     state[u.name] = result[u.name];
     dstate[u.name] = result_d[u.name];
+  }
+
+  // Restore original-shape givens (value + dstate) and reshape the solved
+  // unknowns + their tangents (*, var_size, M) back to the call batch.
+  if (reshape_needed)
+  {
+    for (const auto & g : seg.givens)
+    {
+      state[g.name] = saved_givens[g.name];
+      dstate[g.name] = saved_givens_d[g.name];
+    }
+    for (const auto & u : seg.unknowns)
+    {
+      state[u.name] = unflatten_dyn(state.at(u.name), dyn, var_trail(u));
+      dstate[u.name] = unflatten_dyn(dstate.at(u.name), dyn, /*trail=*/2);
+    }
   }
 }
 } // namespace neml2::aoti

--- a/neml2/models/common/ImplicitUpdate.py
+++ b/neml2/models/common/ImplicitUpdate.py
@@ -26,6 +26,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -46,6 +47,17 @@ if TYPE_CHECKING:
     from ...factory import _NativeInputFile
     from ...solvers import GMRES, BiCGStab
     from ...solvers.newton import _LinearSolver
+
+
+def _capture_solve_failure() -> bool:
+    """Whether to attach a *failure context* (per-element convergence mask +
+    best-effort iterate) to the ``ConvergenceError`` a failed solve raises, for
+    offline debugging. Opt-in via the ``NEML2_CAPTURE_SOLVE_FAILURE`` env var
+    (any non-empty value other than ``"0"``) because the capture costs an extra
+    masked re-solve. Same switch the compiled runtime reads in ``aoti/solve.cpp``
+    so both routes enrich the exception identically."""
+    v = os.environ.get("NEML2_CAPTURE_SOLVE_FAILURE")
+    return bool(v) and v != "0"
 
 
 def _var_offset(layout: AxisLayout, group_index: int, name: str) -> tuple[int, int]:
@@ -447,11 +459,45 @@ class ImplicitUpdate(Model):
     ) -> SparseVector:
         """Single-shot solve; raises the recoverable :class:`ConvergenceError`
         on non-convergence so an outer driver (substepping, or MOOSE's
-        time-stepper) can cut the increment and retry."""
+        time-stepper) can cut the increment and retry.
+
+        When failure capture is enabled (the ``NEML2_CAPTURE_SOLVE_FAILURE`` env
+        var), the raised error additionally carries a *failure context* for
+        offline debugging -- ``converged_mask`` (per-element bool) and
+        ``unknown`` (best-effort iterate per unknown variable) -- recovered by a
+        masked re-solve, mirroring the compiled runtime's capture in
+        ``aoti/solve.cpp``."""
         solution, ret = self._try_solve(state, sub_batch_ndim)
         if solution is None:
-            raise ConvergenceError(f"Nonlinear solve failed with status {ret.name}")
+            err = ConvergenceError(f"Nonlinear solve failed with status {ret.name}")
+            if _capture_solve_failure():
+                self._attach_failure_context(err)
+            raise err
         return solution
+
+    def _attach_failure_context(self, err: ConvergenceError) -> None:
+        """Best-effort: re-run the just-failed solve in masking mode (no throw)
+        to recover the per-element convergence mask + best-effort iterate, and
+        attach them to ``err`` as its ``converged_mask`` / ``unknown``
+        attributes. The system is still initialized from the failed
+        :meth:`_try_solve`, so this reuses it. A masked solve is only available
+        for direct linear solvers -- otherwise attach nothing and keep the bare
+        error."""
+        solve_masked = getattr(self.solver, "solve_masked", None)
+        if solve_masked is None:
+            return
+        try:
+            mask, _ = solve_masked(self.system)
+        except NotImplementedError:
+            return
+        err.converged_mask = mask
+        # Expose raw tensors keyed by unknown name -- uniform with the compiled
+        # route (aoti/solve.cpp), which has no typed wrappers, so an offline
+        # consumer reads e.unknown[name] as a plain torch.Tensor either way.
+        err.unknown = {
+            name: w.data  # data-ok: read-only failure-context export boundary
+            for name, w in dict(self.system.u().disassemble().values).items()
+        }
 
     def _output_sensitivities(self, v: ChainRuleDict) -> ChainRuleDict:
         A, B = self.system.A_and_B()

--- a/neml2/models/common/ImplicitUpdate.py
+++ b/neml2/models/common/ImplicitUpdate.py
@@ -49,15 +49,27 @@ if TYPE_CHECKING:
     from ...solvers.newton import _LinearSolver
 
 
+#: Falsy spellings of a boolean env var (case-insensitive, trimmed); anything
+#: else that is set counts as truthy. Mirrors the C++ parse in
+#: ``aoti/solve.cpp::capture_solve_failure_enabled`` so both routes agree.
+_FALSY_ENV = frozenset({"", "0", "false", "no", "off"})
+
+
+def _env_flag(name: str) -> bool:
+    """Truthy/falsy read of a boolean env var: unset / ``""`` / ``0`` / ``false``
+    / ``no`` / ``off`` (case-insensitive) are OFF, everything else is ON."""
+    v = os.environ.get(name)
+    return v is not None and v.strip().lower() not in _FALSY_ENV
+
+
 def _capture_solve_failure() -> bool:
     """Whether to attach a *failure context* (per-element convergence mask +
     best-effort iterate) to the ``ConvergenceError`` a failed solve raises, for
     offline debugging. Opt-in via the ``NEML2_CAPTURE_SOLVE_FAILURE`` env var
-    (any non-empty value other than ``"0"``) because the capture costs an extra
-    masked re-solve. Same switch the compiled runtime reads in ``aoti/solve.cpp``
-    so both routes enrich the exception identically."""
-    v = os.environ.get("NEML2_CAPTURE_SOLVE_FAILURE")
-    return bool(v) and v != "0"
+    (truthy/falsy) because the capture costs an extra masked re-solve. Same switch
+    the compiled runtime reads in ``aoti/solve.cpp`` so both routes enrich the
+    exception identically."""
+    return _env_flag("NEML2_CAPTURE_SOLVE_FAILURE")
 
 
 def _var_offset(layout: AxisLayout, group_index: int, name: str) -> tuple[int, int]:
@@ -464,7 +476,7 @@ class ImplicitUpdate(Model):
         When failure capture is enabled (the ``NEML2_CAPTURE_SOLVE_FAILURE`` env
         var), the raised error additionally carries a *failure context* for
         offline debugging -- ``converged_mask`` (per-element bool) and
-        ``unknown`` (best-effort iterate per unknown variable) -- recovered by a
+        ``unknowns`` (best-effort iterate per unknown variable) -- recovered by a
         masked re-solve, mirroring the compiled runtime's capture in
         ``aoti/solve.cpp``."""
         solution, ret = self._try_solve(state, sub_batch_ndim)
@@ -478,7 +490,7 @@ class ImplicitUpdate(Model):
     def _attach_failure_context(self, err: ConvergenceError) -> None:
         """Best-effort: re-run the just-failed solve in masking mode (no throw)
         to recover the per-element convergence mask + best-effort iterate, and
-        attach them to ``err`` as its ``converged_mask`` / ``unknown``
+        attach them to ``err`` as its ``converged_mask`` / ``unknowns``
         attributes. The system is still initialized from the failed
         :meth:`_try_solve`, so this reuses it. A masked solve is only available
         for direct linear solvers -- otherwise attach nothing and keep the bare
@@ -491,13 +503,12 @@ class ImplicitUpdate(Model):
         except NotImplementedError:
             return
         err.converged_mask = mask
-        # Expose raw tensors keyed by unknown name -- uniform with the compiled
-        # route (aoti/solve.cpp), which has no typed wrappers, so an offline
-        # consumer reads e.unknown[name] as a plain torch.Tensor either way.
-        err.unknown = {
-            name: w.data  # data-ok: read-only failure-context export boundary
-            for name, w in dict(self.system.u().disassemble().values).items()
-        }
+        # Expose the best-effort iterate as the TYPED wrapper per unknown name.
+        # This is a deliberate eager-mode enrichment over the compiled route
+        # (aoti/solve.cpp), which has no typed wrappers and can only surface a raw
+        # ``torch.Tensor``; both remain keyed by unknown name and both carry the
+        # dynamic-batch leading dim, so an offline consumer indexes them the same.
+        err.unknowns = dict(self.system.u().disassemble().values)
 
     def _output_sensitivities(self, v: ChainRuleDict) -> ChainRuleDict:
         A, B = self.system.A_and_B()

--- a/neml2/solvers/_exceptions.py
+++ b/neml2/solvers/_exceptions.py
@@ -49,10 +49,25 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import torch
+
     # For the type checker, present a stable RuntimeError subclass. At runtime it
     # is aliased to the C++-registered type (below) so identity is unified.
     class ConvergenceError(RuntimeError):
-        """Recoverable nonlinear-solve failure (Newton divergence / max-iters)."""
+        """Recoverable nonlinear-solve failure (Newton divergence / max-iters).
+
+        When failure capture is enabled (the ``NEML2_CAPTURE_SOLVE_FAILURE`` env
+        var) a raised instance additionally carries a *failure context* for
+        offline debugging -- absent otherwise, so read them defensively (e.g.
+        ``getattr(err, "converged_mask", None)``)."""
+
+        #: Per-dynamic-batch-element convergence mask (``True`` where the element
+        #: converged); attached only under failure capture.
+        converged_mask: torch.Tensor
+        #: Best-effort iterate at failure, keyed by unknown-variable name. py-eager
+        #: surfaces a typed wrapper (an eager-mode enrichment), cpp-aoti a raw
+        #: ``torch.Tensor``; attached only under failure capture.
+        unknowns: dict
 else:
     try:
         from neml2.aoti._aoti import ConvergenceError

--- a/neml2/solvers/newton.py
+++ b/neml2/solvers/newton.py
@@ -228,6 +228,59 @@ class Newton:
         ret = RetCode.SUCCESS if converged else RetCode.MAXITER
         return NonlinearResult(ret, iterations, log=tuple(log))
 
+    def solve_masked(self, system: ModelNonlinearSystem) -> tuple[torch.Tensor, int]:
+        """Diagnostic masked solve: run the shared ``Newton::solve_masked`` (which
+        never throws), commit the best-effort iterate into ``system``, and return
+        ``(converged_mask, iterations)``.
+
+        ``converged_mask`` is a raw per-dynamic-batch-element boolean tensor
+        (``True`` where the element converged) -- a diagnostic, not a physical
+        quantity, so it carries no typed wrapper. Used by the failure-capture path
+        (``NEML2_DUMP_SOLVE_FAILURE``) to record which entries diverged and the
+        iterate they got stuck at. Direct linear solvers only.
+        """
+        if getattr(self.linear_solver, "is_iterative", False):
+            raise NotImplementedError("solve_masked is only available for direct linear solvers")
+        from neml2.aoti._aoti import newton_solve_eager_masked  # noqa: PLC0415
+        from neml2.es.implicit import (  # noqa: PLC0415
+            RHS,
+            Jacobian,
+            LinearSolve,
+            _vector_to_per_group_raws,
+        )
+
+        rhs = RHS(system)
+        jacobian = Jacobian(system)
+        linear_solve = LinearSolve(system, self.linear_solver)
+        n_a = system.blayout.ngroup * system.ulayout.ngroup
+
+        with torch.no_grad():
+            g_raws = list(_vector_to_per_group_raws(system.g()))
+            u0_raws = list(_vector_to_per_group_raws(system.u()))
+
+            def residual_fn(u_raws: list[torch.Tensor]) -> list[torch.Tensor]:
+                return list(rhs(*u_raws, *g_raws))
+
+            def step_fn(
+                u_raws: list[torch.Tensor],
+            ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+                jac_out = jacobian(*u_raws, *g_raws)
+                du = linear_solve(*jac_out)
+                b = jac_out[n_a:]
+                return list(du), list(b)
+
+            u_star, converged_mask, iterations = newton_solve_eager_masked(
+                residual_fn=residual_fn,
+                step_fn=step_fn,
+                unknown_layout=_group_layout_descriptor(system.ulayout),
+                residual_layout=_group_layout_descriptor(system.blayout),
+                u0=u0_raws,
+                **self._solver_config(),
+            )
+            system.set_u_from_group_raws(u_star)
+
+        return converged_mask, int(iterations)
+
     def _solve_iterative(self, system: ModelNonlinearSystem) -> NonlinearResult:
         """Solve via the shared C++ Newton loop with a matrix-free Krylov step.
 

--- a/neml2/solvers/newton.py
+++ b/neml2/solvers/newton.py
@@ -236,7 +236,7 @@ class Newton:
         ``converged_mask`` is a raw per-dynamic-batch-element boolean tensor
         (``True`` where the element converged) -- a diagnostic, not a physical
         quantity, so it carries no typed wrapper. Used by the failure-capture path
-        (``NEML2_DUMP_SOLVE_FAILURE``) to record which entries diverged and the
+        (``NEML2_CAPTURE_SOLVE_FAILURE``) to record which entries diverged and the
         iterate they got stuck at. Direct linear solvers only.
         """
         if getattr(self.linear_solver, "is_iterative", False):

--- a/tests/aoti/test_solve_failure_capture.py
+++ b/tests/aoti/test_solve_failure_capture.py
@@ -64,7 +64,7 @@ _MIXED = {
 _B = 2
 
 
-def _model_i(max_substepping_level: int) -> str:
+def _model_i(max_substepping_level: int, linear_solver: str = "lu") -> str:
     """A minimal NONLINEAR scalar implicit (Perzyna cubic rate + backward Euler):
     ``r(x) = x - x~1 - (t - t~1) * (max(x,0))^3``. A small step converges
     single-shot; a huge step overshoots to a non-finite residual and cannot. The
@@ -110,10 +110,13 @@ def _model_i(max_substepping_level: int) -> str:
     abs_tol = 1e-10
     rel_tol = 1e-08
     max_its = 25
-    linear_solver = 'lu'
+    linear_solver = '{linear_solver}'
   []
   [lu]
     type = DenseLU
+  []
+  [gmres]
+    type = GMRES
   []
 []
 [Models]
@@ -132,9 +135,9 @@ def _model_i(max_substepping_level: int) -> str:
 """
 
 
-def _write_model(tmp: Path, max_substepping_level: int) -> Path:
-    src = tmp / f"model_L{max_substepping_level}.i"
-    src.write_text(_model_i(max_substepping_level))
+def _write_model(tmp: Path, max_substepping_level: int, linear_solver: str = "lu") -> Path:
+    src = tmp / f"model_L{max_substepping_level}_{linear_solver}.i"
+    src.write_text(_model_i(max_substepping_level, linear_solver))
     return src
 
 
@@ -153,18 +156,43 @@ def _py_eager_fail(src: Path) -> ConvergenceError:
     return ei.value
 
 
-def _cpp_aoti_fail(out: Path) -> ConvergenceError:
-    """Same mixed batch through a compiled model rooted at ``out``."""
+def _cpp_aoti_fail(out: Path, ins: dict[str, torch.Tensor] | None = None) -> ConvergenceError:
+    """Mixed batch through a compiled model's forward, rooted at ``out``."""
     aoti = AOTIModel(str(out))
     with pytest.raises(ConvergenceError) as ei:
-        aoti.forward(_mixed_tensors())
+        aoti.forward(_mixed_tensors() if ins is None else ins)
     return ei.value
+
+
+def _cpp_aoti_jacobian_fail(
+    out: Path, ins: dict[str, torch.Tensor] | None = None
+) -> ConvergenceError:
+    """Mixed batch through a compiled model's Jacobian, rooted at ``out``."""
+    aoti = AOTIModel(str(out))
+    with pytest.raises(ConvergenceError) as ei:
+        aoti.jacobian(_mixed_tensors() if ins is None else ins)
+    return ei.value
+
+
+def _mixed_2d_tensors() -> dict[str, torch.Tensor]:
+    """A multi-axis (2, 2) dynamic batch mixing easy + impossible columns, so the
+    driver flattens (2, 2) -> (4,), maxes out on the hard entries, and the capture
+    context is reshaped back to (2, 2)."""
+    row = {"x": [0.2, 0.2], "x~1": [0.2, 0.2], "t": [1.0, 1000.0], "t~1": [0.0, 0.0]}
+    return {k: torch.tensor([v, v], dtype=torch.float64) for k, v in row.items()}
 
 
 @pytest.fixture(scope="module")
 def eager_src(tmp_path_factory) -> Path:
     """The eager runtime rejects substepping, so this model caps it at 0."""
     return _write_model(tmp_path_factory.mktemp("eager"), 0)
+
+
+@pytest.fixture(scope="module")
+def eager_gmres_src(tmp_path_factory) -> Path:
+    """Same model with a matrix-free (GMRES) linear solver -- a masked re-solve is
+    only available for direct solvers, so capture degrades to a bare error here."""
+    return _write_model(tmp_path_factory.mktemp("eager_gmres"), 0, linear_solver="gmres")
 
 
 @pytest.fixture(scope="module")
@@ -180,26 +208,28 @@ def nonsubstep_artifact(tmp_path_factory) -> Path:
 @pytest.fixture(scope="module")
 def substep_artifact(tmp_path_factory) -> Path:
     """Compiled model with substepping ON but capped low, so the hard row maxes
-    out substepping and raises -- exercising the masked-substep capture path."""
+    out substepping and raises -- exercising the masked-substep capture path.
+    Exported with a derivative pair so both the value AND the substepped-Jacobian
+    capture paths are reachable from this one artifact."""
     tmp = tmp_path_factory.mktemp("nl_substep")
     out = tmp / "nl"
-    export_model_for_aoti(_write_model(tmp, 1), "model", out)
+    export_model_for_aoti(_write_model(tmp, 1), "model", out, derivatives=["x:t"])
     return out
 
 
-def _assert_mixed_enriched(err, *, typed: bool) -> None:
+def _assert_mixed_enriched(err, *, typed: bool, shape: tuple[int, ...] = (_B,)) -> None:
     """The error carries a genuinely *mixed* per-element convergence mask and the
-    best-effort iterate keyed by unknown name. ``typed`` selects the py-eager
-    (typed wrapper) vs cpp-aoti (raw tensor) surface."""
+    best-effort iterate keyed by unknown name, at the original dynamic-batch
+    ``shape``. ``typed`` selects the py-eager (typed wrapper) vs cpp-aoti (raw
+    tensor) surface."""
     mask = getattr(err, "converged_mask", None)
     assert mask is not None, "converged_mask not attached"
     assert mask.dtype == torch.bool
-    assert tuple(mask.shape) == (_B,)
-    # The isolation the feature exists for: some rows converged, some did not --
-    # NOT a trivially all-False mask. The impossible row (index 1) is unconverged.
-    assert mask.any(), "expected the easy row to have converged"
-    assert not mask.all(), "expected the hard row to be unconverged"
-    assert not bool(mask[1]), "the impossible row must be reported unconverged"
+    assert tuple(mask.shape) == shape
+    # The isolation the feature exists for: some elements converged, some did not
+    # -- NOT a trivially all-False mask (and not all-True either).
+    assert mask.any(), "expected at least one element to have converged"
+    assert not mask.all(), "expected at least one element to be unconverged"
 
     unknowns = getattr(err, "unknowns", None)
     assert unknowns is not None, "unknowns not attached"
@@ -207,14 +237,14 @@ def _assert_mixed_enriched(err, *, typed: bool) -> None:
     w = unknowns["x"]
     if typed:
         # py-eager enrichment: a typed wrapper (NOT a raw torch.Tensor), whose
-        # underlying data carries the dynamic-batch leading dim.
+        # underlying data carries the dynamic-batch shape.
         assert not isinstance(w, torch.Tensor)
         assert isinstance(w.data, torch.Tensor)
-        assert tuple(w.data.shape) == (_B,)
+        assert tuple(w.data.shape) == shape
     else:
         # cpp-aoti: a plain torch.Tensor at the boundary (no typed wrappers).
         assert isinstance(w, torch.Tensor)
-        assert tuple(w.shape) == (_B,)
+        assert tuple(w.shape) == shape
 
 
 # --- capture enriches the error, per route ---------------------------------
@@ -236,6 +266,33 @@ def test_cpp_aoti_substep_capture_enriches_error(monkeypatch, substep_artifact):
     reports -- so a substepping-compiled model is diagnosable too."""
     monkeypatch.setenv(_ENV, "1")
     _assert_mixed_enriched(_cpp_aoti_fail(substep_artifact), typed=False)
+
+
+def test_cpp_aoti_substep_jacobian_capture_enriches_error(monkeypatch, substep_artifact):
+    """The substepped-Jacobian driver, when it maxes out, attaches the same
+    level-0 failure context as the value path -- so a failed consistent-tangent
+    evaluation is diagnosable too, not just a failed forward."""
+    monkeypatch.setenv(_ENV, "1")
+    _assert_mixed_enriched(_cpp_aoti_jacobian_fail(substep_artifact), typed=False)
+
+
+def test_cpp_aoti_substep_multiaxis_capture_enriches_error(monkeypatch, substep_artifact):
+    """A multi-axis (2, 2) dynamic batch is flattened to 1-D inside the masked
+    driver; on max-out the captured mask + iterate are reshaped back to (2, 2), so
+    the failure context matches the caller's batch shape."""
+    monkeypatch.setenv(_ENV, "1")
+    err = _cpp_aoti_fail(substep_artifact, _mixed_2d_tensors())
+    _assert_mixed_enriched(err, typed=False, shape=(2, 2))
+
+
+def test_py_eager_iterative_solver_skips_capture(monkeypatch, eager_gmres_src):
+    """Capture needs a masked re-solve, which only direct linear solvers support;
+    with a matrix-free (GMRES) solver the masked path raises NotImplementedError,
+    so capture is skipped and the error stays bare -- even with capture enabled."""
+    monkeypatch.setenv(_ENV, "1")
+    err = _py_eager_fail(eager_gmres_src)
+    assert not hasattr(err, "converged_mask")
+    assert not hasattr(err, "unknowns")
 
 
 # --- opt-out leaves the error bare (byte-for-byte legacy behavior) ----------

--- a/tests/aoti/test_solve_failure_capture.py
+++ b/tests/aoti/test_solve_failure_capture.py
@@ -25,11 +25,18 @@
 """NEML2_CAPTURE_SOLVE_FAILURE: the recoverable ConvergenceError optionally
 carries a *failure context* for offline debugging -- a per-element convergence
 mask and the best-effort iterate per unknown variable. The capture is opt-in
-(the env var) and identical across the two routes an offline replay can load:
-the pure-Python (py-eager) model and the compiled (cpp-aoti) model. A downstream
-host (e.g. MOOSE) dumps the failing *inputs*; the user reloads them here, re-runs
-the model, and reads the stuck state straight off the exception -- see
-framework/doc/content/source/neml2/actions/NEML2Action.md.
+(the env var) and available on every route an offline replay can load: the
+pure-Python (py-eager) model, the compiled non-substepping (cpp-aoti) model, and
+the compiled substepping (cpp-aoti) model. A downstream host (e.g. MOOSE) dumps
+the failing *inputs*; the user reloads them here, re-runs the model, and reads
+the stuck state straight off the exception.
+
+The scenario is a *mixed* batch -- one row that converges and one that cannot --
+so the mask is genuinely per-element (the isolation the feature exists for), not
+a trivially all-False mask. Across routes the payload is the same information
+keyed by unknown name; the ONE deliberate difference is that py-eager surfaces
+the iterate as a TYPED wrapper (an eager-mode enrichment) while cpp-aoti, which
+has no typed wrappers at its boundary, surfaces a raw ``torch.Tensor``.
 """
 
 from __future__ import annotations
@@ -44,84 +51,233 @@ from neml2.aoti import ConvergenceError
 from neml2.aoti import Model as AOTIModel
 from neml2.cli.aoti_export import export_model_for_aoti
 
-_REPO = Path(__file__).resolve().parents[2]
-# Minimal single-unknown ImplicitUpdate (scalar backward-Euler); miters=0 against
-# a non-zero initial residual is a guaranteed, immediate non-convergence.
-_IMPLICIT = _REPO / "tests" / "aoti" / "implicit_simple" / "model.i"
 _ENV = "NEML2_CAPTURE_SOLVE_FAILURE"
-_B = 4
+
+# Row 0 easy (converges single-shot), row 1 impossible (a step so large it cannot
+# converge single-shot, nor even at a low substepping cap).
+_MIXED = {
+    "x": [0.2, 0.2],
+    "x~1": [0.2, 0.2],
+    "t": [1.0, 1000.0],
+    "t~1": [0.0, 0.0],
+}
+_B = 2
 
 
-def _py_eager_fail():
-    """Drive the pure-Python model into a guaranteed non-convergence (miters=0)
-    and return the raised ConvergenceError."""
-    torch.manual_seed(0)
-    m = neml2.load_model(str(_IMPLICIT), "model").to(torch.float64)
-    m.solver.miters = 0
-    args = tuple(m.input_spec[n](torch.rand(_B, dtype=torch.float64)) for n in m.input_spec)
+def _model_i(max_substepping_level: int) -> str:
+    """A minimal NONLINEAR scalar implicit (Perzyna cubic rate + backward Euler):
+    ``r(x) = x - x~1 - (t - t~1) * (max(x,0))^3``. A small step converges
+    single-shot; a huge step overshoots to a non-finite residual and cannot. The
+    substepping cap is parameterized so the same physics drives the eager (must be
+    0 -- the eager runtime rejects substepping), non-substepping compiled (0), and
+    substepping compiled (>0) routes.
+
+    A ``ConstantExtrapolationPredictor`` warm-starts ``x`` from ``x~1``: the masked
+    substep driver's per-span state carries only the givens, so without a
+    predictor an unknown would seed to zero on the substepping route (and the easy
+    row would then fail single-shot), whereas the eager / non-substepping routes
+    warm-start from the input ``x`` -- the predictor makes the seed uniform."""
+    return f"""
+[Models]
+  [rate]
+    type = PerzynaPlasticFlowRate
+    yield_function = 'x'
+    flow_rate = 'x_rate'
+    reference_stress = 1.0
+    exponent = 3
+  []
+  [integrate]
+    type = ScalarBackwardEulerTimeIntegration
+    variable = 'x'
+    time = 't'
+  []
+  [residual_model]
+    type = ComposedModel
+    models = 'rate integrate'
+  []
+[]
+[EquationSystems]
+  [eq_sys]
+    type = NonlinearSystem
+    model = 'residual_model'
+    unknowns = 'x'
+    residuals = 'x_residual'
+  []
+[]
+[Solvers]
+  [newton]
+    type = Newton
+    abs_tol = 1e-10
+    rel_tol = 1e-08
+    max_its = 25
+    linear_solver = 'lu'
+  []
+  [lu]
+    type = DenseLU
+  []
+[]
+[Models]
+  [predictor]
+    type = ConstantExtrapolationPredictor
+    unknowns_Scalar = 'x'
+  []
+  [model]
+    type = ImplicitUpdate
+    equation_system = 'eq_sys'
+    solver = 'newton'
+    predictor = 'predictor'
+    max_substepping_level = {max_substepping_level}
+  []
+[]
+"""
+
+
+def _write_model(tmp: Path, max_substepping_level: int) -> Path:
+    src = tmp / f"model_L{max_substepping_level}.i"
+    src.write_text(_model_i(max_substepping_level))
+    return src
+
+
+def _mixed_tensors() -> dict[str, torch.Tensor]:
+    return {k: torch.tensor(v, dtype=torch.float64) for k, v in _MIXED.items()}
+
+
+def _py_eager_fail(src: Path) -> ConvergenceError:
+    """Drive the pure-Python model on the mixed batch into a (whole-batch)
+    non-convergence and return the raised ConvergenceError."""
+    m = neml2.load_model(str(src), "model").to(torch.float64)
+    ins = _mixed_tensors()
+    args = tuple(m.input_spec[n](ins[n]) for n in m.input_spec)
     with pytest.raises(ConvergenceError) as ei:
         m(*args)
     return ei.value
 
 
-def _cpp_aoti_fail(tmp_path: Path):
-    """Same, through the compiled runtime: compile the model, override the baked
-    solver config to miters=0, and drive it to non-convergence."""
-    torch.manual_seed(0)
-    py = neml2.load_model(str(_IMPLICIT), "model").to(torch.float64)
-    names = list(py.input_spec)
-    out = tmp_path / "impl"
-    export_model_for_aoti(str(_IMPLICIT), "model", str(out))
+def _cpp_aoti_fail(out: Path) -> ConvergenceError:
+    """Same mixed batch through a compiled model rooted at ``out``."""
     aoti = AOTIModel(str(out))
-    aoti.set_solver_config(1e-10, 1e-8, 0, "none", 0, 0.5, 1e-4)  # miters=0
-    ins = {n: torch.rand(_B, dtype=torch.float64) for n in names}
     with pytest.raises(ConvergenceError) as ei:
-        aoti.forward(ins)
+        aoti.forward(_mixed_tensors())
     return ei.value
 
 
-def _assert_enriched(err):
+@pytest.fixture(scope="module")
+def eager_src(tmp_path_factory) -> Path:
+    """The eager runtime rejects substepping, so this model caps it at 0."""
+    return _write_model(tmp_path_factory.mktemp("eager"), 0)
+
+
+@pytest.fixture(scope="module")
+def nonsubstep_artifact(tmp_path_factory) -> Path:
+    """Compiled model with substepping OFF: the hard row fails the single-shot
+    solve, exercising the ``_run_implicit_segment`` capture path."""
+    tmp = tmp_path_factory.mktemp("nl_nonsubstep")
+    out = tmp / "nl"
+    export_model_for_aoti(_write_model(tmp, 0), "model", out)
+    return out
+
+
+@pytest.fixture(scope="module")
+def substep_artifact(tmp_path_factory) -> Path:
+    """Compiled model with substepping ON but capped low, so the hard row maxes
+    out substepping and raises -- exercising the masked-substep capture path."""
+    tmp = tmp_path_factory.mktemp("nl_substep")
+    out = tmp / "nl"
+    export_model_for_aoti(_write_model(tmp, 1), "model", out)
+    return out
+
+
+def _assert_mixed_enriched(err, *, typed: bool) -> None:
+    """The error carries a genuinely *mixed* per-element convergence mask and the
+    best-effort iterate keyed by unknown name. ``typed`` selects the py-eager
+    (typed wrapper) vs cpp-aoti (raw tensor) surface."""
     mask = getattr(err, "converged_mask", None)
     assert mask is not None, "converged_mask not attached"
     assert mask.dtype == torch.bool
     assert tuple(mask.shape) == (_B,)
-    # miters=0 -> nothing converged.
-    assert not mask.any()
-    unknown = getattr(err, "unknown", None)
-    assert unknown is not None, "unknown not attached"
-    assert set(unknown) == {"x"}  # the single unknown of the implicit_simple model
-    # Best-effort iterate: a plain torch.Tensor (uniform across routes) with the
-    # dynamic-batch leading dim.
-    assert isinstance(unknown["x"], torch.Tensor)
-    assert tuple(unknown["x"].shape) == (_B,)
+    # The isolation the feature exists for: some rows converged, some did not --
+    # NOT a trivially all-False mask. The impossible row (index 1) is unconverged.
+    assert mask.any(), "expected the easy row to have converged"
+    assert not mask.all(), "expected the hard row to be unconverged"
+    assert not bool(mask[1]), "the impossible row must be reported unconverged"
+
+    unknowns = getattr(err, "unknowns", None)
+    assert unknowns is not None, "unknowns not attached"
+    assert set(unknowns) == {"x"}, "the single unknown of the implicit model"
+    w = unknowns["x"]
+    if typed:
+        # py-eager enrichment: a typed wrapper (NOT a raw torch.Tensor), whose
+        # underlying data carries the dynamic-batch leading dim.
+        assert not isinstance(w, torch.Tensor)
+        assert isinstance(w.data, torch.Tensor)
+        assert tuple(w.data.shape) == (_B,)
+    else:
+        # cpp-aoti: a plain torch.Tensor at the boundary (no typed wrappers).
+        assert isinstance(w, torch.Tensor)
+        assert tuple(w.shape) == (_B,)
 
 
-def test_py_eager_capture_enriches_error(monkeypatch):
+# --- capture enriches the error, per route ---------------------------------
+
+
+def test_py_eager_capture_enriches_error(monkeypatch, eager_src):
     monkeypatch.setenv(_ENV, "1")
-    _assert_enriched(_py_eager_fail())
+    _assert_mixed_enriched(_py_eager_fail(eager_src), typed=True)
 
 
-def test_cpp_aoti_capture_enriches_error(monkeypatch, tmp_path):
+def test_cpp_aoti_nonsubstep_capture_enriches_error(monkeypatch, nonsubstep_artifact):
     monkeypatch.setenv(_ENV, "1")
-    _assert_enriched(_cpp_aoti_fail(tmp_path))
+    _assert_mixed_enriched(_cpp_aoti_fail(nonsubstep_artifact), typed=False)
 
 
-def test_py_eager_opt_out_leaves_error_bare(monkeypatch):
+def test_cpp_aoti_substep_capture_enriches_error(monkeypatch, substep_artifact):
+    """The masked substepping driver, when it maxes out, attaches the level-0
+    (single-shot) failure context -- the same information the non-substepping path
+    reports -- so a substepping-compiled model is diagnosable too."""
+    monkeypatch.setenv(_ENV, "1")
+    _assert_mixed_enriched(_cpp_aoti_fail(substep_artifact), typed=False)
+
+
+# --- opt-out leaves the error bare (byte-for-byte legacy behavior) ----------
+
+
+def test_py_eager_opt_out_leaves_error_bare(monkeypatch, eager_src):
     monkeypatch.delenv(_ENV, raising=False)
-    err = _py_eager_fail()
+    err = _py_eager_fail(eager_src)
     assert not hasattr(err, "converged_mask")
-    assert not hasattr(err, "unknown")
+    assert not hasattr(err, "unknowns")
     assert isinstance(err, RuntimeError)  # unchanged: still a recoverable RuntimeError
 
 
-def test_cpp_aoti_opt_out_leaves_error_bare(monkeypatch, tmp_path):
+def test_cpp_aoti_nonsubstep_opt_out_leaves_error_bare(monkeypatch, nonsubstep_artifact):
     monkeypatch.delenv(_ENV, raising=False)
-    err = _cpp_aoti_fail(tmp_path)
+    err = _cpp_aoti_fail(nonsubstep_artifact)
     assert not hasattr(err, "converged_mask")
-    assert not hasattr(err, "unknown")
+    assert not hasattr(err, "unknowns")
 
 
-def test_capture_disabled_by_zero(monkeypatch):
-    monkeypatch.setenv(_ENV, "0")  # explicit "0" is off
-    err = _py_eager_fail()
+def test_cpp_aoti_substep_opt_out_leaves_error_bare(monkeypatch, substep_artifact):
+    monkeypatch.delenv(_ENV, raising=False)
+    err = _cpp_aoti_fail(substep_artifact)
     assert not hasattr(err, "converged_mask")
+    assert not hasattr(err, "unknowns")
+
+
+# --- truthy / falsy env parsing (consistent C++ and Python) -----------------
+
+
+@pytest.mark.parametrize("val", ["0", "false", "off", "no", "  ", "  OFF  "])
+def test_capture_falsy_values_disable(monkeypatch, eager_src, val):
+    """Unset / "" / 0 / false / no / off (case-insensitive, trimmed) are OFF."""
+    monkeypatch.setenv(_ENV, val)
+    err = _py_eager_fail(eager_src)
+    assert not hasattr(err, "converged_mask")
+    assert not hasattr(err, "unknowns")
+
+
+@pytest.mark.parametrize("val", ["1", "true", "on", "yes", "  On  ", "anything"])
+def test_capture_truthy_values_enable(monkeypatch, eager_src, val):
+    """Any other set value (incl. 1 / true / yes / on) is ON."""
+    monkeypatch.setenv(_ENV, val)
+    err = _py_eager_fail(eager_src)
+    assert getattr(err, "converged_mask", None) is not None

--- a/tests/aoti/test_solve_failure_capture.py
+++ b/tests/aoti/test_solve_failure_capture.py
@@ -1,0 +1,127 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""NEML2_CAPTURE_SOLVE_FAILURE: the recoverable ConvergenceError optionally
+carries a *failure context* for offline debugging -- a per-element convergence
+mask and the best-effort iterate per unknown variable. The capture is opt-in
+(the env var) and identical across the two routes an offline replay can load:
+the pure-Python (py-eager) model and the compiled (cpp-aoti) model. A downstream
+host (e.g. MOOSE) dumps the failing *inputs*; the user reloads them here, re-runs
+the model, and reads the stuck state straight off the exception -- see
+framework/doc/content/source/neml2/actions/NEML2Action.md.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+import neml2
+from neml2.aoti import ConvergenceError
+from neml2.aoti import Model as AOTIModel
+from neml2.cli.aoti_export import export_model_for_aoti
+
+_REPO = Path(__file__).resolve().parents[2]
+# Minimal single-unknown ImplicitUpdate (scalar backward-Euler); miters=0 against
+# a non-zero initial residual is a guaranteed, immediate non-convergence.
+_IMPLICIT = _REPO / "tests" / "aoti" / "implicit_simple" / "model.i"
+_ENV = "NEML2_CAPTURE_SOLVE_FAILURE"
+_B = 4
+
+
+def _py_eager_fail():
+    """Drive the pure-Python model into a guaranteed non-convergence (miters=0)
+    and return the raised ConvergenceError."""
+    torch.manual_seed(0)
+    m = neml2.load_model(str(_IMPLICIT), "model").to(torch.float64)
+    m.solver.miters = 0
+    args = tuple(m.input_spec[n](torch.rand(_B, dtype=torch.float64)) for n in m.input_spec)
+    with pytest.raises(ConvergenceError) as ei:
+        m(*args)
+    return ei.value
+
+
+def _cpp_aoti_fail(tmp_path: Path):
+    """Same, through the compiled runtime: compile the model, override the baked
+    solver config to miters=0, and drive it to non-convergence."""
+    torch.manual_seed(0)
+    py = neml2.load_model(str(_IMPLICIT), "model").to(torch.float64)
+    names = list(py.input_spec)
+    out = tmp_path / "impl"
+    export_model_for_aoti(str(_IMPLICIT), "model", str(out))
+    aoti = AOTIModel(str(out))
+    aoti.set_solver_config(1e-10, 1e-8, 0, "none", 0, 0.5, 1e-4)  # miters=0
+    ins = {n: torch.rand(_B, dtype=torch.float64) for n in names}
+    with pytest.raises(ConvergenceError) as ei:
+        aoti.forward(ins)
+    return ei.value
+
+
+def _assert_enriched(err):
+    mask = getattr(err, "converged_mask", None)
+    assert mask is not None, "converged_mask not attached"
+    assert mask.dtype == torch.bool
+    assert tuple(mask.shape) == (_B,)
+    # miters=0 -> nothing converged.
+    assert not mask.any()
+    unknown = getattr(err, "unknown", None)
+    assert unknown is not None, "unknown not attached"
+    assert set(unknown) == {"x"}  # the single unknown of the implicit_simple model
+    # Best-effort iterate: a plain torch.Tensor (uniform across routes) with the
+    # dynamic-batch leading dim.
+    assert isinstance(unknown["x"], torch.Tensor)
+    assert tuple(unknown["x"].shape) == (_B,)
+
+
+def test_py_eager_capture_enriches_error(monkeypatch):
+    monkeypatch.setenv(_ENV, "1")
+    _assert_enriched(_py_eager_fail())
+
+
+def test_cpp_aoti_capture_enriches_error(monkeypatch, tmp_path):
+    monkeypatch.setenv(_ENV, "1")
+    _assert_enriched(_cpp_aoti_fail(tmp_path))
+
+
+def test_py_eager_opt_out_leaves_error_bare(monkeypatch):
+    monkeypatch.delenv(_ENV, raising=False)
+    err = _py_eager_fail()
+    assert not hasattr(err, "converged_mask")
+    assert not hasattr(err, "unknown")
+    assert isinstance(err, RuntimeError)  # unchanged: still a recoverable RuntimeError
+
+
+def test_cpp_aoti_opt_out_leaves_error_bare(monkeypatch, tmp_path):
+    monkeypatch.delenv(_ENV, raising=False)
+    err = _cpp_aoti_fail(tmp_path)
+    assert not hasattr(err, "converged_mask")
+    assert not hasattr(err, "unknown")
+
+
+def test_capture_disabled_by_zero(monkeypatch):
+    monkeypatch.setenv(_ENV, "0")  # explicit "0" is off
+    err = _py_eager_fail()
+    assert not hasattr(err, "converged_mask")

--- a/tests/aoti/test_substep.py
+++ b/tests/aoti/test_substep.py
@@ -26,7 +26,7 @@
 
 These exercise the host-side substep driver through the compiled runtime end to
 end: the Python role classification is serialized into the shared ``metadata.json``,
-the C++ ``Model`` parses it, and ``_run_implicit_segment_substepped``
+the C++ ``Model`` parses it, and ``_run_implicit_segment_substepped_masked``
 dispatches per the roles. The scenario integration is linear-in-time, so the
 substepped answer equals the single-shot answer -- the "no-op equivalence" that
 validates the interpolation / chaining machinery. Genuine convergence-recovery
@@ -459,10 +459,10 @@ def test_substep_trace_logs(tmp_path: Path, capfd):
 
 
 def test_multiaxis_batch_substepping_forward(tmp_path: Path):
-    """A multi-axis (non-1-D) dynamic batch cannot use per-element masking (that
-    requires a single leading batch axis), so it takes the whole-batch
-    ``_run_implicit_segment_substepped`` driver. On a hard step it bisects and
-    recovers the same finite solution the 1-D masked path reaches."""
+    """A multi-axis (non-1-D) dynamic batch is flattened to a single leading axis
+    inside the masked substep driver (masking indexes dim 0), substepped, and
+    reshaped back -- so it recovers the same finite solution the 1-D path reaches
+    on a hard step, at its original (2, 2) shape."""
     from neml2.aoti import Model as AOTIModel
     from neml2.cli.aoti_export import export_model_for_aoti
 
@@ -484,12 +484,13 @@ def test_multiaxis_batch_substepping_forward(tmp_path: Path):
     assert torch.allclose(out2d, out1d.expand_as(out2d), rtol=1e-8, atol=1e-8)
 
 
-def test_multiaxis_batch_substepped_jacobian_not_implemented(tmp_path: Path):
-    """The whole-batch substepped Jacobian enters the non-masked driver and runs
-    the substepped forward, but the underlying per-block (sub-batch) IFT Jacobian
-    is not implemented -- so a multi-axis batch Jacobian raises a clear error
-    rather than returning a wrong tangent. Pins that contract (and the driver's
-    forward-then-compose entry path)."""
+def test_multiaxis_batch_substepped_jacobian(tmp_path: Path):
+    """A multi-axis (non-1-D) dynamic batch Jacobian is flattened to 1-D inside
+    the masked substepped-Jacobian driver, composed, and reshaped back -- so it
+    returns the correct consistent tangent at its original (2, 2) shape, matching
+    the same hard step solved through the 1-D path. (Previously the multi-axis
+    Jacobian took the removed non-masked driver and raised 'not implemented'; the
+    unified masked+flatten path now handles it.)"""
     from neml2.aoti import Model as AOTIModel
     from neml2.cli.aoti_export import export_model_for_aoti
 
@@ -501,8 +502,18 @@ def test_multiaxis_batch_substepped_jacobian_not_implemented(tmp_path: Path):
         return torch.full((2, 2), v, dtype=torch.float64)
 
     ins2d = {"x": mk(0.2), "x~1": mk(0.2), "t": mk(8.0), "t~1": mk(0.0)}
-    with pytest.raises(RuntimeError, match="not yet implemented|BLOCK"):
-        aoti.jacobian(ins2d)
+    out2d, jac2d = aoti.jacobian(ins2d)
+    assert out2d["x"].shape == (2, 2)
+    assert torch.isfinite(jac2d["x"]["t"]).all()
+
+    # Same hard step through the 1-D path -> identical value + tangent per element
+    # (every (2, 2) entry saw the identical increment, so each equals the 1-D one).
+    ins1d = {k: v.reshape(-1)[:1] for k, v in ins2d.items()}
+    out1d, jac1d = aoti.jacobian(ins1d)
+    assert torch.allclose(out2d["x"], out1d["x"].expand_as(out2d["x"]), rtol=1e-8, atol=1e-8)
+    assert torch.allclose(
+        jac2d["x"]["t"], jac1d["x"]["t"].expand_as(jac2d["x"]["t"]), rtol=1e-8, atol=1e-8
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -740,10 +751,10 @@ def test_substep_ramp_role_and_phantom(tmp_path: Path):
 
 
 def test_multiaxis_substep_maxout_raises_recoverable(tmp_path: Path):
-    """A multi-axis (non-masked) batch on a step too hard to rescue even at the
-    depth cap makes the whole-batch substep driver throw a **recoverable**
-    ConvergenceError at ``max_substepping_level`` (so a host can cut the outer
-    step and retry) -- the non-masked counterpart of the masked max-out path."""
+    """A multi-axis batch on a step too hard to rescue even at the depth cap makes
+    the (flatten-to-1-D) masked substep driver throw a **recoverable**
+    ConvergenceError at ``max_substepping_level`` (so a host can cut the outer step
+    and retry) -- the multi-axis counterpart of the 1-D masked max-out path."""
     from neml2.aoti import Model as AOTIModel
     from neml2.cli.aoti_export import export_model_for_aoti
 


### PR DESCRIPTION
## Summary

Optionally attach a **failure context** to the recoverable `ConvergenceError` a failed implicit solve raises, so a non-converged constitutive update can be diagnosed offline with near-zero boilerplate:

- `e.converged_mask` — per-dynamic-batch-element `bool` tensor (`True` where that entry converged).
- `e.unknown` — `{unknown-variable name -> best-effort iterate}`, i.e. the state the Newton solve got stuck at. Plain `torch.Tensor` values, **uniform across routes**.

Opt-in via the `NEML2_CAPTURE_SOLVE_FAILURE` env var (any non-empty value other than `"0"`), read live on each failure. Off by default because the capture costs an extra masked re-solve; when off, behavior is byte-for-byte unchanged.

## Motivation

A downstream host (e.g. MOOSE) can already dump the failing constitutive-update *inputs*. Reloading those inputs and re-running the model reproduces the failure, but isolating *which* batch entries (quadrature points) diverged, and reading the stuck state, previously meant a per-entry re-solve loop plus manual residual assembly. With this change the isolation is a single `(~e.converged_mask).nonzero()` and the stuck state is right there on the exception — identical whether the offline user loads a compiled (cpp-aoti) or a Python (py-eager) model.

## What changed

**cpp-aoti** — `aoti/solve.cpp` catches the bare Newton throw and, when enabled, re-runs the existing `_run_implicit_segment_masked` to recover the mask + best-effort iterate, then re-throws a `ConvergenceError` enriched with new `at::Tensor` / `std::map<std::string, at::Tensor>` members (`Exception.{h,cpp}`). A custom pybind exception translator in `_aoti.cpp` surfaces those members as Python attributes. Adds a `newton_solve_eager_masked` binding + `run_eager_newton_masked` runner.

**py-eager** — `ImplicitUpdate._solve` attaches the same context via the new `Newton.solve_masked`, keyed by name from `system.u().disassemble()`.

## Backward compatibility

- The message-only `ConvergenceError` constructor and `recoverable()` are unchanged — existing `except ConvergenceError` and the recoverable-vs-fatal split are unaffected.
- No metadata schema change; existing compiled `.pt2` artifacts remain valid.
- The capture is not carried across the C++-driven cpp-eager boundary (`eager/Model.cpp` reconstructs a bare error from `what()`); the offline-replay routes above are unaffected.

## Testing

`tests/aoti/test_solve_failure_capture.py` — both routes (py-eager + cpp-aoti) enrich the exception when enabled; the exception stays bare when the env var is unset or `"0"`. Existing exception tests (`test_eager`, `test_substep`) pass unchanged.