### PR TITLE
Fix eager call_batch_shape to strip parameter sub-batch axes

### DIFF
--- a/neml2/models/param_ad.py
+++ b/neml2/models/param_ad.py
@@ -110,7 +110,17 @@ def call_batch_shape(
     for q in param_names:
         base = tuple(param_base_shapes.get(q, ()))
         pshape = tuple(params[q].shape)
-        shapes.append(pshape[: len(pshape) - len(base)])
+        # A parameter's stored tensor is laid out (*batch, *sub_batch, *base). Strip
+        # the natural base AND any sub-batch (intermediate) axes -- e.g. an
+        # interpolation grid's knot axis declared via `.sub_batch.retag(1)`. The
+        # forward reduces over sub-batch axes, so they are NOT broadcastable
+        # call-batch axes; only the remaining leading dims are the parameter's true
+        # batch. NEML2 records the per-parameter count in the owning module's
+        # _typed_storage_sub_batch_ndim (Model.__setattr__/__getattr__).
+        mod_path, _, pname = q.rpartition(".")
+        owner = model.get_submodule(mod_path) if mod_path else model
+        sub_ndim = owner.__dict__.get("_typed_storage_sub_batch_ndim", {}).get(pname, 0)
+        shapes.append(pshape[: len(pshape) - len(base) - sub_ndim])
     return tuple(torch.broadcast_shapes(*shapes)) if shapes else ()
 
 

--- a/tests/unit/test_eager.py
+++ b/tests/unit/test_eager.py
@@ -58,6 +58,10 @@ _IMPLICIT = _REPO / "tests" / "aoti" / "implicit_simple" / "model.i"
 _SUB_BATCH = (
     _REPO / "tests" / "models" / "solid_mechanics" / "crystal_plasticity" / "ResolvedShear.i"
 )
+# An interpolation leaf whose abscissa/ordinate grid parameters carry a knot
+# sub-batch axis (declared via `.sub_batch.retag(1)`) -- exercises call-batch
+# shape stripping of parameter sub-batch axes.
+_INTERP = _REPO / "tests" / "models" / "common" / "ScalarLinearInterpolation.i"
 
 
 def _rand_inputs(m, b):
@@ -208,6 +212,27 @@ def test_jacobian_matches_autograd():
     # d sum_b stress_k / d strain_{b,j} -> (6, 4, 6); permute to per-batch (4,6,6).
     ref = torch.autograd.functional.jacobian(f, x).permute(1, 0, 2)
     assert torch.allclose(block, ref, atol=1e-10)
+
+
+def test_jacobian_interpolation_sub_batch_param():
+    """An interpolation model's grid parameters (``abscissa``/``ordinate``) carry a
+    knot *sub-batch* axis, NOT a call-batch axis. ``jacobian`` must strip that
+    sub-batch axis when forming the common call batch; otherwise it broadcasts the
+    knot count (here 100) against the input batch (8) and crashes. Regression for
+    the eager interpolation shape error."""
+    m = _EagerModel(str(_INTERP), "E")
+    B = 8  # deliberately != the 100 interpolation knots
+    T = torch.linspace(300.0, 1500.0, B, dtype=m.dtype, device=m.device)
+
+    outputs, jac = m.jacobian({"T": T})
+    block = jac["E"]["T"]
+    assert block.shape == (B,)  # (*B, *out_base=(), *in_base=()); knot axis not leaked
+    # The value half matches a plain forward.
+    assert torch.allclose(outputs["E"], m.forward({"T": T})["E"])
+    # dE/dT equals the (constant) slope of the piecewise-linear grid, per element.
+    h = 1.0
+    fd = (m.forward({"T": T + h})["E"] - m.forward({"T": T - h})["E"]) / (2 * h)
+    assert torch.allclose(block.reshape(-1), fd.reshape(-1), atol=1e-6)
 
 
 def test_jvp_equals_jacobian_times_tangent():


### PR DESCRIPTION
## Problem

`call_batch_shape` (used by the eager `jacobian()` / `param_jacobian()` paths in `neml2/eager/_model.py` and `neml2/models/model.py`) derived each parameter's contribution to the common call batch by stripping only its natural base shape (`BASE_SHAPE`). Any **sub-batch** (intermediate) axis was therefore treated as a broadcastable call-batch axis.

For an interpolation leaf (e.g. `ScalarLinearInterpolation`) whose `abscissa`/`ordinate` grid parameters carry a knot sub-batch axis (declared via `.sub_batch.retag(1)`), this leaked the knot count into the call batch and crashed eager Jacobian evaluation whenever the input batch differed from the knot count:

```
RuntimeError: Attempting to broadcast a dimension of length 100 at -1!
Mismatching argument at index 1 had (100,); but expected shape should be broadcastable to [8]
```

This surfaced in a downstream MOOSE WAAM thermo-mechanical model (temperature-dependent properties via interpolation) run through the eager runtime.

## Fix

The forward reduces over sub-batch axes, so they are **not** call-batch axes. Strip both the base shape **and** the per-parameter sub-batch ndim (recorded in the owning module's `_typed_storage_sub_batch_ndim`) so only the true leading batch dims remain.

## Test

Adds `tests/unit/test_eager.py::test_jacobian_interpolation_sub_batch_param`, which runs `ScalarLinearInterpolation` (100 knots) through the eager Jacobian with an input batch of 8 — reproducing the crash on `main` and asserting correct shape + derivative (validated against finite differences) with the fix.

Verified locally: before/after (crash → pass), the new test, and the full eager + adjacent param-AD/sub-batch unit suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)