### PR TITLE
Fix AOTI export crash for custom predictors consuming a non-top-level given

### DIFF
--- a/neml2/cli/aoti_export.py
+++ b/neml2/cli/aoti_export.py
@@ -62,7 +62,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from math import prod
 from pathlib import Path
@@ -2036,7 +2036,7 @@ def _compile_param_vjp(
 
 
 def _predictor_input_shapes(
-    predictor: Model,
+    input_names: Iterable[str],
     shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]],
     dyn_shape: tuple[int, ...],
 ) -> dict[str, tuple[tuple[int, ...], tuple[int, ...]]]:
@@ -2052,14 +2052,15 @@ def _predictor_input_shapes(
     :func:`_example_inputs_for` would raise a bare ``KeyError`` with no
     diagnostic context.
 
-    Resolve each predictor input by the same cascade
-    :func:`_example_for_given` already uses for the system's own givens: the
-    exact name, then the bare name with any ``~k`` history suffix stripped, then
-    the shared dynamic shape with no sub-batch.
+    Resolve each name in ``input_names`` -- the predictor's ``input_spec`` at
+    the call site -- by the same cascade :func:`_example_for_given` already uses
+    for the system's own givens: the exact name, then the bare name with any
+    ``~k`` history suffix stripped, then the shared dynamic shape with no
+    sub-batch.
     """
     return {
         name: shapes.get(name, shapes.get(name.split("~", 1)[0], (dyn_shape, ())))
-        for name in predictor.input_spec
+        for name in input_names
     }
 
 
@@ -2614,7 +2615,7 @@ def _compile_implicit_segment(
     if inner.predictor is not None:
         pred = inner.predictor.to(device)
         pred_exportable = ComposedModel([pred])
-        pred_shapes = _predictor_input_shapes(pred_exportable, shapes, dyn_shape)
+        pred_shapes = _predictor_input_shapes(pred_exportable.input_spec, shapes, dyn_shape)
         pred_inputs = _example_inputs_for(pred_exportable, device, shapes=pred_shapes)
         pred_name = f"{pkg_basename}_predictor.pt2"
         compile_model(

--- a/neml2/cli/aoti_export.py
+++ b/neml2/cli/aoti_export.py
@@ -2035,6 +2035,34 @@ def _compile_param_vjp(
 # ---------------------------------------------------------------------------
 
 
+def _predictor_input_shapes(
+    predictor: Model,
+    shapes: dict[str, tuple[tuple[int, ...], tuple[int, ...]]],
+    dyn_shape: tuple[int, ...],
+) -> dict[str, tuple[tuple[int, ...], tuple[int, ...]]]:
+    """Example-input shapes for a predictor, tolerant of non-top-level givens.
+
+    ``shapes`` is keyed by the *enclosing* composed model's own ``input_spec``.
+    That is enough for ``ConstantExtrapolationPredictor``, which only ever
+    consumes ``<unknown>~1`` history variables -- always top-level inputs, so
+    always present. A custom predictor may instead consume a "given" that is
+    internal to the composition: a frozen trial-state quantity threaded into the
+    implicit system as one of its ``given_names`` but never a model input. That
+    name is absent from ``shapes``, and the hard index inside
+    :func:`_example_inputs_for` would raise a bare ``KeyError`` with no
+    diagnostic context.
+
+    Resolve each predictor input by the same cascade
+    :func:`_example_for_given` already uses for the system's own givens: the
+    exact name, then the bare name with any ``~k`` history suffix stripped, then
+    the shared dynamic shape with no sub-batch.
+    """
+    return {
+        name: shapes.get(name, shapes.get(name.split("~", 1)[0], (dyn_shape, ())))
+        for name in predictor.input_spec
+    }
+
+
 def _compile_implicit_segment(
     inner,
     pkg_basename: str,
@@ -2586,19 +2614,7 @@ def _compile_implicit_segment(
     if inner.predictor is not None:
         pred = inner.predictor.to(device)
         pred_exportable = ComposedModel([pred])
-        # A custom predictor may consume a "given" that is internal to the
-        # enclosing composed model (e.g. a frozen trial-state quantity threaded
-        # in as one of this system's `given_names`, not a top-level model
-        # input) -- unlike `ConstantExtrapolationPredictor`, which only ever
-        # consumes `<unknown>~1` history variables that are always top-level
-        # inputs and thus already keyed in `shapes`. Fall back to the same
-        # bare-name / shared-dyn-shape default used by `_example_for_given`
-        # above so a name missing from `shapes` doesn't crash the hard index
-        # inside `_example_inputs_for`.
-        pred_shapes = {
-            name: shapes.get(name, shapes.get(name.split("~", 1)[0], (dyn_shape, ())))
-            for name in pred_exportable.input_spec
-        }
+        pred_shapes = _predictor_input_shapes(pred_exportable, shapes, dyn_shape)
         pred_inputs = _example_inputs_for(pred_exportable, device, shapes=pred_shapes)
         pred_name = f"{pkg_basename}_predictor.pt2"
         compile_model(

--- a/neml2/cli/aoti_export.py
+++ b/neml2/cli/aoti_export.py
@@ -2586,7 +2586,20 @@ def _compile_implicit_segment(
     if inner.predictor is not None:
         pred = inner.predictor.to(device)
         pred_exportable = ComposedModel([pred])
-        pred_inputs = _example_inputs_for(pred_exportable, device, shapes=shapes)
+        # A custom predictor may consume a "given" that is internal to the
+        # enclosing composed model (e.g. a frozen trial-state quantity threaded
+        # in as one of this system's `given_names`, not a top-level model
+        # input) -- unlike `ConstantExtrapolationPredictor`, which only ever
+        # consumes `<unknown>~1` history variables that are always top-level
+        # inputs and thus already keyed in `shapes`. Fall back to the same
+        # bare-name / shared-dyn-shape default used by `_example_for_given`
+        # above so a name missing from `shapes` doesn't crash the hard index
+        # inside `_example_inputs_for`.
+        pred_shapes = {
+            name: shapes.get(name, shapes.get(name.split("~", 1)[0], (dyn_shape, ())))
+            for name in pred_exportable.input_spec
+        }
+        pred_inputs = _example_inputs_for(pred_exportable, device, shapes=pred_shapes)
         pred_name = f"{pkg_basename}_predictor.pt2"
         compile_model(
             pred_exportable, pred_inputs, output_dir / pred_name, dynamic_batch_dim=dynamic_dim

--- a/tests/unit/test_aoti_export.py
+++ b/tests/unit/test_aoti_export.py
@@ -1057,3 +1057,48 @@ def test_prepare_opts_in_worker_no_load_is_identity_copy():
     opts = _prepare_opts_in_worker(src)
     assert opts == src
     assert opts is not src  # a copy -- never mutate the caller's dict
+
+
+# --------------------------------------------------------------------------- #
+# _predictor_input_shapes                                                      #
+# --------------------------------------------------------------------------- #
+
+
+class _FakePredictor:
+    """Stand-in for a predictor: `_predictor_input_shapes` only reads input_spec."""
+
+    def __init__(self, names):
+        self.input_spec = dict.fromkeys(names)
+
+
+def test_predictor_input_shapes_prefers_exact_then_bare_then_default():
+    from neml2.cli.aoti_export import _predictor_input_shapes
+
+    dyn = (7,)
+    shapes = {
+        "stress~1": ((2,), (5,)),  # exact hit, sub-batched
+        "trial_stress": ((3,), ()),  # bare-name hit for `trial_stress~1`
+    }
+    pred = _FakePredictor(["stress~1", "trial_stress~1", "frozen_given"])
+    got = _predictor_input_shapes(pred, shapes, dyn)
+
+    # Exact name wins, sub-batch preserved.
+    assert got["stress~1"] == ((2,), (5,))
+    # `~1` stripped to find the bare name -- a history variable whose current
+    # counterpart is the one actually keyed in `shapes`.
+    assert got["trial_stress~1"] == ((3,), ())
+    # Neither present: this is the case that used to raise a bare KeyError
+    # inside `_example_inputs_for`. A given internal to the composition falls
+    # back to the shared dynamic shape with no sub-batch.
+    assert got["frozen_given"] == (dyn, ())
+    # Exactly the predictor's inputs, nothing inherited from `shapes`.
+    assert set(got) == {"stress~1", "trial_stress~1", "frozen_given"}
+
+
+def test_predictor_input_shapes_handles_empty_and_multi_tilde():
+    from neml2.cli.aoti_export import _predictor_input_shapes
+
+    assert _predictor_input_shapes(_FakePredictor([]), {}, (2,)) == {}
+    # Only the FIRST `~` splits, so `a~2` resolves against bare `a`.
+    got = _predictor_input_shapes(_FakePredictor(["a~2"]), {"a": ((4,), (6,))}, (2,))
+    assert got["a~2"] == ((4,), (6,))

--- a/tests/unit/test_aoti_export.py
+++ b/tests/unit/test_aoti_export.py
@@ -1064,13 +1064,6 @@ def test_prepare_opts_in_worker_no_load_is_identity_copy():
 # --------------------------------------------------------------------------- #
 
 
-class _FakePredictor:
-    """Stand-in for a predictor: `_predictor_input_shapes` only reads input_spec."""
-
-    def __init__(self, names):
-        self.input_spec = dict.fromkeys(names)
-
-
 def test_predictor_input_shapes_prefers_exact_then_bare_then_default():
     from neml2.cli.aoti_export import _predictor_input_shapes
 
@@ -1079,8 +1072,8 @@ def test_predictor_input_shapes_prefers_exact_then_bare_then_default():
         "stress~1": ((2,), (5,)),  # exact hit, sub-batched
         "trial_stress": ((3,), ()),  # bare-name hit for `trial_stress~1`
     }
-    pred = _FakePredictor(["stress~1", "trial_stress~1", "frozen_given"])
-    got = _predictor_input_shapes(pred, shapes, dyn)
+    names = ["stress~1", "trial_stress~1", "frozen_given"]
+    got = _predictor_input_shapes(names, shapes, dyn)
 
     # Exact name wins, sub-batch preserved.
     assert got["stress~1"] == ((2,), (5,))
@@ -1098,7 +1091,7 @@ def test_predictor_input_shapes_prefers_exact_then_bare_then_default():
 def test_predictor_input_shapes_handles_empty_and_multi_tilde():
     from neml2.cli.aoti_export import _predictor_input_shapes
 
-    assert _predictor_input_shapes(_FakePredictor([]), {}, (2,)) == {}
+    assert _predictor_input_shapes([], {}, (2,)) == {}
     # Only the FIRST `~` splits, so `a~2` resolves against bare `a`.
-    got = _predictor_input_shapes(_FakePredictor(["a~2"]), {"a": ((4,), (6,))}, (2,))
+    got = _predictor_input_shapes(["a~2"], {"a": ((4,), (6,))}, (2,))
     assert got["a~2"] == ((4,), (6,))


### PR DESCRIPTION
## The bug

`_compile_implicit_segment`'s predictor-export step reused the outer model's top-level input shapes dict verbatim:

```python
pred_inputs = _example_inputs_for(pred_exportable, device, shapes=shapes)
```

`shapes` is keyed by the *enclosing composed model's* own `input_spec`. That is sufficient for `ConstantExtrapolationPredictor`, which only ever consumes `<unknown>~1` history variables — always top-level inputs, so always present.

A **custom** predictor may instead consume a "given" that is internal to the composition: a frozen trial-state quantity threaded into the implicit system as one of its `given_names`, but never a top-level model input. That name is absent from `shapes`, and the hard index inside `_example_inputs_for` raised a bare `KeyError` with no diagnostic context.

## The fix

Build a per-predictor shapes dict using the same resolution cascade `_example_for_given` already applies to the system's own givens — exact name, then bare name with any `~k` history suffix stripped, then the shared dynamic shape with no sub-batch.

## Coverage

The logic lived as an inline dict comprehension inside a function that runs a full Inductor compile, so the only end-to-end route to it is an AOTI compile of a model with such a predictor. It is extracted here into a named `_predictor_input_shapes` helper — **behaviour byte-identical**, purely to make it reachable — matching how every other private helper in this module is covered (`_parse_example_batch_shape`, `_predict_implicit_artifacts`, `_resolve_derivative_specs`, `_prepare_opts_in_worker` are all unit-tested by direct import).

Two tests exercise all three branches of the cascade:

| input | resolves via | expected |
|---|---|---|
| `stress~1` | exact hit | `((2,), (5,))` — sub-batch preserved |
| `trial_stress~1` | bare name after stripping `~1` | `((3,), ())` |
| `frozen_given` | neither — **the crash case** | `(dyn_shape, ())` |

plus an empty predictor, and `a~2` to confirm only the first `~` splits.

Verified the tests have teeth rather than just passing: reverting the cascade to the pre-fix hard index `shapes[name]` fails both with the original `KeyError`; restoring the fallback passes.

## Verification

- `pytest tests/unit` — 797 passed
- `pytest tests/aoti` — 140 passed, 1 skipped, 2 xfailed
- `pre-commit` on touched files — clean

## Note

The first commit here is `89d1e6d6` from your local `main`, which had not been pushed. It was briefly swept into #444 because that branch was cut from local `main`; it was rebased out before merge, so this is its first appearance on the remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)