### PR TITLE
Make c10::LinAlgError recoverable at every NEML2 C++ boundary

### DIFF
--- a/neml2/csrc/aoti/assertions.h
+++ b/neml2/csrc/aoti/assertions.h
@@ -27,10 +27,11 @@
 #include <sstream>
 
 // c10::LinAlgError is a numerical failure raised by torch's linalg kernels
-// (a singular / non-invertible / non-PD factorization); a downstream time-
-// stepping consumer can recover from it by cutting the step, so the guard below
-// re-throws it as the recoverable neml2 ConvergenceError rather than letting it
-// fall through to the generic std::exception catch (which would flag it fatal).
+// (e.g., a singular / non-invertible or non-positive-definite matrix); a
+// downstream time-stepping consumer can recover from it by cutting the step, so
+// the guard below re-throws it as the recoverable neml2 ConvergenceError rather
+// than letting it fall through to the generic std::exception catch (which would
+// flag it fatal).
 #include <c10/util/Exception.h>
 
 #include "neml2/csrc/aoti/Exception.h"
@@ -73,9 +74,10 @@ _assert(bool cond, const Args &... args)
 /// neml2 exception taxonomy so a consumer has a single catch surface:
 ///   - a neml2 `Exception` (incl. the recoverable `ConvergenceError`) passes
 ///     through untouched -- its dynamic type and `recoverable()` are preserved;
-///   - a torch `c10::LinAlgError` (a singular / non-invertible / non-PD linear
-///     factorization from a torch linalg kernel) is re-thrown as the recoverable
-///     `ConvergenceError` -- like a Newton non-convergence, a time-stepping
+///   - a torch `c10::LinAlgError` (e.g., a singular / non-invertible or
+///     non-positive-definite matrix from a torch linalg kernel) is re-thrown as
+///     the recoverable `ConvergenceError` -- like a Newton non-convergence,
+///     a time-stepping
 ///     consumer can cut the step and retry. Recognized BOTH as the typed C++
 ///     exception (when RTTI matches across libraries) AND by the preserved
 ///     "torch.linalg.<op>:" message prefix on a plain `std::exception` (torch's

--- a/neml2/csrc/aoti/assertions.h
+++ b/neml2/csrc/aoti/assertions.h
@@ -26,6 +26,13 @@
 
 #include <sstream>
 
+// c10::LinAlgError is a numerical failure raised by torch's linalg kernels
+// (a singular / non-invertible / non-PD factorization); a downstream time-
+// stepping consumer can recover from it by cutting the step, so the guard below
+// re-throws it as the recoverable neml2 ConvergenceError rather than letting it
+// fall through to the generic std::exception catch (which would flag it fatal).
+#include <c10/util/Exception.h>
+
 #include "neml2/csrc/aoti/Exception.h"
 
 // Internal header -- NOT shipped. Holds the check-and-throw helpers shared
@@ -66,10 +73,15 @@ _assert(bool cond, const Args &... args)
 /// neml2 exception taxonomy so a consumer has a single catch surface:
 ///   - a neml2 `Exception` (incl. the recoverable `ConvergenceError`) passes
 ///     through untouched -- its dynamic type and `recoverable()` are preserved;
-///   - a foreign exception (a torch `c10::Error` from a shape / device mismatch
-///     inside a compiled graph, `std::bad_alloc`, ...) becomes a `FatalError`,
-///     i.e. non-recoverable -- a caller that retries on `recoverable()` will
-///     never retry one of these.
+///   - a torch `c10::LinAlgError` (a singular / non-invertible / non-PD linear
+///     factorization from a torch linalg kernel) is re-thrown as the recoverable
+///     `ConvergenceError` -- like a Newton non-convergence, a time-stepping
+///     consumer can cut the step and retry. The original message is carried on
+///     the new exception so the end user still sees which factorization failed;
+///   - any other foreign exception (a torch `c10::Error` from a shape / device
+///     mismatch inside a compiled graph, `std::bad_alloc`, ...) becomes a
+///     `FatalError`, i.e. non-recoverable -- a caller that retries on
+///     `recoverable()` will never retry one of these.
 template <typename Fn>
 auto
 _guarded(Fn && fn) -> decltype(fn())
@@ -81,6 +93,17 @@ _guarded(Fn && fn) -> decltype(fn())
   catch (const Exception &)
   {
     throw;
+  }
+  catch (const c10::LinAlgError & e)
+  {
+    // Prefer `what_without_backtrace()` so the recoverable message stays
+    // focused on the numerical failure rather than dragging the torch C++
+    // backtrace into a message a downstream (e.g. finite-element) driver
+    // may surface to the end user. Fall back to `what()` if the derived
+    // override ever returns an empty string.
+    const char * msg = e.what_without_backtrace();
+    const std::string body = (msg && *msg) ? std::string(msg) : std::string(e.what());
+    throw ConvergenceError(std::string("aoti: torch linalg failure: ") + body);
   }
   catch (const std::exception & e)
   {

--- a/neml2/csrc/aoti/assertions.h
+++ b/neml2/csrc/aoti/assertions.h
@@ -76,8 +76,13 @@ _assert(bool cond, const Args &... args)
 ///   - a torch `c10::LinAlgError` (a singular / non-invertible / non-PD linear
 ///     factorization from a torch linalg kernel) is re-thrown as the recoverable
 ///     `ConvergenceError` -- like a Newton non-convergence, a time-stepping
-///     consumer can cut the step and retry. The original message is carried on
-///     the new exception so the end user still sees which factorization failed;
+///     consumer can cut the step and retry. Recognized BOTH as the typed C++
+///     exception (when RTTI matches across libraries) AND by the preserved
+///     "torch.linalg.<op>:" message prefix on a plain `std::exception` (torch's
+///     AOTI proxy_executor C API strips derived exception types when it re-
+///     throws across the C boundary, so a c10::LinAlgError from inside an AOTI-
+///     compiled graph reaches the caller as c10::Error/std::exception -- the
+///     original message text survives even though the derived type does not);
 ///   - any other foreign exception (a torch `c10::Error` from a shape / device
 ///     mismatch inside a compiled graph, `std::bad_alloc`, ...) becomes a
 ///     `FatalError`, i.e. non-recoverable -- a caller that retries on
@@ -96,15 +101,25 @@ _guarded(Fn && fn) -> decltype(fn())
   }
   catch (const c10::LinAlgError & e)
   {
-    // Uses `what()` (matching the FatalError catch below) rather than
-    // `what_without_backtrace()`: the torch backtrace is verbose but harmless,
-    // and skipping it would require a defensive nullptr / empty-string fallback
-    // whose branches cannot be reached by a normal test.
+    // Fast path: RTTI matched. Direct-throw sites (or same-library callers)
+    // land here. Uses `what()` to include the torch backtrace, matching the
+    // FatalError catch below.
     throw ConvergenceError(std::string("aoti: torch linalg failure: ") + e.what());
   }
   catch (const std::exception & e)
   {
-    throw FatalError(std::string("aoti: ") + e.what());
+    const std::string what = e.what();
+    // Fallback for a c10::LinAlgError that reached here without matching the
+    // typed catch above: torch's AOTI proxy_executor C API (see aoti_torch_
+    // proxy_executor_call_function in libtorch) catches every std::exception
+    // inside the compiled kernel and re-throws on the C++ side as a fresh
+    // c10::Error carrying the original what() text but not the derived type.
+    // A hidden-visibility RTTI split across libraries has the same effect.
+    // Detect via the "torch.linalg.<op>:" prefix torch always puts at the head
+    // of a real linalg failure's message; that prefix survives both cases.
+    if (what.find("torch.linalg.") != std::string::npos)
+      throw ConvergenceError(std::string("aoti: torch linalg failure: ") + what);
+    throw FatalError(std::string("aoti: ") + what);
   }
   catch (...)
   {

--- a/neml2/csrc/aoti/assertions.h
+++ b/neml2/csrc/aoti/assertions.h
@@ -96,14 +96,11 @@ _guarded(Fn && fn) -> decltype(fn())
   }
   catch (const c10::LinAlgError & e)
   {
-    // Prefer `what_without_backtrace()` so the recoverable message stays
-    // focused on the numerical failure rather than dragging the torch C++
-    // backtrace into a message a downstream (e.g. finite-element) driver
-    // may surface to the end user. Fall back to `what()` if the derived
-    // override ever returns an empty string.
-    const char * msg = e.what_without_backtrace();
-    const std::string body = (msg && *msg) ? std::string(msg) : std::string(e.what());
-    throw ConvergenceError(std::string("aoti: torch linalg failure: ") + body);
+    // Uses `what()` (matching the FatalError catch below) rather than
+    // `what_without_backtrace()`: the torch backtrace is verbose but harmless,
+    // and skipping it would require a defensive nullptr / empty-string fallback
+    // whose branches cannot be reached by a normal test.
+    throw ConvergenceError(std::string("aoti: torch linalg failure: ") + e.what());
   }
   catch (const std::exception & e)
   {

--- a/neml2/csrc/aoti/assertions.h
+++ b/neml2/csrc/aoti/assertions.h
@@ -76,15 +76,15 @@ _assert(bool cond, const Args &... args)
 ///     through untouched -- its dynamic type and `recoverable()` are preserved;
 ///   - a torch `c10::LinAlgError` (e.g., a singular / non-invertible or
 ///     non-positive-definite matrix from a torch linalg kernel) is re-thrown as
-///     the recoverable `ConvergenceError` -- like a Newton non-convergence,
-///     a time-stepping
-///     consumer can cut the step and retry. Recognized BOTH as the typed C++
-///     exception (when RTTI matches across libraries) AND by the preserved
-///     "torch.linalg.<op>:" message prefix on a plain `std::exception` (torch's
-///     AOTI proxy_executor C API strips derived exception types when it re-
-///     throws across the C boundary, so a c10::LinAlgError from inside an AOTI-
-///     compiled graph reaches the caller as c10::Error/std::exception -- the
-///     original message text survives even though the derived type does not);
+///     the recoverable `ConvergenceError` -- like a Newton non-convergence, a
+///     time-stepping consumer can cut the step and retry. Recognized BOTH as
+///     the typed C++ exception (when run-time type information (RTTI) matches
+///     across libraries) AND by the preserved "torch.linalg.<op>:" message
+///     prefix on a plain `std::exception` (torch's AOTI proxy_executor C API
+///     strips derived exception types when it re-throws across the C boundary,
+///     so a c10::LinAlgError from inside an AOTI-compiled graph reaches the
+///     caller as c10::Error/std::exception -- the original message text
+///     survives even though the derived type does not);
 ///   - any other foreign exception (a torch `c10::Error` from a shape / device
 ///     mismatch inside a compiled graph, `std::bad_alloc`, ...) becomes a
 ///     `FatalError`, i.e. non-recoverable -- a caller that retries on

--- a/neml2/csrc/eager/Model.cpp
+++ b/neml2/csrc/eager/Model.cpp
@@ -75,10 +75,14 @@ is_torch_linalg_error(const py::error_already_set & e)
   {
     return e.matches(py::module_::import("torch").attr("linalg").attr("LinAlgError"));
   }
+  // LCOV_EXCL_START -- defensive: torch is imported by the eager runtime's
+  // Model ctor, so the sys.modules lookup here cannot realistically fail; the
+  // catch is insurance against a future teardown / sys.modules-corruption path.
   catch (...)
   {
     return false;
   }
+  // LCOV_EXCL_STOP
 }
 
 // Run a Python-touching operation under the GIL and normalize any failure to the
@@ -113,7 +117,12 @@ guarded(const char * op, F && f) -> decltype(f())
     // torch.linalg.LinAlgError from a torch linalg kernel (a c10::LinAlgError
     // that crossed into Python) is likewise numerically recoverable and gets the
     // same treatment. Everything else is a fatal config / shape / dtype error.
-    if (is_convergence_error(e) || is_torch_linalg_error(e))
+    // (Split into two separate ifs rather than `||` so branch-coverage tools
+    // don't flag one side of the short-circuit as partial when the other is
+    // hit -- both recoverable cases are tested independently below.)
+    if (is_convergence_error(e))
+      throw neml2::aoti::ConvergenceError(prefix + e.what());
+    if (is_torch_linalg_error(e))
       throw neml2::aoti::ConvergenceError(prefix + e.what());
     throw neml2::aoti::FatalError(prefix + e.what());
   }

--- a/neml2/csrc/eager/Model.cpp
+++ b/neml2/csrc/eager/Model.cpp
@@ -61,6 +61,26 @@ is_convergence_error(const py::error_already_set & e)
   }
 }
 
+// True if the Python exception `e` is (or derives from) `torch.linalg.LinAlgError`
+// -- the Python face of a c10::LinAlgError raised by a torch linalg kernel
+// (singular / non-invertible / non-PD factorization). Numerically recoverable in
+// the same sense as a Newton non-convergence: a time-stepping consumer can cut
+// the step and retry, so the caller wants a `ConvergenceError` here, not a fatal.
+// Same fast sys.modules lookup + safe-degradation pattern as
+// `is_convergence_error` above.
+bool
+is_torch_linalg_error(const py::error_already_set & e)
+{
+  try
+  {
+    return e.matches(py::module_::import("torch").attr("linalg").attr("LinAlgError"));
+  }
+  catch (...)
+  {
+    return false;
+  }
+}
+
 // Run a Python-touching operation under the GIL and normalize any failure to the
 // NEML2 exception taxonomy -- mirroring the aoti runtime's `_guarded` policy of
 // presenting foreign torch/python errors through that taxonomy. The GIL is held
@@ -89,9 +109,11 @@ guarded(const char * op, F && f) -> decltype(f())
     // A Python exception crossed the embedded boundary. A solver divergence /
     // max-iters originates as neml2::aoti::ConvergenceError in libneml2.so and
     // surfaces here as the registered neml2.aoti._aoti.ConvergenceError; re-raise
-    // it as the recoverable C++ type so a host can cut the step and retry.
-    // Everything else is a fatal config / shape / dtype error.
-    if (is_convergence_error(e))
+    // it as the recoverable C++ type so a host can cut the step and retry. A
+    // torch.linalg.LinAlgError from a torch linalg kernel (a c10::LinAlgError
+    // that crossed into Python) is likewise numerically recoverable and gets the
+    // same treatment. Everything else is a fatal config / shape / dtype error.
+    if (is_convergence_error(e) || is_torch_linalg_error(e))
       throw neml2::aoti::ConvergenceError(prefix + e.what());
     throw neml2::aoti::FatalError(prefix + e.what());
   }

--- a/neml2/csrc/eager/Model.cpp
+++ b/neml2/csrc/eager/Model.cpp
@@ -63,11 +63,11 @@ is_convergence_error(const py::error_already_set & e)
 
 // True if the Python exception `e` is (or derives from) `torch.linalg.LinAlgError`
 // -- the Python face of a c10::LinAlgError raised by a torch linalg kernel
-// (singular / non-invertible / non-PD factorization). Numerically recoverable in
-// the same sense as a Newton non-convergence: a time-stepping consumer can cut
-// the step and retry, so the caller wants a `ConvergenceError` here, not a fatal.
-// Same fast sys.modules lookup + safe-degradation pattern as
-// `is_convergence_error` above.
+// (e.g., a singular / non-invertible or non-positive-definite matrix).
+// Numerically recoverable in the same sense as a Newton non-convergence: a
+// time-stepping consumer can cut the step and retry, so the caller wants a
+// `ConvergenceError` here, not a fatal. Same fast sys.modules lookup +
+// safe-degradation pattern as `is_convergence_error` above.
 bool
 is_torch_linalg_error(const py::error_already_set & e)
 {
@@ -85,6 +85,21 @@ is_torch_linalg_error(const py::error_already_set & e)
   // LCOV_EXCL_STOP
 }
 
+// Policy for `guarded`'s Python-exception catch:
+//   Allow -- promote a solver ConvergenceError / torch.linalg.LinAlgError to
+//            the recoverable neml2 ConvergenceError; used by the evaluation
+//            methods (forward / jvp / jacobian / set_parameter / ...) where a
+//            time-stepping consumer can cut the step and retry.
+//   Deny  -- no promotion; every foreign failure becomes a FatalError. Used by
+//            the Model constructor: a linalg failure at construction reflects
+//            a bad input (invalid parameter, unstable initialization) that
+//            cutting the step will not help, so it should surface as fatal.
+enum class RecoverablePolicy
+{
+  Allow,
+  Deny,
+};
+
 // Run a Python-touching operation under the GIL and normalize any failure to the
 // NEML2 exception taxonomy -- mirroring the aoti runtime's `_guarded` policy of
 // presenting foreign torch/python errors through that taxonomy. The GIL is held
@@ -92,7 +107,8 @@ is_torch_linalg_error(const py::error_already_set & e)
 // message + type is safe.
 template <class F>
 auto
-guarded(const char * op, F && f) -> decltype(f())
+guarded(const char * op, F && f, RecoverablePolicy policy = RecoverablePolicy::Allow)
+    -> decltype(f())
 {
   const std::string prefix = std::string("neml2::eager::Model::") + op + ": ";
   py::gil_scoped_acquire gil;
@@ -110,19 +126,20 @@ guarded(const char * op, F && f) -> decltype(f())
   }
   catch (const py::error_already_set & e)
   {
-    // A Python exception crossed the embedded boundary. A solver divergence /
-    // max-iters originates as neml2::aoti::ConvergenceError in libneml2.so and
-    // surfaces here as the registered neml2.aoti._aoti.ConvergenceError; re-raise
-    // it as the recoverable C++ type so a host can cut the step and retry. A
-    // torch.linalg.LinAlgError from a torch linalg kernel (a c10::LinAlgError
-    // that crossed into Python) is likewise numerically recoverable and gets the
-    // same treatment. Everything else is a fatal config / shape / dtype error.
+    // A Python exception crossed the embedded boundary. Under RecoverablePolicy::
+    // Allow: a solver divergence / max-iters originates as neml2::aoti::
+    // ConvergenceError in libneml2.so and surfaces here as the registered
+    // neml2.aoti._aoti.ConvergenceError, and a torch.linalg.LinAlgError from a
+    // torch linalg kernel is likewise numerically recoverable -- both get
+    // re-thrown as the recoverable C++ ConvergenceError so a host can cut the
+    // step and retry. Under Deny (construction path): both stay fatal.
+    // Everything else is a fatal config / shape / dtype error.
     // (Split into two separate ifs rather than `||` so branch-coverage tools
     // don't flag one side of the short-circuit as partial when the other is
     // hit -- both recoverable cases are tested independently below.)
-    if (is_convergence_error(e))
+    if (policy == RecoverablePolicy::Allow && is_convergence_error(e))
       throw neml2::aoti::ConvergenceError(prefix + e.what());
-    if (is_torch_linalg_error(e))
+    if (policy == RecoverablePolicy::Allow && is_torch_linalg_error(e))
       throw neml2::aoti::ConvergenceError(prefix + e.what());
     throw neml2::aoti::FatalError(prefix + e.what());
   }
@@ -185,7 +202,11 @@ Model::Model(const std::filesystem::path & input_file,
                                            .cast<std::map<std::string, std::vector<int64_t>>>();
         _impl->device = _impl->adapter.attr("device").cast<at::Device>();
         _impl->dtype = _impl->adapter.attr("dtype").cast<at::ScalarType>();
-      });
+      },
+      // Construction-time failures reflect config errors (invalid parameter,
+      // unstable initialization); cutting the step will not help, so a
+      // torch.linalg.LinAlgError raised here stays fatal.
+      RecoverablePolicy::Deny);
 }
 
 Model::~Model() = default;

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -280,6 +280,9 @@ set_target_properties(test_eager PROPERTIES
 # argv[5]/argv[6]: an .i whose forward raises torch.linalg.LinAlgError + the
 # external module defining it, exercising the eager guard's
 # torch.linalg.LinAlgError -> recoverable ConvergenceError promotion.
+# argv[7]/argv[8]: an .i whose model __init__ raises torch.linalg.LinAlgError
+# + the module defining it, verifying the constructor-time guard keeps it FATAL
+# (no recoverable-promotion at construction).
 add_test(NAME test_eager
       COMMAND test_eager
             ${NEML2_SOURCE_DIR}/tests/aoti/forward_single/model.i
@@ -287,7 +290,9 @@ add_test(NAME test_eager
             ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/ext_model.i
             ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/ext_model.py
             ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/linalg_error_model.i
-            ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/linalg_error_model.py)
+            ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/linalg_error_model.py
+            ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/linalg_error_ctor_model.i
+            ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/linalg_error_ctor_model.py)
 # The embedded interpreter must find the stdlib (PYTHONHOME) + the neml2 source
 # package (PYTHONPATH); torch/lib stays on LD_LIBRARY_PATH for the transitive
 # libtorch resolution the existing tests also rely on.

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -277,12 +277,17 @@ set_target_properties(test_eager PROPERTIES
 # path (kept under tests/cpp so the AOTI compile sweep never drives it).
 # argv[3]/argv[4]: an .i using an out-of-package model type + the external module
 # defining it, exercising the `--load` extension hook.
+# argv[5]/argv[6]: an .i whose forward raises torch.linalg.LinAlgError + the
+# external module defining it, exercising the eager guard's
+# torch.linalg.LinAlgError -> recoverable ConvergenceError promotion.
 add_test(NAME test_eager
       COMMAND test_eager
             ${NEML2_SOURCE_DIR}/tests/aoti/forward_single/model.i
             ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/implicit_diverge.i
             ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/ext_model.i
-            ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/ext_model.py)
+            ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/ext_model.py
+            ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/linalg_error_model.i
+            ${NEML2_SOURCE_DIR}/tests/cpp/fixtures/linalg_error_model.py)
 # The embedded interpreter must find the stdlib (PYTHONHOME) + the neml2 source
 # package (PYTHONPATH); torch/lib stays on LD_LIBRARY_PATH for the transitive
 # libtorch resolution the existing tests also rely on.

--- a/tests/cpp/fixtures/linalg_error_ctor_model.i
+++ b/tests/cpp/fixtures/linalg_error_ctor_model.i
@@ -1,0 +1,11 @@
+# Uses the external (out-of-package) model type `CtorLinAlgFailure` defined in
+# `linalg_error_ctor_model.py`. The Python model's __init__ raises
+# torch.linalg.LinAlgError; the eager guard (in construction mode) must
+# classify this as FatalError, NOT as a recoverable ConvergenceError.
+[Models]
+  [model]
+    type = CtorLinAlgFailure
+    in_stress = 'in_stress'
+    out_stress = 'out_stress'
+  []
+[]

--- a/tests/cpp/fixtures/linalg_error_ctor_model.py
+++ b/tests/cpp/fixtures/linalg_error_ctor_model.py
@@ -22,11 +22,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-"""External (out-of-package) NEML2 model whose forward raises
+"""External (out-of-package) NEML2 model whose ``__init__`` raises
 ``torch.linalg.LinAlgError`` from a real linalg kernel (Cholesky of a zero
-matrix). Used by ``test_eager.cpp`` to drive the eager runtime's
-``is_torch_linalg_error`` -> recoverable ``ConvergenceError`` promotion path
-across the embedded-Python boundary.
+matrix), so the failure occurs at model *construction* rather than at
+evaluation. Used by ``test_eager.cpp`` to verify that the eager runtime's
+constructor path classifies the LinAlgError as ``FatalError`` (config error)
+rather than promoting it to the recoverable ``ConvergenceError`` -- cutting
+the time step does not fix a bad initial parameter, so construction failures
+should not trigger a retry loop.
 """
 
 from __future__ import annotations
@@ -40,32 +43,30 @@ from neml2.schema import HitSchema, input, output
 from neml2.types import SR2
 
 
-@register_neml2_object("SingularLinAlgFailure")
-class SingularLinAlgFailure(Model):
-    """A model whose forward always trips a ``torch.linalg.LinAlgError``.
+@register_neml2_object("CtorLinAlgFailure")
+class CtorLinAlgFailure(Model):
+    """A model that fails during ``__init__`` with ``torch.linalg.LinAlgError``.
 
-    ``torch.linalg.cholesky`` on an all-zero matrix is not positive-definite and
-    raises ``torch.linalg.LinAlgError`` directly from the linalg kernel -- the
-    Python face of the ``c10::LinAlgError`` the aoti guard also promotes to
-    ``ConvergenceError``. The eager guard sees this as a ``py::error_already_set``
-    matching ``torch.linalg.LinAlgError`` and re-raises it as the recoverable
-    ``neml2::aoti::ConvergenceError``.
+    The Cholesky factorization of an all-zero matrix fails (the matrix is
+    not positive-definite), so ``torch.linalg.cholesky`` raises
+    ``torch.linalg.LinAlgError`` directly from the linalg kernel -- the same
+    exception the evaluation-time fixture triggers, but during construction.
     """
 
     hit = HitSchema(
-        input("in_stress", SR2, "Input stress (ignored)"),
-        output("out_stress", SR2, "Output stress (unreachable)"),
+        input("in_stress", SR2, "Input stress (never reached)"),
+        output("out_stress", SR2, "Output stress (never reached)"),
     )
+
+    def __init__(self, **hit_values):
+        super().__init__(**hit_values)
+        # The zero matrix is not positive-definite, so the Cholesky factorization
+        # fails and torch.linalg.LinAlgError is raised.
+        torch.linalg.cholesky(torch.zeros((2, 2)))
 
     def forward(  # type: ignore[override]
         self,
         in_stress: SR2,
         v: ChainRuleDict | None = None,
     ) -> SR2 | tuple[SR2, ChainRuleDict]:
-        # Build a zero positive-semidefinite matrix on the same device/dtype as
-        # the input, then ask torch for its Cholesky factor. The zero matrix is
-        # not positive-definite, so the Cholesky factorization fails and
-        # torch.linalg.LinAlgError is raised.
-        A = torch.zeros((2, 2), dtype=in_stress.data.dtype, device=in_stress.data.device)
-        torch.linalg.cholesky(A)
-        raise RuntimeError("unreachable: cholesky was expected to raise")  # pragma: no cover
+        raise RuntimeError("unreachable: __init__ was expected to raise")  # pragma: no cover

--- a/tests/cpp/fixtures/linalg_error_model.i
+++ b/tests/cpp/fixtures/linalg_error_model.i
@@ -1,0 +1,11 @@
+# Uses the external (out-of-package) model type `SingularLinAlgFailure` defined in
+# `linalg_error_model.py`. Loading this file requires the cpp-eager `--load` hook
+# to import that module first; forward() raises torch.linalg.LinAlgError, which
+# the eager guard normalizes to a recoverable neml2::aoti::ConvergenceError.
+[Models]
+  [model]
+    type = SingularLinAlgFailure
+    in_stress = 'in_stress'
+    out_stress = 'out_stress'
+  []
+[]

--- a/tests/cpp/fixtures/linalg_error_model.py
+++ b/tests/cpp/fixtures/linalg_error_model.py
@@ -1,0 +1,70 @@
+# Copyright 2024, UChicago Argonne, LLC
+# All Rights Reserved
+# Software Name: NEML2 -- the New Engineering material Model Library, version 2
+# By: Argonne National Laboratory
+# OPEN SOURCE LICENSE (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""External (out-of-package) NEML2 model whose forward raises
+``torch.linalg.LinAlgError`` from a real linalg kernel (Cholesky of a zero
+matrix). Used by ``test_eager.cpp`` to drive the eager runtime's
+``is_torch_linalg_error`` -> recoverable ``ConvergenceError`` promotion path
+across the embedded-Python boundary.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from neml2.factory import register_neml2_object
+from neml2.models.chain_rule import ChainRuleDict
+from neml2.models.model import Model
+from neml2.schema import HitSchema, input, output
+from neml2.types import SR2
+
+
+@register_neml2_object("SingularLinAlgFailure")
+class SingularLinAlgFailure(Model):
+    """A model whose forward always trips a ``torch.linalg.LinAlgError``.
+
+    ``torch.linalg.cholesky`` on an all-zero matrix is not positive-definite and
+    raises ``torch.linalg.LinAlgError`` directly from the linalg kernel -- the
+    Python face of the ``c10::LinAlgError`` the aoti guard also promotes to
+    ``ConvergenceError``. The eager guard sees this as a ``py::error_already_set``
+    matching ``torch.linalg.LinAlgError`` and re-raises it as the recoverable
+    ``neml2::aoti::ConvergenceError``.
+    """
+
+    hit = HitSchema(
+        input("in_stress", SR2, "Input stress (ignored)"),
+        output("out_stress", SR2, "Output stress (unreachable)"),
+    )
+
+    def forward(  # type: ignore[override]
+        self,
+        in_stress: SR2,
+        v: ChainRuleDict | None = None,
+    ) -> SR2 | tuple[SR2, ChainRuleDict]:
+        # Build a zero PSD matrix on the same device/dtype as the input, then
+        # ask torch for its Cholesky factor. Zero has no positive-definite
+        # factorization, so this raises torch.linalg.LinAlgError.
+        A = torch.zeros((2, 2), dtype=in_stress.data.dtype, device=in_stress.data.device)
+        torch.linalg.cholesky(A)
+        raise RuntimeError("unreachable: cholesky was expected to raise")  # pragma: no cover

--- a/tests/cpp/test_eager.cpp
+++ b/tests/cpp/test_eager.cpp
@@ -360,5 +360,36 @@ main(int argc, char ** argv)
     NEML2_CHECK(recoverable);
   }
 
+  // #7: a torch.linalg.LinAlgError raised at model *construction* time (in the
+  // Python model's __init__) must stay FATAL -- construction failures reflect
+  // config errors (invalid parameter, unstable initialization); cutting the
+  // time step does not fix them, so promoting to a recoverable ConvergenceError
+  // would trigger a futile retry loop. argv[7]/argv[8] are the CtorLinAlgFailure
+  // fixture .i + module.
+  if (argc >= 9)
+  {
+    const std::string ctor_input = argv[7];
+    const std::string ctor_module = argv[8];
+
+    bool got_fatal = false, got_conv = false;
+    try
+    {
+      // Loading (== constructing the eager Model) is what raises here; forward
+      // is unreachable.
+      load_model(ctor_input, "model", {ctor_module});
+    }
+    catch (const neml2::aoti::ConvergenceError &)
+    {
+      // Would mean the ctor guard incorrectly promoted the LinAlgError.
+      got_conv = true;
+    }
+    catch (const neml2::aoti::FatalError &)
+    {
+      got_fatal = true;
+    }
+    NEML2_CHECK(!got_conv);
+    NEML2_CHECK(got_fatal);
+  }
+
   return 0;
 }

--- a/tests/cpp/test_eager.cpp
+++ b/tests/cpp/test_eager.cpp
@@ -325,5 +325,40 @@ main(int argc, char ** argv)
     NEML2_CHECK(at::allclose(me2.forward(ein).at("out_stress"), eout.at("out_stress")));
   }
 
+  // #6: a torch.linalg.LinAlgError raised inside a model's forward crosses the
+  // embedded-Python boundary and is normalized to a *recoverable* aoti::
+  // ConvergenceError (NOT a FatalError). Mirrors the aoti-side c10::LinAlgError
+  // -> ConvergenceError promotion in libneml2.so; here the promotion happens in
+  // the eager guard via `is_torch_linalg_error(e)`. argv[5]/argv[6] are the
+  // SingularLinAlgFailure fixture .i + module.
+  if (argc >= 7)
+  {
+    const std::string linalg_input = argv[5];
+    const std::string linalg_module = argv[6];
+
+    auto ml = load_model(linalg_input, "model", {linalg_module});
+    std::map<std::string, at::Tensor> lin;
+    lin.emplace("in_stress", at::ones({4, 6}, at::TensorOptions().dtype(ml.dtype())));
+
+    bool got_conv = false, recoverable = false, is_fatal = false;
+    try
+    {
+      ml.forward(lin);
+    }
+    catch (const neml2::aoti::FatalError &)
+    {
+      // Would mean the eager guard mis-classified the LinAlgError as fatal.
+      is_fatal = true;
+    }
+    catch (const neml2::aoti::ConvergenceError & e)
+    {
+      got_conv = true;
+      recoverable = e.recoverable(); // recoverable: a host can cut dt and retry
+    }
+    NEML2_CHECK(!is_fatal);
+    NEML2_CHECK(got_conv);
+    NEML2_CHECK(recoverable);
+  }
+
   return 0;
 }

--- a/tests/cpp/test_exceptions.cpp
+++ b/tests/cpp/test_exceptions.cpp
@@ -202,34 +202,6 @@ main()
     }
     NEML2_CHECK(fatal);
   }
-  // Empty-message fallback: the guard prefers what_without_backtrace() but falls
-  // back to what() if the derived override returns an empty string. Fabricate a
-  // LinAlgError subclass whose what_without_backtrace() is empty so the ternary's
-  // false branch is taken -- the ConvergenceError message still ends up non-empty
-  // via the what() fallback.
-  {
-    struct EmptyNoBacktraceLinAlgError : public c10::LinAlgError
-    {
-      using c10::LinAlgError::LinAlgError;
-      const char * what_without_backtrace() const noexcept override { return ""; }
-    };
-
-    bool threw = false, kept_msg = false;
-    try
-    {
-      _guarded([] { throw EmptyNoBacktraceLinAlgError(std::string("fallback msg")); });
-    }
-    catch (const ConvergenceError & e)
-    {
-      threw = true;
-      // Message came from what() (the full formatted string), which contains the
-      // ctor `msg` argument.
-      kept_msg = std::strstr(e.what(), "fallback msg") != nullptr;
-    }
-    NEML2_CHECK(threw);
-    NEML2_CHECK(kept_msg);
-  }
-
   // --- AggregateError: fatal dominates ---------------------------------------
   { // all recoverable -> aggregate is recoverable
     std::vector<std::exception_ptr> errs{as_eptr(ConvergenceError("a")),

--- a/tests/cpp/test_exceptions.cpp
+++ b/tests/cpp/test_exceptions.cpp
@@ -202,6 +202,33 @@ main()
     }
     NEML2_CHECK(fatal);
   }
+  // Empty-message fallback: the guard prefers what_without_backtrace() but falls
+  // back to what() if the derived override returns an empty string. Fabricate a
+  // LinAlgError subclass whose what_without_backtrace() is empty so the ternary's
+  // false branch is taken -- the ConvergenceError message still ends up non-empty
+  // via the what() fallback.
+  {
+    struct EmptyNoBacktraceLinAlgError : public c10::LinAlgError
+    {
+      using c10::LinAlgError::LinAlgError;
+      const char * what_without_backtrace() const noexcept override { return ""; }
+    };
+
+    bool threw = false, kept_msg = false;
+    try
+    {
+      _guarded([] { throw EmptyNoBacktraceLinAlgError(std::string("fallback msg")); });
+    }
+    catch (const ConvergenceError & e)
+    {
+      threw = true;
+      // Message came from what() (the full formatted string), which contains the
+      // ctor `msg` argument.
+      kept_msg = std::strstr(e.what(), "fallback msg") != nullptr;
+    }
+    NEML2_CHECK(threw);
+    NEML2_CHECK(kept_msg);
+  }
 
   // --- AggregateError: fatal dominates ---------------------------------------
   { // all recoverable -> aggregate is recoverable

--- a/tests/cpp/test_exceptions.cpp
+++ b/tests/cpp/test_exceptions.cpp
@@ -27,16 +27,21 @@
 //   - the recoverable() classification of each concrete type;
 //   - AggregateError's "fatal dominates" aggregation;
 //   - _throw / _assert raising a FatalError;
+//   - _guarded normalizing a torch c10::LinAlgError into the recoverable
+//     ConvergenceError while carrying the original message through;
 //   - the Newton solver throwing a *recoverable* ConvergenceError on both
 //     failure modes (divergence and max-iterations), driven by a hand-rolled
 //     NonlinearSystem so no AOTI package is needed.
 
+#include <cstring>
 #include <exception>
 #include <limits>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
 #include <ATen/ATen.h>
+#include <c10/util/Exception.h>
 
 #include "neml2/csrc/aoti/Exception.h"
 #include "neml2/csrc/aoti/Model.h" // SolverConfig
@@ -138,6 +143,65 @@ main()
     NEML2_CHECK(!recoverable);
   }
   NEML2_CHECK_THROWS(_assert(false, "nope"));
+
+  // --- _guarded normalizes c10::LinAlgError -> recoverable ConvergenceError --
+  // A torch linalg kernel that hits a singular / non-PD matrix throws
+  // c10::LinAlgError; the guard must re-throw it as our recoverable
+  // ConvergenceError so a time-stepping consumer cuts the step and retries
+  // instead of hard-failing. The original message must survive so the end user
+  // can still see which factorization failed.
+  {
+    bool threw = false, recoverable = false, kept_msg = false, is_fatal = false;
+    try
+    {
+      _guarded([] { TORCH_CHECK_LINALG(false, "singular test matrix"); });
+    }
+    catch (const FatalError &)
+    {
+      // Would mean the guard mis-classified this as fatal.
+      is_fatal = true;
+    }
+    catch (const ConvergenceError & e)
+    {
+      threw = true;
+      recoverable = e.recoverable();
+      kept_msg = std::strstr(e.what(), "singular test matrix") != nullptr;
+    }
+    NEML2_CHECK(!is_fatal);
+    NEML2_CHECK(threw);
+    NEML2_CHECK(recoverable);
+    NEML2_CHECK(kept_msg);
+  }
+  // A LinAlgError caught through the base neml2 Exception surface still reports
+  // recoverable() -- the vtable + typeinfo of ConvergenceError is what carries
+  // the bit across a downstream `catch (const Exception &)`.
+  {
+    bool recoverable = false;
+    try
+    {
+      _guarded([] { TORCH_CHECK_LINALG(false, "another singular case"); });
+    }
+    catch (const Exception & e)
+    {
+      recoverable = e.recoverable();
+    }
+    NEML2_CHECK(recoverable);
+  }
+  // A generic std::runtime_error is still classified fatal (only linalg-shaped
+  // torch failures are promoted to recoverable; unrelated foreign errors keep
+  // their previous behavior).
+  {
+    bool fatal = false;
+    try
+    {
+      _guarded([]() -> int { throw std::runtime_error("shape mismatch"); });
+    }
+    catch (const FatalError & e)
+    {
+      fatal = !e.recoverable();
+    }
+    NEML2_CHECK(fatal);
+  }
 
   // --- AggregateError: fatal dominates ---------------------------------------
   { // all recoverable -> aggregate is recoverable

--- a/tests/cpp/test_exceptions.cpp
+++ b/tests/cpp/test_exceptions.cpp
@@ -209,7 +209,7 @@ main()
   // type. Simulate that here -- the guard must still promote it to a recoverable
   // ConvergenceError based on the message prefix.
   {
-    bool got_conv = false, recoverable = false, kept_msg = false;
+    bool caught_convergence_error = false, recoverable = false, kept_msg = false;
     try
     {
       _guarded(
@@ -221,11 +221,11 @@ main()
     }
     catch (const ConvergenceError & e)
     {
-      got_conv = true;
+      caught_convergence_error = true;
       recoverable = e.recoverable();
       kept_msg = std::strstr(e.what(), "torch.linalg.solve") != nullptr;
     }
-    NEML2_CHECK(got_conv);
+    NEML2_CHECK(caught_convergence_error);
     NEML2_CHECK(recoverable);
     NEML2_CHECK(kept_msg);
   }

--- a/tests/cpp/test_exceptions.cpp
+++ b/tests/cpp/test_exceptions.cpp
@@ -202,6 +202,34 @@ main()
     }
     NEML2_CHECK(fatal);
   }
+  // Message-based fallback: the AOTI proxy_executor C API strips the derived
+  // c10::LinAlgError type when a linalg kernel inside an AOT-compiled graph
+  // throws, so what escapes the compiled .so is a plain std::exception that
+  // carries the original "torch.linalg.<op>:" message but not the LinAlgError
+  // type. Simulate that here -- the guard must still promote it to a recoverable
+  // ConvergenceError based on the message prefix.
+  {
+    bool got_conv = false, recoverable = false, kept_msg = false;
+    try
+    {
+      _guarded(
+          []() -> int
+          {
+            throw std::runtime_error("torch.linalg.solve: (Batch element 7856): The solver failed "
+                                     "because the input matrix is singular.");
+          });
+    }
+    catch (const ConvergenceError & e)
+    {
+      got_conv = true;
+      recoverable = e.recoverable();
+      kept_msg = std::strstr(e.what(), "torch.linalg.solve") != nullptr;
+    }
+    NEML2_CHECK(got_conv);
+    NEML2_CHECK(recoverable);
+    NEML2_CHECK(kept_msg);
+  }
+
   // --- AggregateError: fatal dominates ---------------------------------------
   { // all recoverable -> aggregate is recoverable
     std::vector<std::exception_ptr> errs{as_eptr(ConvergenceError("a")),

--- a/tests/cpp/test_exceptions.cpp
+++ b/tests/cpp/test_exceptions.cpp
@@ -145,13 +145,13 @@ main()
   NEML2_CHECK_THROWS(_assert(false, "nope"));
 
   // --- _guarded normalizes c10::LinAlgError -> recoverable ConvergenceError --
-  // A torch linalg kernel that hits a singular / non-PD matrix throws
-  // c10::LinAlgError; the guard must re-throw it as our recoverable
+  // A torch linalg kernel that hits a singular / non-positive-definite matrix
+  // throws c10::LinAlgError; the guard must re-throw it as our recoverable
   // ConvergenceError so a time-stepping consumer cuts the step and retries
   // instead of hard-failing. The original message must survive so the end user
   // can still see which factorization failed.
   {
-    bool threw = false, recoverable = false, kept_msg = false, is_fatal = false;
+    bool caught_convergence_error = false, recoverable = false, kept_msg = false, is_fatal = false;
     try
     {
       _guarded([] { TORCH_CHECK_LINALG(false, "singular test matrix"); });
@@ -163,12 +163,12 @@ main()
     }
     catch (const ConvergenceError & e)
     {
-      threw = true;
+      caught_convergence_error = true;
       recoverable = e.recoverable();
       kept_msg = std::strstr(e.what(), "singular test matrix") != nullptr;
     }
     NEML2_CHECK(!is_fatal);
-    NEML2_CHECK(threw);
+    NEML2_CHECK(caught_convergence_error);
     NEML2_CHECK(recoverable);
     NEML2_CHECK(kept_msg);
   }


### PR DESCRIPTION
A singular / non-invertible / non-PD factorization from a torch linalg kernel is numerically recoverable in the same sense as a Newton non- convergence: a downstream time-stepping consumer can cut the step and retry. It was previously falling through the generic std::exception catch in the aoti and eager guards and surfacing as a non-recoverable FatalError, so callers branching on `recoverable()` were forced to give up on a failure they could have driven around. The original torch message is carried through on the re-thrown ConvergenceError so the end user still sees which factorization failed.