### PR TITLE
Materialize broadcast initial guesses in Newton::solve_masked

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -60,7 +60,10 @@ jobs:
         # and only needed when the validator runs, so it's fetched here
         # rather than at wheel install time. The validator's error list
         # lands in the job step summary via $GITHUB_STEP_SUMMARY.
-        run: playwright install --with-deps chromium
+        run: |
+          # Remove the unrelated Chrome repository to keep CI stable.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          playwright install --with-deps chromium
       - name: Validate built doc site (MathJax, JS errors, broken assets)
         run: python doc/scripts/check_doc_render.py doc/_build/html
       - name: Write build metadata for the deploy job

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -60,10 +60,7 @@ jobs:
         # and only needed when the validator runs, so it's fetched here
         # rather than at wheel install time. The validator's error list
         # lands in the job step summary via $GITHUB_STEP_SUMMARY.
-        run: |
-          # Remove the unrelated Chrome repository to keep CI stable.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
-          playwright install --with-deps chromium
+        run: playwright install --with-deps chromium
       - name: Validate built doc site (MathJax, JS errors, broken assets)
         run: python doc/scripts/check_doc_render.py doc/_build/html
       - name: Write build metadata for the deploy job

--- a/neml2/aoti/__init__.py
+++ b/neml2/aoti/__init__.py
@@ -53,7 +53,19 @@ Example usage::
     m.named_parameters()["E"].fill_(210000.0)
 """
 
-from ._aoti import ConvergenceError, Model
+from typing import TYPE_CHECKING
+
+from ._aoti import Model
 from ._shim import AOTIModel  # noqa: F401 (registers AOTIModel with native factory)
+
+if TYPE_CHECKING:
+    # Same object at runtime -- the pybind layer registers the one C++
+    # `neml2::aoti::ConvergenceError` and `neml2.solvers._exceptions` aliases it.
+    # For the type checker, though, point at that module's documented stub: the
+    # auto-generated `_aoti.pyi` carries no declaration of the failure-capture
+    # attributes (`converged_mask`, `unknowns`) callers read off a raised instance.
+    from neml2.solvers._exceptions import ConvergenceError
+else:
+    from ._aoti import ConvergenceError
 
 __all__ = ["Model", "AOTIModel", "ConvergenceError"]

--- a/neml2/aoti/__init__.py
+++ b/neml2/aoti/__init__.py
@@ -61,8 +61,8 @@ from ._shim import AOTIModel  # noqa: F401 (registers AOTIModel with native fact
 if TYPE_CHECKING:
     # Same object at runtime -- the pybind layer registers the one C++
     # `neml2::aoti::ConvergenceError` and `neml2.solvers._exceptions` aliases it.
-    # For the type checker, though, point at that module's documented stub: the
-    # auto-generated `_aoti.pyi` carries no declaration of the failure-capture
+    # For type checking, though, we use Pyright in CI. Use that module's documented
+    # type declaration because the auto-generated `_aoti.pyi` does not declare the
     # attributes (`converged_mask`, `unknowns`) callers read off a raised instance.
     from neml2.solvers._exceptions import ConvergenceError
 else:

--- a/neml2/csrc/aoti/newton.cpp
+++ b/neml2/csrc/aoti/newton.cpp
@@ -459,6 +459,22 @@ Newton::solve_masked(const NonlinearSystem & sys, const std::vector<at::Tensor> 
           ")");
   auto b0_norm = pergroup_norm_sq(b_outs, residual_layout).sqrt();
 
+  // Materialize broadcast initial guesses to the residual's dynamic batch.
+  // Without an iteration to broadcast u through a Newton update, solve_masked
+  // would otherwise return unbatched best-effort iterates beside a batched mask.
+  for (std::size_t k = 0; k < u.size(); ++k)
+  {
+    const int64_t trail = group_trail(unknown_layout[k]);
+    _assert(u[k].dim() >= trail,
+            "Newton::solve_masked: unknown group ndim=",
+            u[k].dim(),
+            " < trail ndim=",
+            trail);
+    std::vector<int64_t> target(b0_norm.sizes().begin(), b0_norm.sizes().end());
+    target.insert(target.end(), u[k].sizes().end() - trail, u[k].sizes().end());
+    u[k] = u[k].expand(target).contiguous();
+  }
+
   const bool console_debug = nlog::enabled(nlog::Channel::Newton, nlog::Level::Debug);
   const bool collect = _cfg.collect_log;
   std::vector<std::string> log;

--- a/neml2/csrc/aoti/newton.h
+++ b/neml2/csrc/aoti/newton.h
@@ -52,6 +52,11 @@ class NonlinearSystem;
 /// than returning, so a returned result is by construction converged.
 struct NewtonResult
 {
+  /// Per-unknown-group iterate. Whenever ``converged_mask`` is populated (the
+  /// ``solve_masked`` path) this carries the residual's dynamic-batch leading
+  /// axes, so ``u`` and ``converged_mask`` index the same rows -- a broadcast
+  /// (unbatched) ``u0`` is materialized on entry. The throwing ``solve`` makes
+  /// no such promise: it leaves ``converged_mask`` undefined.
   std::vector<at::Tensor> u;
   bool converged = false;
   /// Per-dynamic-batch-element convergence mask (bool, dynamic-batch shape).

--- a/tests/aoti/test_solve_failure_capture.py
+++ b/tests/aoti/test_solve_failure_capture.py
@@ -64,7 +64,7 @@ _MIXED = {
 _B = 2
 
 
-def _model_i(max_substepping_level: int, linear_solver: str = "lu") -> str:
+def _model_i(max_substepping_level: int, linear_solver: str = "lu", max_its: int = 25) -> str:
     """A minimal NONLINEAR scalar implicit (Perzyna cubic rate + backward Euler):
     ``r(x) = x - x~1 - (t - t~1) * (max(x,0))^3``. A small step converges
     single-shot; a huge step overshoots to a non-finite residual and cannot. The
@@ -109,7 +109,7 @@ def _model_i(max_substepping_level: int, linear_solver: str = "lu") -> str:
     type = Newton
     abs_tol = 1e-10
     rel_tol = 1e-08
-    max_its = 25
+    max_its = {max_its}
     linear_solver = '{linear_solver}'
   []
   [lu]
@@ -135,9 +135,11 @@ def _model_i(max_substepping_level: int, linear_solver: str = "lu") -> str:
 """
 
 
-def _write_model(tmp: Path, max_substepping_level: int, linear_solver: str = "lu") -> Path:
+def _write_model(
+    tmp: Path, max_substepping_level: int, linear_solver: str = "lu", max_its: int = 25
+) -> Path:
     src = tmp / f"model_L{max_substepping_level}_{linear_solver}.i"
-    src.write_text(_model_i(max_substepping_level, linear_solver))
+    src.write_text(_model_i(max_substepping_level, linear_solver, max_its))
     return src
 
 
@@ -145,11 +147,11 @@ def _mixed_tensors() -> dict[str, torch.Tensor]:
     return {k: torch.tensor(v, dtype=torch.float64) for k, v in _MIXED.items()}
 
 
-def _py_eager_fail(src: Path) -> ConvergenceError:
-    """Drive the pure-Python model on the mixed batch into a (whole-batch)
+def _py_eager_fail(src: Path, ins: dict[str, torch.Tensor] | None = None) -> ConvergenceError:
+    """Drive the pure-Python model on a mixed batch into a (whole-batch)
     non-convergence and return the raised ConvergenceError."""
     m = neml2.load_model(str(src), "model").to(torch.float64)
-    ins = _mixed_tensors()
+    ins = _mixed_tensors() if ins is None else ins
     args = tuple(m.input_spec[n](ins[n]) for n in m.input_spec)
     with pytest.raises(ConvergenceError) as ei:
         m(*args)
@@ -193,6 +195,12 @@ def eager_gmres_src(tmp_path_factory) -> Path:
     """Same model with a matrix-free (GMRES) linear solver -- a masked re-solve is
     only available for direct solvers, so capture degrades to a bare error here."""
     return _write_model(tmp_path_factory.mktemp("eager_gmres"), 0, linear_solver="gmres")
+
+
+@pytest.fixture(scope="module")
+def eager_zero_iteration_src(tmp_path_factory) -> Path:
+    """A zero-iteration solve leaves the scalar initial unknown unexpanded."""
+    return _write_model(tmp_path_factory.mktemp("eager_zero_iteration"), 0, max_its=0)
 
 
 @pytest.fixture(scope="module")
@@ -253,6 +261,13 @@ def _assert_mixed_enriched(err, *, typed: bool, shape: tuple[int, ...] = (_B,)) 
 def test_py_eager_capture_enriches_error(monkeypatch, eager_src):
     monkeypatch.setenv(_ENV, "1")
     _assert_mixed_enriched(_py_eager_fail(eager_src), typed=True)
+
+
+def test_py_eager_zero_iteration_capture_enriches_error(monkeypatch, eager_zero_iteration_src):
+    monkeypatch.setenv(_ENV, "1")
+    err = _py_eager_fail(eager_zero_iteration_src, _mixed_2d_tensors())
+    assert tuple(err.converged_mask.shape) == (2, 2)
+    assert tuple(err.unknowns["x"].shape) == (2, 2)
 
 
 def test_cpp_aoti_nonsubstep_capture_enriches_error(monkeypatch, nonsubstep_artifact):


### PR DESCRIPTION
solve_masked promises that `u` and `converged_mask` index the same rows, but an unbatched initial guess only picked up the residual's dynamic batch as a side effect of a Newton update. With zero iterations (max_its = 0, or a first-iteration bail) the best-effort iterates came back unbatched beside a batched mask, so a consumer zipping the two got a shape mismatch.

Expand each unknown group to the dynamic batch on entry, before the iteration loop, and document the invariant on `NewtonResult::u`. The throwing `solve` path is unaffected: it leaves `converged_mask` undefined and makes no such promise.

Covered by a new zero-iteration case in the failure-capture suite (`max_its` is now a knob on the generated input) asserting both the mask and the captured unknowns carry the 2x2 batch.